### PR TITLE
Add CODEOWNERS to the repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners for the whole repository
+* @itential/mcp-committers


### PR DESCRIPTION
Initial add of the CODEOWNERS file to the repository with access to the entire repo for the `mcp-committers` team.