### PR TITLE
Attempting to start the server would fail

### DIFF
--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -22,15 +22,15 @@ def get() -> dict:
         None
     """
     return {
-        "host": env.getstr("PLATFORM_HOST", default="localhost"),
-        "port": env.getint("PLATFORM_PORT", default=0),
+        "host": env.getstr("ITENTIAL_MCP_PLATFORM_HOST", default="localhost"),
+        "port": env.getint("ITENTIAL_MCP_PLATFORM_PORT", default=0),
 
-        "use_tls": not env.getbool("PLATFORM_DISABLE_TLS", default=False),
-        "verify": not env.getbool("PLATFORM_DISABLE_VERFITY", default=False),
+        "use_tls": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_TLS", default=False),
+        "verify": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_VERFITY", default=False),
 
-        "user": env.getstr("PLATFORM_USER", default="admin"),
-        "password": env.getstr("PLATFORM_PASSWORD", default="admin"),
+        "user": env.getstr("ITENTIAL_MCP_PLATFORM_USER", default="admin"),
+        "password": env.getstr("ITENTIAL_MCP_PLATFORM_PASSWORD", default="admin"),
 
-        "client_id": env.getstr("PLATFORM_CLIENT_ID"),
-        "client_secret": env.getstr("PLATFORM_CLIENT_SECRET"),
+        "client_id": env.getstr("ITENTIAL_MCP_PLATFORM_CLIENT_ID"),
+        "client_secret": env.getstr("ITENTIAL_MCP_PLATFORM_CLIENT_SECRET"),
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,14 +32,14 @@ class TestConfig:
 
     def test_config_with_env_vars(self):
         os.environ.update({
-            "PLATFORM_HOST": "platform.local",
-            "PLATFORM_PORT": "443",
-            "PLATFORM_DISABLE_TLS": "true",
-            "PLATFORM_DISABLE_VERFITY": "true",
-            "PLATFORM_USER": "itential",
-            "PLATFORM_PASSWORD": "secret",
-            "PLATFORM_CLIENT_ID": "client123",
-            "PLATFORM_CLIENT_SECRET": "secret456"
+            "ITENTIAL_MCP_PLATFORM_HOST": "platform.local",
+            "ITENTIAL_MCP_PLATFORM_PORT": "443",
+            "ITENTIAL_MCP_PLATFORM_DISABLE_TLS": "true",
+            "ITENTIAL_MCP_PLATFORM_DISABLE_VERFITY": "true",
+            "ITENTIAL_MCP_PLATFORM_USER": "itential",
+            "ITENTIAL_MCP_PLATFORM_PASSWORD": "secret",
+            "ITENTIAL_MCP_PLATFORM_CLIENT_ID": "client123",
+            "ITENTIAL_MCP_PLATFORM_CLIENT_SECRET": "secret456"
         })
 
         expected = {


### PR DESCRIPTION
Starting the server would fail because the configuration for Platform was not properly captured in the config module.  The config module was looking for the wrong keys.  This problem has been fixed.