### PR TITLE
Fix ENV -> config typo

### DIFF
--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -26,7 +26,7 @@ def get() -> dict:
         "port": env.getint("ITENTIAL_MCP_PLATFORM_PORT", default=0),
 
         "use_tls": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_TLS", default=False),
-        "verify": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_VERFITY", default=False),
+        "verify": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_VERIFY", default=False),
         "timeout": env.getint("ITENTIAL_MCP_PLATFORM_TIMEOUT", default=30),
 
         "user": env.getstr("ITENTIAL_MCP_PLATFORM_USER", default="admin"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,7 @@ class TestConfig:
             "ITENTIAL_MCP_PLATFORM_HOST": "platform.local",
             "ITENTIAL_MCP_PLATFORM_PORT": "443",
             "ITENTIAL_MCP_PLATFORM_DISABLE_TLS": "true",
-            "ITENTIAL_MCP_PLATFORM_DISABLE_VERFITY": "true",
+            "ITENTIAL_MCP_PLATFORM_DISABLE_VERIFY": "true",
             "ITENTIAL_MCP_PLATFORM_USER": "itential",
             "ITENTIAL_MCP_PLATFORM_PASSWORD": "secret",
             "ITENTIAL_MCP_PLATFORM_CLIENT_ID": "client123",
@@ -57,4 +57,3 @@ class TestConfig:
         }
 
         assert get() == expected
-


### PR DESCRIPTION
## Summary
`---platform-disable-verify` sets env variable as `ITENTIAL_MCP_PLATFORM_DISABLE_VERIFY` but config.py is looking for ITENTIAL_MCP_PLATFORM_DISABLE_VERFITY _(typo)_

## Fix
Replace with 
```python
"verify": not env.getbool("ITENTIAL_MCP_PLATFORM_DISABLE_VERIFY", default=False),
```