### PR TITLE
Add verbose output when running `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 # The test target will invoke the unit tests using pytest.   This target
 # requires uv to be installed and the environment created.
 test:
-	uv run pytest tests
+	uv run pytest tests -v
 
 # Builds the local environment which can be used for development or simply
 # running the server from source.  This target requires `uv` to be installed


### PR DESCRIPTION
The make target for running the unit test cases provides summarized output for the test cases that have run or been skipped.  This updates the target to enable verbose output by providing the `-v` flag to `pytest` when running tests.