### PR TITLE
Fixes issue coericing env var to proper type

### DIFF
--- a/src/itential_mcp/cli.py
+++ b/src/itential_mcp/cli.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from . import server
+from . import env
 
 
 def parse_args(args: Sequence) -> dict[str, Any]:
@@ -121,15 +122,21 @@ def parse_args(args: Sequence) -> dict[str, Any]:
 
     for key, value in dict(args._get_kwargs()).items():
         envkey = f"ITENTIAL_MCP_{key}".upper()
+
         if key.startswith("platform"):
             if value is not None:
                 if envkey not in os.environ:
                     os.environ[envkey] = str(value)
         else:
-            if envkey in os.environ:
-                kwargs[key] = os.environ[envkey]
+            if isinstance(value, bool):
+                v = env.getbool(envkey, default=value)
+            elif isinstance(value, int):
+                v = env.getint(envkey, default=value)
+            elif isinstance(value, str):
+                v = env.getstr(envkey, default=value)
             else:
-                kwargs[key] = value
+                v = value
+            kwargs[key] = v
 
     return kwargs
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,5 +68,5 @@ class TestCLI:
         parsed = parse_args(args)
 
         assert parsed["transport"] == "sse"
-        assert parsed["port"] == "1234"  # Note: string because taken from env
+        assert parsed["port"] == 1234
 


### PR DESCRIPTION
When using environment variables to configure the MCP server, the applicaiton would try to pass them as string values which is incorrect. The correct behavior is to corece them to the proper type.  This change will now coerce the env variables for the MCP server to the same type as the default.

fixes #14