### PR TITLE
Add support for setting a timeout value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,25 +80,26 @@ itential-mcp --transport sse --host 0.0.0.0 --port 8000
 
 ### Server Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--transport` | Transport protocol (stdio or sse) | stdio |
-| `--host` | Host address to listen on | localhost |
-| `--port` | Port to listen on | 8000 |
-| `--log-level` | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | INFO |
+| Option        | Description                                       | Default   |
+|---------------|---------------------------------------------------|-----------|
+| `--transport` | Transport protocol (stdio or sse)                 | stdio     |
+| `--host`      | Host address to listen on                         | localhost |
+| `--port`      | Port to listen on                                 | 8000      |
+| `--log-level` | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | INFO      |
 
 ### Platform Configuration
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--platform-host` | Itential Platform hostname | localhost |
-| `--platform-port` | Platform port (0 = auto-detect) | 0 |
-| `--platform-disable-tls` | Disable TLS for platform connection | false |
-| `--platform-disable-verify` | Disable certificate verification | false |
-| `--platform-user` | Username for authentication | admin |
-| `--platform-password` | Password for authentication | admin |
-| `--platform-client-id` | OAuth client ID | none |
-| `--platform-client-secret` | OAuth client secret | none |
+| Option                      | Description                         | Default   |
+|-----------------------------|-------------------------------------|-----------|
+| `--platform-host`           | Itential Platform hostname          | localhost |
+| `--platform-port`           | Platform port (0 = auto-detect)     | 0         |
+| `--platform-disable-tls`    | Disable TLS for platform connection | false     |
+| `--platform-disable-verify` | Disable certificate verification    | false     |
+| `--platform-timeout`        | Connection timeout                  | 30        |
+| `--platform-user`           | Username for authentication         | admin     |
+| `--platform-password`       | Password for authentication         | admin     |
+| `--platform-client-id`      | OAuth client ID                     | none      |
+| `--platform-client-secret`  | OAuth client secret                 | none      |
 
 ### Environment Variables
 
@@ -136,22 +137,22 @@ from fastmcp import Context
 async def my_new_tool(ctx: Context) -> dict:
     """
     Description of what the tool does
-    
+
     Args:
         ctx (Context): The FastMCP Context object
-        
+
     Returns:
         dict: The response data
-        
+
     Raises:
         None
     """
     # Get the platform client
     client = ctx.request_context.lifespan_context.get("client")
-    
+
     # Make API requests
     res = await client.get("/your/api/path")
-    
+
     # Return JSON-serializable results
     return res.json()
 ```

--- a/src/itential_mcp/cli.py
+++ b/src/itential_mcp/cli.py
@@ -110,6 +110,11 @@ def parse_args(args: Sequence) -> dict[str, Any]:
         help="Client secret to use when authenticating to the server with OAuth",
     )
 
+    platform_group.add_argument(
+        "--platform-timeout",
+        help="Configure the connection timeout in seconds (default=30)",
+    )
+
     args = parser.parse_args(args=args)
 
     kwargs = {}

--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -27,6 +27,7 @@ def get() -> dict:
 
         "use_tls": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_TLS", default=False),
         "verify": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_VERFITY", default=False),
+        "timeout": env.getint("ITENTIAL_MCP_PLATFORM_TIMEOUT", default=30),
 
         "user": env.getstr("ITENTIAL_MCP_PLATFORM_USER", default="admin"),
         "password": env.getstr("ITENTIAL_MCP_PLATFORM_PASSWORD", default="admin"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,8 @@ class TestConfig:
             "user": "admin",
             "password": "admin",
             "client_id": None,
-            "client_secret": None
+            "client_secret": None,
+            "timeout": 30,
         }
         assert get() == expected
 
@@ -39,7 +40,8 @@ class TestConfig:
             "ITENTIAL_MCP_PLATFORM_USER": "itential",
             "ITENTIAL_MCP_PLATFORM_PASSWORD": "secret",
             "ITENTIAL_MCP_PLATFORM_CLIENT_ID": "client123",
-            "ITENTIAL_MCP_PLATFORM_CLIENT_SECRET": "secret456"
+            "ITENTIAL_MCP_PLATFORM_CLIENT_SECRET": "secret456",
+            "ITENTIAL_MCP_PLATFORM_TIMEOUT": "123"
         })
 
         expected = {
@@ -50,7 +52,8 @@ class TestConfig:
             "user": "itential",
             "password": "secret",
             "client_id": "client123",
-            "client_secret": "secret456"
+            "client_secret": "secret456",
+            "timeout": 123
         }
 
         assert get() == expected


### PR DESCRIPTION
When sending requests to Itential Platform a connection timeout value can now be configured using either the command line or environment variable.  This adds support for `--platform-timeout` or `ITENTIAL_MCP_PLATFORM_TIMEOUT` specifying the value in seconds.  The default timeout value is 30.