### PR TITLE
Sets the log level only when transport=sse

### DIFF
--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -129,7 +129,6 @@ async def run() -> int:
         name="Itential Platform MCP",
         instructions="Itential tools and resources for interacting with Itential Platform",
         lifespan=lifespan,
-        log_level=cfg.server.get("log_level").upper(),
         include_tags=cfg.server.get("include_tags"),
         exclude_tags=cfg.server.get("exclude_tags")
     )
@@ -147,7 +146,8 @@ async def run() -> int:
     if kwargs["transport"] == "sse":
         kwargs.update({
             "host": cfg.server.get("host"),
-            "port": cfg.server.get("port")
+            "port": cfg.server.get("port"),
+            "log_level": cfg.server.get("log_level")
         })
 
     try:


### PR DESCRIPTION
Setting the log level only makes sense when the transport is sse.  This address that change and will only configure the log level when the transport is set to `sse`.