### PR TITLE
Fixes typo in command_templates keyword arg

### DIFF
--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -115,7 +115,7 @@ async def describe_command_template(
         description="The name of the command template to describe"
     )],
     project: Annotated[str | None, Field(
-        descrption="The name of the project to get the command template from",
+        description="The name of the project to get the command template from",
         default=None
     )]
 ) -> dict:


### PR DESCRIPTION
This fixes a typo in the command_templates keyword argument for description.  The typo is now fixed and this will remove the warning message generated by Pydantic on startup.