### PR TITLE
Fixes issue where call to devices tool doesn't return

### DIFF
--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -52,7 +52,7 @@ async def get_devices(ctx: Context) -> list[dict]:
 
         results.extend(data["list"])
 
-        if len(results) == data["total"]:
+        if len(results) == data["return_count"]:
             break
 
         start += limit


### PR DESCRIPTION
When a device is reachable through multiple adapters, the API call will only return one of the device entries.  In this situation, the code needs to check for the number of unique devices instead of the total device count otherwise the function is stuck in a loop.  This is now fixed with this patch.