### PR TITLE
Update all tools to use annotated arguments

### DIFF
--- a/src/itential_mcp/tools/compliance_reports.py
+++ b/src/itential_mcp/tools/compliance_reports.py
@@ -1,10 +1,21 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import Annotated
+
+from pydantic import Field
+
 from fastmcp import Context
 
 
-async def describe_compliance_report(ctx: Context, report_id: str) -> dict:
+async def describe_compliance_report(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+    report_id: Annotated[str, Field(
+        description="The ID of the report to describe"
+    )]
+) -> dict:
     """
     Retrieve the compliance report from the server
 
@@ -20,7 +31,6 @@ async def describe_compliance_report(ctx: Context, report_id: str) -> dict:
     Raises:
         None
     """
-
     await ctx.info("inside describe_compliance_report(...)")
 
     client = ctx.request_context.lifespan_context.get("client")

--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -1,10 +1,18 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import Annotated
+
+from pydantic import Field
+
 from fastmcp import Context
 
 
-async def get_devices(ctx: Context) -> list[dict]:
+async def get_devices(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+) -> list[dict]:
     """
     Retrieve all devies known to Itential Platform
 
@@ -39,7 +47,6 @@ async def get_devices(ctx: Context) -> list[dict]:
                 "sort": [{"name": 1}],
                 "start": start,
                 "limit": limit
-
             }
         }
 

--- a/src/itential_mcp/tools/jobs.py
+++ b/src/itential_mcp/tools/jobs.py
@@ -1,12 +1,21 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import Annotated
+
+from pydantic import Field
+
 from fastmcp import Context
 
 
 async def get_jobs(
-    ctx: Context,
-    status: str | None = None
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+    status: Annotated[str | None, Field(
+        description="Job status used to filter the results",
+        default=None
+    )]
 ) -> list[dict]:
     """
     Get all jobs from the Itential Platform server
@@ -91,7 +100,14 @@ async def get_jobs(
     return results
 
 
-async def describe_job(ctx: Context, job_id: str) -> dict:
+async def describe_job(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+    job_id: Annotated[str, Field(
+        description="The ID used to retreive the job"
+    )]
+) -> dict:
     """
     Get details about a job from Itential Platform
 

--- a/src/itential_mcp/tools/system.py
+++ b/src/itential_mcp/tools/system.py
@@ -1,10 +1,18 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import Annotated
+
+from pydantic import Field
+
 from fastmcp import Context
 
 
-async def get_health(ctx: Context) -> dict:
+async def get_health(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )]
+) -> dict:
     """
     Get the Itential Platforms server health
 

--- a/src/itential_mcp/tools/wfe.py
+++ b/src/itential_mcp/tools/wfe.py
@@ -1,10 +1,18 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import Annotated
+
+from pydantic import Field
+
 from fastmcp import Context
 
 
-async def get_job_metrics(ctx: Context) -> list[dict]:
+async def get_job_metrics(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )]
+) -> list[dict]:
     """
     Get the aggregate job metrics from workflow engine
 
@@ -59,7 +67,11 @@ async def get_job_metrics(ctx: Context) -> list[dict]:
     return results
 
 
-async def get_task_metrics(ctx: Context) -> list[dict]:
+async def get_task_metrics(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )]
+) -> list[dict]:
     """
     Get the aggregate task metrics from workflow engine
 
@@ -102,3 +114,4 @@ async def get_task_metrics(ctx: Context) -> list[dict]:
         skip += limit
 
     return results
+


### PR DESCRIPTION
All public functions have now been updated to use argument annotations using the Python typing library.  Annontated functions will provide better details to calling functions to help understand the rquired and optional arguments.