### PR TITLE
Adds new tools for getting device config and performing backup

### DIFF
--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -65,3 +65,110 @@ async def get_devices(
         start += limit
 
     return results
+
+
+async def get_device_configuration(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+        )],
+    name: Annotated[str, Field(
+        description="The name of the device to retrieve the configuration from"
+    )]
+) -> str:
+    """
+    Get the device current configuration
+
+    This tool will get the current device configuration using Itential
+    Platform.  The device configuration will be returned if the device
+    is a valid device otherwise it will raise an error.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+        name (str): The name of the device to backup.  The device must be
+            available in the list of devices returned from Itential Platform
+
+    Returns:
+        str: The current device configuration
+
+    Raises:
+        ValueError: When there is an exception making the API call
+    """
+    await ctx.info("inside get_device_configuration(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    try:
+        res = await client.get(f"/configuration_manager/devices/{name}/configuration")
+    except ValueError:
+        raise
+
+    return res.json()["config"]
+
+
+async def backup_device_configuration(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+        )],
+    name: Annotated[str, Field(
+        description="The name of the device to backup"
+    )],
+    description: Annotated[str, Field(
+        description="Short description to attach to the backup",
+        default=None
+    )],
+    notes: Annotated[str, Field(
+        description="Notes to attach to the backup",
+        default=None
+    )]
+) -> dict:
+    """
+    Backup a device configuration to Itential Platform
+
+    This tool will invoke an operation to backup the configuration of a
+    specific device to Itential Platform.  The deivce's configuration will be
+    backed up and added to the Itential Platform server.
+
+    The returned object includes the following fields:
+
+        * id: The unique identifer for the backup on the server.  This value
+            can be used to retreive the backup later
+        * status: The status of the backup operation job
+        * message: A short descriptive message about the status of the job
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+        name (str): The name of the device to backup.  The device must be
+            available in the list of devices returned from Itential Platform
+
+        description (str): Optional short description of the backup
+
+        notes (str): Optional text notes to append to the backup for later
+            reference
+
+    Returns:
+        dict: A Python dic object that returns the success or failure of the
+            backup operation
+
+    Raises:
+        None
+    """
+    await ctx.info("inside backup_device_configuration(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    body = {
+        "name": name,
+        "options": {
+            "description": description or "",
+            "notes": notes or ""
+        }
+    }
+
+    res = await client.post(
+        "/configuration_manager/devices/backups",
+        json=body
+    )
+
+    return res.json()


### PR DESCRIPTION
This adds two new MCP tools to the server for working with device configurations.

- `get_device_configuration`
- `backup_device_configuration`

The first tool, `get_device_configuration(...)` will attempt to retrieve the current active configuration from the device.  The second tool, `backup_device_configuration(...)` will backup the active configuration to the server.