### PR TITLE
Update the inspect logic to avoid loading imported functions

### DIFF
--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -73,9 +73,9 @@ def register_tools(mcp: FastMCP) -> None:
             # Add the module to globals
             globals()[module_name] = module
 
-            # Inspect the module to retreive all of the functions
+            # Inspect the module to retreive all of the functions.
             for name, f in inspect.getmembers(module, inspect.isfunction):
-                if not name.startswith("_"):
+                if not name.startswith("_") and f.__module__ == module_name:
                     mcp.add_tool(f)
 
 


### PR DESCRIPTION
The server will introspect the tools folder and load all public functions as a MCP tool.  There is a bug in the original code where by it will attempt to load any callable function even if it is imported by
the tooling.   This change fixes that problem and now only loads
functions defined in the module.