### PR TITLE
Set the CLI default timeout to 30

### DIFF
--- a/src/itential_mcp/cli.py
+++ b/src/itential_mcp/cli.py
@@ -113,6 +113,8 @@ def parse_args(args: Sequence) -> dict[str, Any]:
 
     platform_group.add_argument(
         "--platform-timeout",
+        type=int,
+        default=30,
         help="Configure the connection timeout in seconds (default=30)",
     )
 


### PR DESCRIPTION
The default timeout value was not set and the default data type was not set to integer.  This causes an error when attempting to coerce the value in the config.  This error is now fixed.