### PR TITLE
Updated container target and build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,21 +13,18 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
+COPY pyproject.toml .
+COPY README.md .
+
 # Generate uv lock file
-RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml  \
-    --mount=type=bind,source=README.md,target=README.md,relabel=shared  \
-    uv lock
+RUN uv lock
 
 # Install the project's dependencies using the lockfile
-RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock,relabel=shared \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+RUN uv sync --frozen --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 ADD . /app
-RUN --mount=type=bind,source=uv.lock,target=uv.lock \
-    uv sync --frozen --no-dev --no-editable
-
+RUN uv sync --frozen --no-dev --no-editable
 
 # Create the final container with the application installed
 FROM python:3.10-slim

--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,4 @@ premerge: clean lint test
 # Build a container image that include the MCP server.  The server will start
 # when the container is run and can be configured using environment variables
 container:
-	${CONTAINER_RUNTIME} build ${PWD} --tag ${CONTAINER_TAG}
+	${CONTAINER_RUNTIME} build ${PWD} --file Containerfile --tag ${CONTAINER_TAG}


### PR DESCRIPTION
The container target in the `Makefile` has been updated to explicitly use `Containerfile` which can be an issue for `docker` users.  This also updates the `Containerfile` to remove the dependency on using `relabel=shared` which is a `podman` only flag.