### PR TITLE
The `get_devices(...)` tool doesnt return all devices

### DIFF
--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -36,7 +36,7 @@ async def get_devices(ctx: Context) -> list[dict]:
         body = {
             "options": {
                 "order": "ascending",
-                "sort": {"name": 1},
+                "sort": [{"name": 1}],
                 "start": start,
                 "limit": limit
 
@@ -58,9 +58,3 @@ async def get_devices(ctx: Context) -> list[dict]:
         start += limit
 
     return results
-
-
-    res = await client.post("/configuration_manager/devices")
-
-    return res.json()
-


### PR DESCRIPTION
When calling the `get_devices(...)` tool, not all devices are being returned from the server.  This was due to a issue with the POST body, specifically the `sort` key not being a list.  This is now fixed and the entire set of devices is returned.