### PR TITLE
Add tool for job and task aggregate metrics

### DIFF
--- a/src/itential_mcp/tools/wfe.py
+++ b/src/itential_mcp/tools/wfe.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from fastmcp import Context
+
+
+async def get_job_metrics(ctx: Context) -> list[dict]:
+    """
+    Get the aggregate job metrics from workflow engine
+
+    The Itential Platform workflow engine maintains records that aggregate
+    workflow job metrics over the life of automation executions.  This
+    function will return the aggregate job metrics for automations that
+    have been executed by Itential Platform.
+
+    It will provide information such as the number of jobs completed in the
+    `jobsComplete` key, the name of the workflow that was executed and the
+    total run time among other key statistics
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+    Returns:
+        list[dict]: A Python list object that contains job metric data as
+            a Python dict object
+
+    Raises:
+        None
+    """
+    await ctx.debug("inside get_job_metrics(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    limit = 100
+    skip = 0
+
+    results = list()
+
+    while True:
+        res = await client.get("/workflow_engine/jobs/metrics")
+
+        data = res.json()
+        results.extend(data["results"])
+
+        if len(results) == data["total"]:
+            break
+
+        skip += limit
+
+    return results
+
+    res = await client.get("/workflow_engine/jobs/metrics")
+
+    return res.json()
+
+
+async def get_task_metrics(ctx: Context) -> list[dict]:
+    """
+    Get the aggregate task metrics from workflow engine
+
+    The Itential Platform workflow engine maintains records that aggregate
+    workflow task metrics over the life of automation executions.  This
+    function will return the aggregate task metrics for automations that
+    have been executed by Itential Platform.
+
+    It will provide details about tasks from workflows such as the application
+    associated with the task, the task name and type and metrics for the task.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+    Returns:
+        list[dict]: A Python list object that contains task metric data as
+            a Python dict object
+
+    Raises:
+        None
+    """
+    await ctx.debug("inside get_task_metrics(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    limit = 100
+    skip = 0
+
+    results = list()
+
+    while True:
+        res = await client.get("/workflow_engine/tasks/metrics")
+
+        data = res.json()
+        results.extend(data["results"])
+
+        if len(results) == data["total"]:
+            break
+
+        skip += limit
+
+    return results
+


### PR DESCRIPTION
The workflow engine maintains two API routes for metric data, one for aggregate job metrics and one for aggregate task metrics.  This adds support for both API enpoints allowing a system to retreive the aggregate metrics.

It adds two new MCP tools:

- `get_job_metrics(...)`
- `get_task_metrics(...)`