### PR TITLE
Add support for streamble HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,15 @@ itential-mcp --transport sse --host 0.0.0.0 --port 8000
 
 ### Server Options
 
-| Option           | Description                                       | Default            |
-|------------------|---------------------------------------------------|--------------------|
-| `--transport`    | Transport protocol (stdio or sse)                 | stdio              |
-| `--host`         | Host address to listen on                         | localhost          |
-| `--port`         | Port to listen on                                 | 8000               |
-| `--log-level`    | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | INFO               |
-| `--include-tags` | Tags to include registered tools                  | none               |
-| `--exclude-tags` | Tags to exclude registered tools                  | experimental,beta  |
+| Option           | Description                                       | Default           |
+|------------------|---------------------------------------------------|-------------------|
+| `--transport`    | Transport protocol (stdio, sse, streamable-http)  | stdio             |
+| `--host`         | Host address to listen on                         | localhost         |
+| `--port`         | Port to listen on                                 | 8000              |
+| `--path`         | The streamable HTTP path to use                   | /mcp              |
+| `--log-level`    | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | INFO              |
+| `--include-tags` | Tags to include registered tools                  | none              |
+| `--exclude-tags` | Tags to exclude registered tools                  | experimental,beta |
 
 ### Platform Configuration
 

--- a/docs/mcp.conf.example
+++ b/docs/mcp.conf.example
@@ -10,7 +10,8 @@
 [server]
 
 # Configures the transport to use when starting the MCP server.  This
-# configuration option accepts one of two valid values: `sse` or `stdio`.  
+# configuration option accepts one of three valid values: `sse`, `stdio`  
+# or `streamable-http`
 #
 # Default value: stdio
 # Environment variable: ITENTIAL_MCP_SERVER_TRANSPORT
@@ -34,6 +35,15 @@
 # Environment variable: ITENTIAL_MCP_SERVER_PORT
 #
 # port = 8000
+
+# Configure the URL path for the server to listen for client requests on.  This
+# value is appened to the host to create the full URL path for sending requests
+# to.
+#
+# Default value: /mcp
+# Environment variable: ITENTIAL_MCP_SERVER_PATH
+#
+# path = /mcp
 
 # Configures the logging level for output of log messages when running the
 # server.  This configuration option accepts one of the following values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "itential-mcp"
 description = "Itential MCP Server"
 
 dependencies = [
-    "fastmcp>=2.2.10",
+    "fastmcp>=2.8.0",
     "ipsdk>=0.2.0",
 ]
 
@@ -70,5 +70,3 @@ dev = [
     "ruff",
     "build"
 ]
-
-

--- a/src/itential_mcp/cli.py
+++ b/src/itential_mcp/cli.py
@@ -49,6 +49,7 @@ def parse_args(args: Sequence) -> None:
 
     server_group.add_argument(
         "--transport",
+        choices=("stdio", "sse", "streamable-http"),
         dest="server_transport",
         help="The MCP server transport to use (default=stdio)"
     )
@@ -56,7 +57,7 @@ def parse_args(args: Sequence) -> None:
     server_group.add_argument(
         "--host",
         dest="server_host",
-        help="Address to listen for connections on (default=localhost)"
+        help="Address to listen for connections on (default=127.0.0.1)"
     )
 
     server_group.add_argument(
@@ -64,6 +65,12 @@ def parse_args(args: Sequence) -> None:
         type=int,
         dest="server_port",
         help="Port to listen for connections on (default=8000)",
+    )
+
+    server_group.add_argument(
+        "--path",
+        dest="server_path",
+        help="The URL used to accept requests from (default=/mcp)"
     )
 
     server_group.add_argument(

--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -19,9 +19,10 @@ from . import env
 @dataclass(frozen=True)
 class Config(object):
 
-    server_transport: Literal["stdio", "sse"] = Field(default="stdio")
-    server_host: str = Field(default="localhost")
+    server_transport: Literal["stdio", "sse", "streamable-http"] = Field(default="stdio")
+    server_host: str = Field(default="127.0.0.1")
     server_port: int = Field(default=0)
+    server_path: str = Field(default="/mcp")
     server_log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(default="INFO")
     server_include_tags: str | None = Field(default=None)
     server_exclude_tags: str | None = Field(default="experimental,beta")
@@ -42,6 +43,7 @@ class Config(object):
             "transport": self.server_transport,
             "host": self.server_host,
             "port": self.server_port,
+            "path": self.server_path,
             "log_level": self.server_log_level,
             "include_tags": self._coerce_to_set(self.server_include_tags) if self.server_include_tags else None,
             "exclude_tags": self._coerce_to_set(self.server_exclude_tags) if self.server_exclude_tags else None

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -144,11 +144,13 @@ async def run() -> int:
         "transport": cfg.server.get("transport")
     }
 
-    if kwargs["transport"] == "sse":
+    if kwargs["transport"] in ("sse", "streamable-http"):
         kwargs.update({
             "host": cfg.server.get("host"),
             "port": cfg.server.get("port")
         })
+        if kwargs["transport"] == "streamable-http":
+            kwargs["path"] = cfg.server.get("path")
 
     try:
         await mcp.run_async(**kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.8.1"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -283,9 +283,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/76/d9b352dd632dbac9eea3255df7bba6d83b2def769b388ec332368d7b4638/fastmcp-2.8.1.tar.gz", hash = "sha256:c89d8ce8bf53a166eda444cfdcb2c638170e62445487229fbaf340aed31beeaf", size = 2559427 }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/43/31af92e392c8e28269599fe3228419fe4bbb829b04a61fac17ab8dd2a7a9/fastmcp-2.9.0.tar.gz", hash = "sha256:3f1dc97c409193729b4aa8ad240ad396fe767a982c55c3a3e788f422b1278dd6", size = 2650412 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/f9/ecb902857d634e81287f205954ef1c69637f27b487b109bf3b4b62d3dbe7/fastmcp-2.8.1-py3-none-any.whl", hash = "sha256:3b56a7bbab6bbac64d2a251a98b3dec5bb822ab1e4e9f20bb259add028b10d44", size = 138191 },
+    { url = "https://files.pythonhosted.org/packages/dc/43/1095c0cbcf9f3b25d048faaf361b81b4dec403c3f75990dc93eeb6f3c3af/fastmcp-2.9.0-py3-none-any.whl", hash = "sha256:e5b00e5fcea2d216d96f7cfb8b67836bd58fc3cd57147e0d89043d905a84334f", size = 159401 },
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.2.10" },
+    { name = "fastmcp", specifier = ">=2.8.0" },
     { name = "ipsdk", specifier = ">=0.2.0" },
 ]
 
@@ -594,25 +594,25 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.9.1"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/ef/3d61472b7801c896f9efd9bb8750977d9577098b05224c5c41820690155e/pydantic_settings-2.10.0.tar.gz", hash = "sha256:7a12e0767ba283954f3fd3fefdd0df3af21b28aa849c40c35811d52d682fa876", size = 172625 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356 },
+    { url = "https://files.pythonhosted.org/packages/7d/9e/fce9331fecf1d2761ff0516c5dceab8a5fd415e82943e727dc4c5fa84a90/pydantic_settings-2.10.0-py3-none-any.whl", hash = "sha256:33781dfa1c7405d5ed2b6f150830a93bb58462a847357bd8f162f8bacb77c027", size = 45232 },
 ]
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
 ]
 
 [[package]]
@@ -626,7 +626,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -637,9 +637,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232 }
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797 },
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474 },
 ]
 
 [[package]]
@@ -766,14 +766,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.47.0"
+version = "0.47.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/0332bd8a25779a0e2082b0e179805ad39afad642938b371ae0882e7f880d/starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af", size = 2582856 }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/81/c60b35fe9674f63b38a8feafc414fca0da378a9dbd5fa1e0b8d23fcc7a9b/starlette-0.47.0-py3-none-any.whl", hash = "sha256:9d052d4933683af40ffd47c7465433570b4949dc937e20ad1d73b34e72f10c37", size = 72796 },
+    { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747 },
 ]
 
 [[package]]


### PR DESCRIPTION
Streamable HTTP is the preferred transport for hosting MCP servers on the web.  This adds support for streamable HTTP in addition to stdio and sse.  To use this transport, simply pass the `--transport streamable-http` option via the command line or update your configuration file.