### PR TITLE
Get workflows will timeout

### DIFF
--- a/src/itential_mcp/tools/workflows.py
+++ b/src/itential_mcp/tools/workflows.py
@@ -76,9 +76,8 @@ async def get_workflows(
     client = ctx.request_context.lifespan_context.get("client")
 
     limit = 100
-    skip = 0
 
-    params = {}
+    params = {"limit": limit}
 
     if include_projects is None:
         include_projects = False
@@ -88,9 +87,12 @@ async def get_workflows(
     if name is not None:
         params["equals[name]"] = name
 
+    skip = 0
     results = list()
 
     while True:
+        params["skip"] = skip
+
         res = await client.get("/automation-studio/workflows", params=params)
 
         data = res.json()


### PR DESCRIPTION
The `get_workflows(...)` tool will timeout when attempting to retrieve the workflows from the server that is paginated.  This is due to a bug in how pagination was handled in the code.  The bug is now fixed and will return all of the workflows.