### PR TITLE
Adds two new tools for managing device groups

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -55,10 +55,12 @@ The following tags are available for filtering tools based on their functionalit
 - **render_template** - Render a Jinja2 template with provided variables for configuration generation
 
 ## Device Groups (`device_groups.py`)
-** Group Tags:** `configuration_manager`, `devices`
+** Group Tags:** `configuration_manager`
 
 - **get_device_groups** - Get all device groups from Itential Platform with device lists and descriptions
-- **create_device_group** - Create a new device group on Itential Platform with optional device assignment
+- **create_device_group** - Create a new device group on Itential Platform with optional device assignment and duplicate name validation
+- **add_devices_to_group** - Add one or more devices to an existing device group with device list replacement
+- **remove_devices_from_group** - Remove one or more devices from an existing device group with filtered device list reconstruction
 
 ## Devices Management (`devices.py`)
 ** Group Tags:** `configuration_manager`

--- a/src/itential_mcp/functions.py
+++ b/src/itential_mcp/functions.py
@@ -6,19 +6,19 @@ from fastmcp import Context
 
 async def account_id_to_username(ctx: Context, account_id: str) -> str:
     """Retrieve the username for an account ID.
-    
+
     This function will take an account ID and use it to look up the username
     associated with it. The function will cache the username value to
     avoid making duplicate calls to the server.
-    
+
     Args:
         ctx (Context): The FastMCP Context object.
         account_id (str): The ID of the account to lookup and return the
             username for.
-            
+
     Returns:
         str: The username associated with the account ID.
-        
+
     Raises:
         ValueError: If the account ID cannot be found on the server.
         Exception: If there is an error communicating with the authorization API.
@@ -64,42 +64,5 @@ async def account_id_to_username(ctx: Context, account_id: str) -> str:
         raise ValueError(f"unable to find account with id {account_id}")
 
     cache.put(f"/accounts/{account_id}", value)
-
-    return value
-
-
-async def group_id_to_name(ctx: Context, group_id: str) -> str:
-    """Retrieve the group name for the specified group ID.
-    
-    This function will attempt to get the group name for the specified
-    group ID from the authorization system, using caching to avoid
-    duplicate API calls.
-    
-    Args:
-        ctx (Context): The FastMCP Context object.
-        group_id (str): The group ID to find the group name for.
-        
-    Returns:
-        str: The name of the group associated with this group ID.
-        
-    Raises:
-        KeyError: If the response does not contain the expected 'name' field.
-        Exception: If there is an error communicating with the authorization API.
-    """
-    cache = ctx.request_context.lifespan_context.get("cache")
-
-    value = cache.get(f"/authorization/groups/{group_id}")
-    if value is not None:
-        return value
-
-    client = ctx.request_context.lifespan_context.get("client")
-
-    res = await client.get(f"/authorization/groups/{group_id}")
-
-    data = res.json()
-
-    value = data["name"]
-
-    cache.put(f"/authorization/groups/{group_id}", value)
 
     return value

--- a/src/itential_mcp/models/device_groups.py
+++ b/src/itential_mcp/models/device_groups.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import inspect
+from typing import Annotated, List
+
+from pydantic import BaseModel, RootModel, Field
+
+
+class DeviceGroupElement(BaseModel):
+    """
+    Represents an individual device group element in Itential Platform.
+
+    Device groups are logical collections of network devices that can be managed
+    together for configuration, compliance, and automation tasks. This model contains
+    all essential information about a single device group including its identity,
+    member devices, and description.
+    """
+
+    object_id: Annotated[
+        str,
+        Field(
+            alias="id",
+            description=inspect.cleandoc(
+                """
+                Unique identifier for the device group
+                """
+            )
+        )
+    ]
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Device group name
+                """
+            )
+        )
+    ]
+
+    devices: Annotated[
+        List[str],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of device names in this group
+                """
+            ),
+            default_factory=list
+        )
+    ]
+
+    description: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Device group description
+                """
+            )
+        )
+    ]
+
+
+class GetDeviceGroupsResponse(RootModel):
+    """
+    Response model for retrieving all device groups from Itential Platform.
+
+    This model wraps a list of DeviceGroupElement objects, providing a complete
+    inventory of all device groups configured on the platform instance along
+    with their member devices and metadata.
+    """
+
+    root: Annotated[
+        List[DeviceGroupElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of device group objects with id, name, devices, and description
+                """
+            ),
+            default_factory=list
+        )
+    ]
+
+
+class CreateDeviceGroupResponse(BaseModel):
+    """
+    Response model for creating a device group on Itential Platform.
+
+    Contains the result of a device group creation operation including the
+    unique identifier, name, status message, and current status of the
+    newly created device group.
+    """
+
+    object_id: Annotated[
+        str,
+        Field(
+            alias="id",
+            description=inspect.cleandoc(
+                """
+                Unique identifier for the created device group
+                """
+            )
+        )
+    ]
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Name of the device group
+                """
+            )
+        )
+    ]
+
+    message: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Status message describing the create operation
+                """
+            )
+        )
+    ]
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Current status of the device group
+                """
+            )
+        )
+    ]
+
+
+class AddDevicesToGroupResponse(BaseModel):
+    """
+    Response model for adding devices to a device group on Itential Platform.
+
+    Contains the result of adding one or more devices to an existing device
+    group including the operation status and descriptive message.
+    """
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Message that provides the status of the operation
+                """
+            )
+        )
+    ]
+
+    message: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Short description of the status of the operation
+                """
+            )
+        )
+    ]
+
+
+class RemoveDevicesFromGroupResponse(BaseModel):
+    """
+    Response model for removing devices from a device group on Itential Platform.
+
+    Contains the result of removing one or more devices from an existing device
+    group including the operation status and count of devices that were removed.
+    """
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Message that provides the status of the operation
+                """
+            )
+        )
+    ]
+
+    message: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Short description of the status of the operation
+                """
+            )
+        )
+    ]
+
+

--- a/src/itential_mcp/services/configuration_manager.py
+++ b/src/itential_mcp/services/configuration_manager.py
@@ -3,7 +3,6 @@
 
 import json
 
-
 import ipsdk
 
 from itential_mcp import exceptions
@@ -34,13 +33,12 @@ class Service(ServiceBase):
         res = await self.client.get("/configuration_manager/configs")
         return res.json()
 
-
     async def create_golden_config_tree(
         self,
         name: str,
         device_type: str,
         template: str | None = None,
-        variables: dict | None = None
+        variables: dict | None = None,
     ) -> dict:
         """
         Create a new Golden Configuration tree in the Configuration Manager.
@@ -66,7 +64,7 @@ class Service(ServiceBase):
         try:
             res = await self.client.post(
                 "/configuration_manager/configs",
-                json={"name": name, "deviceType": device_type}
+                json={"name": name, "deviceType": device_type},
             )
             tree_id = res.json()["id"]
         except ipsdk.exceptions.ServerError as exc:
@@ -74,16 +72,11 @@ class Service(ServiceBase):
             raise exceptions.ServerException(msg)
 
         if variables:
-            body = {
-                "name": "initial",
-                "variables": variables
-            }
+            body = {"name": "initial", "variables": variables}
 
             await self.client.put(
-                f"/configuration_manager/configs/{tree_id}/initial",
-                json=body
+                f"/configuration_manager/configs/{tree_id}/initial", json=body
             )
-
 
         if template:
             await self.set_golden_config_template(tree_id, "initial", template)
@@ -91,9 +84,7 @@ class Service(ServiceBase):
         return res.json()
 
     async def describe_golden_config_tree_version(
-        self,
-        tree_id: str,
-        version: str
+        self, tree_id: str, version: str
     ) -> dict:
         """
         Retrieve detailed information about a specific version of a Golden Configuration tree.
@@ -118,12 +109,8 @@ class Service(ServiceBase):
         )
         return res.json()
 
-
     async def set_golden_config_template(
-        self,
-        tree_id: str,
-        version: str,
-        template: str
+        self, tree_id: str, version: str, template: str
     ) -> dict:
         """
         Set or update the configuration template for a specific tree version.
@@ -153,28 +140,16 @@ class Service(ServiceBase):
         config_id = tree_version["root"]["attributes"]["configId"]
         variables = tree_version["variables"]
 
-        body = {
-            "data": {
-                "template": template,
-                "variables": variables
-            }
-        }
+        body = {"data": {"template": template, "variables": variables}}
 
         r = await self.client.put(
-            f"/configuration_manager/config_specs/{config_id}",
-            json=body
+            f"/configuration_manager/config_specs/{config_id}", json=body
         )
 
         return r.json()
 
-
     async def add_golden_config_node(
-        self,
-        tree_name: str,
-        version: str,
-        path: str,
-        name: str,
-        template: str
+        self, tree_name: str, version: str, path: str, name: str, template: str
     ) -> dict:
         """
         Add a new node to a specific version of a Golden Configuration tree.
@@ -207,11 +182,10 @@ class Service(ServiceBase):
         else:
             raise exceptions.NotFoundError(f"tree {tree_name} could not be found")
 
-
         try:
             res = await self.client.post(
                 f"/configuration_manager/configs/{tree_id}/{version}/{path}",
-                json={"name": name}
+                json={"name": name},
             )
         except ipsdk.exceptions.ServerError as exc:
             msg = json.loads(exc.details["response_body"])
@@ -219,5 +193,156 @@ class Service(ServiceBase):
 
         if template:
             await self.set_golden_config_template(tree_id, version, template)
+
+        return res.json()
+
+    async def describe_device_group(self, name: str) -> dict:
+        """
+        Retrieve detailed information about a specific device group by name.
+
+        This method fetches comprehensive details about a device group including
+        its unique identifier, list of member devices, description, and other
+        metadata. The device group is identified by its name.
+
+        Args:
+            name (str): Name of the device group to retrieve details for
+
+        Returns:
+            dict: Device group details containing ID, name, devices list, and description
+
+        Raises:
+            NotFoundError: If the specified device group name cannot be found
+            ServerException: If there is an error communicating with the server
+        """
+        res = await self.client._send_request(
+            "GET", "/configuration_manager/name/devicegroups", json={"groupName": name}
+        )
+        return res.json()
+
+    async def get_device_groups(self) -> list[dict]:
+        """
+        Retrieve all device groups from the Configuration Manager.
+
+        This method fetches a complete list of all device groups that have been
+        configured in the Configuration Manager. Device groups are logical
+        collections of network devices that can be managed together for
+        configuration, compliance, and automation tasks.
+
+        Returns:
+            list[dict]: List of device group objects containing group metadata
+                including IDs, names, device lists, and descriptions
+
+        Raises:
+            ServerException: If there is an error communicating with the server
+        """
+        res = await self.client.get("/configuration_manager/deviceGroups")
+        return res.json()
+
+    async def create_device_group(
+        self, name: str, devices: list, description: str | None = None
+    ) -> dict:
+        """
+        Create a new device group in the Configuration Manager.
+
+        This method creates a new device group with the specified name and
+        optional description. A list of device names can be provided to
+        populate the group initially. The method checks for duplicate
+        group names and raises an error if a group with the same name
+        already exists.
+
+        Args:
+            name (str): Name of the device group to create
+            devices (list): List of device names to include in the group
+            description (str | None): Optional description for the device group
+
+        Returns:
+            dict: Created device group details including ID, name, and status
+
+        Raises:
+            ValueError: If a device group with the same name already exists
+            ServerException: If there is an error creating the device group
+        """
+        groups_response = await self.get_device_groups()
+
+        for ele in groups_response:
+            if ele["name"] == name:
+                raise ValueError(f"device group {name} already exists")
+
+        body = {"groupName": name, "groupDescription": description}
+
+        if devices:
+            body["deviceNames"] = ",".join(devices)
+        else:
+            body["deviceNames"] = ""
+
+        res = await self.client.post("/configuration_manager/devicegroup", json=body)
+
+        return res.json()
+
+    async def add_devices_to_group(self, name: str, devices: list) -> dict:
+        """
+        Add one or more devices to an existing device group.
+
+        This method adds a list of devices to the specified device group.
+        The method first retrieves the device group ID by name, then updates
+        the group to include the new devices. The devices list replaces any
+        existing devices in the group.
+
+        Args:
+            name (str): Name of the device group to add devices to
+            devices (list): List of device names to add to the group
+
+        Returns:
+            dict: Operation result containing status and details of the update
+
+        Raises:
+            NotFoundError: If the specified device group name cannot be found
+            ServerException: If there is an error updating the device group
+        """
+        device_group = await self.describe_device_group(name)
+        device_group_id = device_group["id"]
+
+        body = {"details": {"devices": devices}}
+
+        res = await self.client.put(
+            f"/configuration_manager/deviceGroups/{device_group_id}", json=body
+        )
+
+        return res.json()
+
+    async def remove_devices_from_group(self, name: str, devices: list) -> dict:
+        """
+        Remove one or more devices from an existing device group.
+
+        This method removes specified devices from a device group by
+        reconstructing the device list without the devices to be removed.
+        The method retrieves the current group configuration, filters out
+        the specified devices, and updates the group with the remaining devices.
+
+        Args:
+            name (str): Name of the device group to remove devices from
+            devices (list): List of device names to remove from the group
+
+        Returns:
+            dict: Operation result containing status and details of the update
+
+        Raises:
+            NotFoundError: If the specified device group name cannot be found
+            ServerException: If there is an error updating the device group
+        """
+        data = await self.describe_device_group(name)
+
+        device_group_id = data["id"]
+
+        device_groups = list()
+        for ele in data["devices"]:
+            if ele not in devices:
+                device_groups.append(ele)
+
+        body = {"details": {"devices": device_groups}}
+
+        res = await self.client.put(
+            f"/configuration_manager/deviceGroups/{device_group_id}", json=body
+        )
 
         return res.json()

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -7,15 +7,17 @@ from pydantic import Field
 
 from fastmcp import Context
 
+from itential_mcp.models import device_groups as models
 
-__tags__ = ("configuration_manager", "devices")
+
+__tags__ = ("configuration_manager",)
 
 
 async def get_device_groups(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
     )],
-) -> list[dict]:
+) -> models.GetDeviceGroupsResponse:
     """
     Get all device groups from Itential Platform.
 
@@ -27,7 +29,7 @@ async def get_device_groups(
         ctx (Context): The FastMCP Context object
 
     Returns:
-        list[dict]: List of device group objects with the following fields:
+        GetDeviceGroupsResponse: List of device group objects with the following fields:
             - id: Unique identifier for the group
             - name: Device group name
             - devices: List of device names in this group
@@ -37,29 +39,16 @@ async def get_device_groups(
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    results = list()
+    data = await client.configuration_manager.get_device_groups()
 
-    res = await client.get("/configuration_manager/deviceGroups")
-
-    data = res.json()
-
+    results = []
     for ele in data:
-        results.append({
-            "id": ele["id"],
-            "name": ele["name"],
-            "devices": ele["devices"],
-            "description": ele["description"],
-        })
+        device_group = models.DeviceGroupElement(
+            **ele
+        )
+        results.append(device_group)
 
-    #for ele in data:
-    #    for gbac in ("read", "write"):
-    #        items = list()
-    #        for item in ele["gbac"][gbac]:
-    #            items.append(await functions.group_id_to_name(ctx, item))
-    #        ele["gbac"][gbac] = items
-    #    results.append(ele)
-
-    return results
+    return models.GetDeviceGroupsResponse(results)
 
 
 async def create_device_group(
@@ -72,12 +61,12 @@ async def create_device_group(
     description: Annotated[str | None, Field(
         description="Short description of the device group",
         default=None
-    )],
+    )] = None,
     devices: Annotated[list | None, Field(
         description="List of devices to add to the group",
         default=None
-    )]
-) -> dict:
+    )] = None
+) -> models.CreateDeviceGroupResponse:
     """
     Create a new device group on Itential Platform.
 
@@ -91,7 +80,7 @@ async def create_device_group(
         devices (list | None): List of device names to include in the group. Use `get_devices` to see available devices. (optional)
 
     Returns:
-        dict: Creation operation result with the following fields:
+        CreateDeviceGroupResponse: Creation operation result with the following fields:
             - id: Unique identifier for the created device group
             - name: Name of the device group
             - message: Status message describing the create operation
@@ -104,10 +93,10 @@ async def create_device_group(
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    groups = await get_device_groups(ctx)
+    groups_response = await get_device_groups(ctx)
 
-    for ele in groups:
-        if ele["name"] == name:
+    for ele in groups_response.root:
+        if ele.name == name:
             raise ValueError(f"device group {name} already exists")
 
     body = {
@@ -117,10 +106,119 @@ async def create_device_group(
 
     if devices:
         body["deviceNames"] = ",".join(devices)
+    else:
+        body["deviceNames"] = ""
 
     res = await client.post(
         "/configuration_manager/devicegroup",
         json=body
     )
 
-    return res.json()
+    data = res.json()
+    return models.CreateDeviceGroupResponse(
+        **data
+    )
+
+
+async def add_devices_to_group(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+    name: Annotated[str, Field(
+        description="The name of the device group to add devices to"
+    )],
+    devices: Annotated[list | None, Field(
+        description="List of devices to add to the group",
+        default=None
+    )] = None
+) -> models.AddDevicesToGroupResponse:
+    """
+    Add one or more devices to a device group
+
+    This tool will add one or more devices to a named device group defined
+    in Itential Platform.  The name argument specifies the name of the device
+    group to add the list of devices to.  The name must be a valid device
+    group.  The list of named device groups can be found using the
+    get_device_groups tool.
+
+    The devices argument provides the list of devices to be added to the
+    named device group.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+        name (str): The name of the device group to add devices too
+
+        devices (list[str]): The list of device names to add to the
+            device group
+
+    Returns:
+        dict: An object representing the status of the operation with the
+            following fields:
+
+            - status: Message the provides the status of the operation
+            - message: Short description of the status of the operation
+
+    Raises:
+        None
+
+    """
+    await ctx.info("inside add_devices_to_group(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    data = await client.configuration_manager.add_devices_to_group(name, devices)
+
+    return models.AddDevicesToGroupResponse(
+        status=data["status"],
+        message=data.get("message", "Devices added successfully")
+    )
+
+async def remove_devices_from_group(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+    name: Annotated[str, Field(
+        description="The name of the device group to remove devices from"
+    )],
+    devices: Annotated[list[str] | None, Field(
+        description="List of devices to remove from the group"
+    )]
+) -> models.RemoveDevicesFromGroupResponse:
+    """
+    Remove one or more devices from a device group
+
+    This tool will remove one or more devices from a named device group.
+    The name argument specifies the name of the device group to remove the
+    list of devices from.  The name must be a valid device group.  The
+    list of device groups can be found using the get_device_groups
+    tool.
+
+    The devices argument provides the list of devices to be removed from
+    the device group.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+        name (str): The name of the device group to remove devices from
+
+        devices (list[str]): The list of device names to remove from the
+            device group
+
+    Returns:
+        RemoveDevicesFromGroupResponse: An object representing the status of the operation with the
+            following fields:
+
+    Raises:
+        None
+    """
+    await ctx.info("inside remove_devices_from_group(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    data = await client.configuration_manager.remove_devices_from_group(name, devices)
+
+    return models.RemoveDevicesFromGroupResponse(
+        status=data["status"],
+        message=data.get("message", "Devices removed successfully")
+    )

--- a/tests/test_models_device_groups.py
+++ b/tests/test_models_device_groups.py
@@ -1,0 +1,717 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from pydantic import ValidationError
+
+from itential_mcp.models.device_groups import (
+    DeviceGroupElement,
+    GetDeviceGroupsResponse,
+    CreateDeviceGroupResponse,
+    AddDevicesToGroupResponse,
+    RemoveDevicesFromGroupResponse
+)
+
+
+class TestDeviceGroupElement:
+    """Test cases for DeviceGroupElement model"""
+
+    def test_device_group_element_valid_creation(self):
+        """Test creating DeviceGroupElement with valid data"""
+        element = DeviceGroupElement(
+            id="group-123",
+            name="test-group",
+            devices=["device1", "device2", "device3"],
+            description="Test device group for unit testing"
+        )
+        
+        assert element.object_id == "group-123"
+        assert element.name == "test-group"
+        assert element.devices == ["device1", "device2", "device3"]
+        assert element.description == "Test device group for unit testing"
+
+    def test_device_group_element_empty_devices_list(self):
+        """Test DeviceGroupElement with empty devices list"""
+        element = DeviceGroupElement(
+            id="empty-group",
+            name="empty-test",
+            devices=[],
+            description="Empty device group"
+        )
+        
+        assert element.devices == []
+        assert len(element.devices) == 0
+
+    def test_device_group_element_default_devices_list(self):
+        """Test DeviceGroupElement with default devices list"""
+        element = DeviceGroupElement(
+            id="default-group",
+            name="default-test",
+            description="Default device group"
+        )
+        
+        assert element.devices == []
+        assert isinstance(element.devices, list)
+
+    def test_device_group_element_missing_required_fields(self):
+        """Test DeviceGroupElement with missing required fields"""
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceGroupElement()
+        
+        errors = exc_info.value.errors()
+        required_fields = {"id", "name", "description"}
+        missing_fields = {error["loc"][0] for error in errors if error["type"] == "missing"}
+        
+        assert required_fields == missing_fields
+
+    def test_device_group_element_serialization_with_alias(self):
+        """Test DeviceGroupElement serialization with alias"""
+        element = DeviceGroupElement(
+            id="serialize-group",
+            name="serialize-test",
+            devices=["dev1", "dev2"],
+            description="Serialization test"
+        )
+        
+        # Test model_dump() - should use field names
+        model_dict = element.model_dump()
+        assert "object_id" in model_dict
+        assert "id" not in model_dict
+        assert model_dict["object_id"] == "serialize-group"
+        
+        # Test model_dump(by_alias=True) - should use aliases
+        alias_dict = element.model_dump(by_alias=True)
+        assert "id" in alias_dict
+        assert "object_id" not in alias_dict
+        assert alias_dict["id"] == "serialize-group"
+
+    def test_device_group_element_field_validation(self):
+        """Test DeviceGroupElement field type validation"""
+        # Test non-string object_id
+        with pytest.raises(ValidationError):
+            DeviceGroupElement(
+                id=123,
+                name="test",
+                description="test",
+                devices=[]
+            )
+        
+        # Test non-list devices
+        with pytest.raises(ValidationError):
+            DeviceGroupElement(
+                id="test-id",
+                name="test",
+                description="test",
+                devices="not-a-list"
+            )
+
+    def test_device_group_element_unicode_support(self):
+        """Test DeviceGroupElement with Unicode characters"""
+        element = DeviceGroupElement(
+            id="测试组-123",
+            name="测试设备组",
+            devices=["设备1", "设备2", "устройство3"],
+            description="Device group de test avec émojis 🌐📱"
+        )
+        
+        assert element.object_id == "测试组-123"
+        assert element.name == "测试设备组"
+        assert "设备1" in element.devices
+        assert "устройство3" in element.devices
+        assert "🌐📱" in element.description
+
+    def test_device_group_element_large_devices_list(self):
+        """Test DeviceGroupElement with large number of devices"""
+        large_devices_list = [f"device-{i:04d}" for i in range(1000)]
+        
+        element = DeviceGroupElement(
+            id="large-group",
+            name="large-device-group",
+            devices=large_devices_list,
+            description="Group with many devices"
+        )
+        
+        assert len(element.devices) == 1000
+        assert element.devices[0] == "device-0000"
+        assert element.devices[-1] == "device-0999"
+
+    def test_device_group_element_duplicate_devices(self):
+        """Test DeviceGroupElement with duplicate devices"""
+        devices_with_duplicates = ["device1", "device2", "device1", "device3", "device2"]
+        
+        element = DeviceGroupElement(
+            id="duplicate-group",
+            name="duplicate-test",
+            devices=devices_with_duplicates,
+            description="Group with duplicate devices"
+        )
+        
+        # Should preserve duplicates as-is (no automatic deduplication)
+        assert len(element.devices) == 5
+        assert element.devices.count("device1") == 2
+        assert element.devices.count("device2") == 2
+
+    def test_device_group_element_special_characters_in_devices(self):
+        """Test DeviceGroupElement with special characters in device names"""
+        special_devices = [
+            "device-with-dashes",
+            "device_with_underscores",
+            "device.with.dots",
+            "device:with:colons",
+            "device@with@symbols"
+        ]
+        
+        element = DeviceGroupElement(
+            id="special-group",
+            name="special-devices-test",
+            devices=special_devices,
+            description="Group with special device names"
+        )
+        
+        assert all(device in element.devices for device in special_devices)
+
+    def test_device_group_element_empty_strings(self):
+        """Test DeviceGroupElement with empty string values"""
+        element = DeviceGroupElement(
+            id="",
+            name="",
+            devices=[""],
+            description=""
+        )
+        
+        assert element.object_id == ""
+        assert element.name == ""
+        assert element.devices == [""]
+        assert element.description == ""
+
+
+class TestGetDeviceGroupsResponse:
+    """Test cases for GetDeviceGroupsResponse model"""
+
+    def test_get_device_groups_response_empty_list(self):
+        """Test GetDeviceGroupsResponse with empty device groups list"""
+        response = GetDeviceGroupsResponse(root=[])
+        assert response.root == []
+
+    def test_get_device_groups_response_single_group(self):
+        """Test GetDeviceGroupsResponse with single device group"""
+        group = DeviceGroupElement(
+            id="single-group",
+            name="single-test",
+            devices=["device1"],
+            description="Single device group"
+        )
+        
+        response = GetDeviceGroupsResponse(root=[group])
+        assert len(response.root) == 1
+        assert response.root[0].name == "single-test"
+
+    def test_get_device_groups_response_multiple_groups(self):
+        """Test GetDeviceGroupsResponse with multiple device groups"""
+        groups = [
+            DeviceGroupElement(
+                id=f"group-{i}",
+                name=f"test-group-{i}",
+                devices=[f"device-{i}-1", f"device-{i}-2"],
+                description=f"Test device group {i}"
+            )
+            for i in range(5)
+        ]
+        
+        response = GetDeviceGroupsResponse(root=groups)
+        assert len(response.root) == 5
+        
+        for i, group in enumerate(response.root):
+            assert group.name == f"test-group-{i}"
+            assert group.object_id == f"group-{i}"
+
+    def test_get_device_groups_response_mixed_group_sizes(self):
+        """Test GetDeviceGroupsResponse with groups of different sizes"""
+        groups = [
+            DeviceGroupElement(
+                id="empty-group",
+                name="empty-group",
+                devices=[],
+                description="Empty group"
+            ),
+            DeviceGroupElement(
+                id="small-group",
+                name="small-group",
+                devices=["device1"],
+                description="Small group"
+            ),
+            DeviceGroupElement(
+                id="large-group",
+                name="large-group",
+                devices=[f"device-{i}" for i in range(100)],
+                description="Large group"
+            )
+        ]
+        
+        response = GetDeviceGroupsResponse(root=groups)
+        assert len(response.root) == 3
+        assert len(response.root[0].devices) == 0
+        assert len(response.root[1].devices) == 1
+        assert len(response.root[2].devices) == 100
+
+    def test_get_device_groups_response_serialization(self):
+        """Test GetDeviceGroupsResponse serialization"""
+        group = DeviceGroupElement(
+            id="serialize-test",
+            name="serialize-group",
+            devices=["dev1", "dev2"],
+            description="Serialization test"
+        )
+        
+        response = GetDeviceGroupsResponse(root=[group])
+        serialized = response.model_dump()
+        
+        # GetDeviceGroupsResponse is a RootModel, so it serializes directly as a list
+        assert isinstance(serialized, list)
+        assert len(serialized) == 1
+        assert serialized[0]["name"] == "serialize-group"
+        assert serialized[0]["object_id"] == "serialize-test"
+
+    def test_get_device_groups_response_serialization_with_alias(self):
+        """Test GetDeviceGroupsResponse serialization with aliases"""
+        group = DeviceGroupElement(
+            id="alias-test",
+            name="alias-group",
+            devices=["dev1"],
+            description="Alias test"
+        )
+        
+        response = GetDeviceGroupsResponse(root=[group])
+        serialized = response.model_dump(by_alias=True)
+        
+        assert isinstance(serialized, list)
+        assert len(serialized) == 1
+        assert serialized[0]["id"] == "alias-test"
+        assert "object_id" not in serialized[0]
+
+
+class TestCreateDeviceGroupResponse:
+    """Test cases for CreateDeviceGroupResponse model"""
+
+    def test_create_device_group_response_valid_creation(self):
+        """Test creating CreateDeviceGroupResponse with valid data"""
+        response = CreateDeviceGroupResponse(
+            id="created-group-123",
+            name="created-test-group",
+            message="Device group created successfully",
+            status="active"
+        )
+        
+        assert response.object_id == "created-group-123"
+        assert response.name == "created-test-group"
+        assert response.message == "Device group created successfully"
+        assert response.status == "active"
+
+    def test_create_device_group_response_missing_required_fields(self):
+        """Test CreateDeviceGroupResponse with missing required fields"""
+        with pytest.raises(ValidationError) as exc_info:
+            CreateDeviceGroupResponse()
+        
+        errors = exc_info.value.errors()
+        required_fields = {"id", "name", "message", "status"}
+        missing_fields = {error["loc"][0] for error in errors if error["type"] == "missing"}
+        
+        assert required_fields == missing_fields
+
+    def test_create_device_group_response_serialization_with_alias(self):
+        """Test CreateDeviceGroupResponse serialization with alias"""
+        response = CreateDeviceGroupResponse(
+            id="alias-create-test",
+            name="alias-create-group",
+            message="Created with alias",
+            status="created"
+        )
+        
+        # Test model_dump() - should use field names
+        model_dict = response.model_dump()
+        assert "object_id" in model_dict
+        assert "id" not in model_dict
+        assert model_dict["object_id"] == "alias-create-test"
+        
+        # Test model_dump(by_alias=True) - should use aliases
+        alias_dict = response.model_dump(by_alias=True)
+        assert "id" in alias_dict
+        assert "object_id" not in alias_dict
+        assert alias_dict["id"] == "alias-create-test"
+
+    @pytest.mark.parametrize("status", [
+        "active", "inactive", "pending", "created", "error", "unknown"
+    ])
+    def test_create_device_group_response_various_statuses(self, status):
+        """Test CreateDeviceGroupResponse with various status values"""
+        response = CreateDeviceGroupResponse(
+            id="status-test",
+            name="status-group",
+            message=f"Group is {status}",
+            status=status
+        )
+        assert response.status == status
+
+    def test_create_device_group_response_unicode_support(self):
+        """Test CreateDeviceGroupResponse with Unicode characters"""
+        response = CreateDeviceGroupResponse(
+            id="unicode-组-123",
+            name="测试组创建",
+            message="Création réussie du groupe avec émojis ✅🎉",
+            status="активный"
+        )
+        
+        assert response.object_id == "unicode-组-123"
+        assert response.name == "测试组创建"
+        assert "✅🎉" in response.message
+        assert response.status == "активный"
+
+    def test_create_device_group_response_field_validation(self):
+        """Test CreateDeviceGroupResponse field type validation"""
+        # Test non-string object_id
+        with pytest.raises(ValidationError):
+            CreateDeviceGroupResponse(
+                id=123,
+                name="test",
+                message="test",
+                status="active"
+            )
+
+
+class TestAddDevicesToGroupResponse:
+    """Test cases for AddDevicesToGroupResponse model"""
+
+    def test_add_devices_to_group_response_valid_creation(self):
+        """Test creating AddDevicesToGroupResponse with valid data"""
+        response = AddDevicesToGroupResponse(
+            status="success",
+            message="Devices added successfully to the group"
+        )
+        
+        assert response.status == "success"
+        assert response.message == "Devices added successfully to the group"
+
+    def test_add_devices_to_group_response_missing_required_fields(self):
+        """Test AddDevicesToGroupResponse with missing required fields"""
+        with pytest.raises(ValidationError) as exc_info:
+            AddDevicesToGroupResponse()
+        
+        errors = exc_info.value.errors()
+        required_fields = {"status", "message"}
+        missing_fields = {error["loc"][0] for error in errors if error["type"] == "missing"}
+        
+        assert required_fields == missing_fields
+
+    @pytest.mark.parametrize("status", [
+        "success", "failure", "partial", "error", "warning", "info"
+    ])
+    def test_add_devices_to_group_response_various_statuses(self, status):
+        """Test AddDevicesToGroupResponse with various status values"""
+        response = AddDevicesToGroupResponse(
+            status=status,
+            message=f"Operation completed with status: {status}"
+        )
+        assert response.status == status
+
+    def test_add_devices_to_group_response_error_scenarios(self):
+        """Test AddDevicesToGroupResponse for error scenarios"""
+        error_response = AddDevicesToGroupResponse(
+            status="error",
+            message="Failed to add devices: Device 'invalid-device' not found"
+        )
+        
+        assert error_response.status == "error"
+        assert "Failed to add" in error_response.message
+        assert "not found" in error_response.message
+
+    def test_add_devices_to_group_response_partial_success(self):
+        """Test AddDevicesToGroupResponse for partial success scenarios"""
+        partial_response = AddDevicesToGroupResponse(
+            status="partial",
+            message="2 of 3 devices added successfully. Device 'offline-device' was unreachable."
+        )
+        
+        assert partial_response.status == "partial"
+        assert "2 of 3" in partial_response.message
+        assert "unreachable" in partial_response.message
+
+    def test_add_devices_to_group_response_unicode_support(self):
+        """Test AddDevicesToGroupResponse with Unicode characters"""
+        response = AddDevicesToGroupResponse(
+            status="успех",
+            message="设备成功添加到组 ✅ Dispositifs ajoutés avec succès 🚀"
+        )
+        
+        assert response.status == "успех"
+        assert "设备成功添加" in response.message
+        assert "✅" in response.message
+        assert "🚀" in response.message
+
+    def test_add_devices_to_group_response_serialization(self):
+        """Test AddDevicesToGroupResponse serialization"""
+        response = AddDevicesToGroupResponse(
+            status="success",
+            message="All devices added successfully"
+        )
+        
+        expected_dict = {
+            "status": "success",
+            "message": "All devices added successfully"
+        }
+        
+        assert response.model_dump() == expected_dict
+
+
+class TestRemoveDevicesFromGroupResponse:
+    """Test cases for RemoveDevicesFromGroupResponse model"""
+
+    def test_remove_devices_from_group_response_valid_creation(self):
+        """Test creating RemoveDevicesFromGroupResponse with valid data"""
+        response = RemoveDevicesFromGroupResponse(
+            status="success",
+            message="3 devices removed successfully"
+        )
+        
+        assert response.status == "success"
+        assert response.message == "3 devices removed successfully"
+
+    def test_remove_devices_from_group_response_missing_required_fields(self):
+        """Test RemoveDevicesFromGroupResponse with missing required fields"""
+        with pytest.raises(ValidationError) as exc_info:
+            RemoveDevicesFromGroupResponse()
+        
+        errors = exc_info.value.errors()
+        required_fields = {"status", "message"}
+        missing_fields = {error["loc"][0] for error in errors if error["type"] == "missing"}
+        
+        assert required_fields == missing_fields
+
+    @pytest.mark.parametrize("deleted_count", [0, 1, 5, 100, 1000])
+    def test_remove_devices_from_group_response_various_counts(self, deleted_count):
+        """Test RemoveDevicesFromGroupResponse with various deleted counts in message"""
+        response = RemoveDevicesFromGroupResponse(
+            status="success",
+            message=f"{deleted_count} devices removed successfully"
+        )
+        assert f"{deleted_count} devices" in response.message
+
+    def test_remove_devices_from_group_response_zero_deleted(self):
+        """Test RemoveDevicesFromGroupResponse when no devices were deleted"""
+        response = RemoveDevicesFromGroupResponse(
+            status="warning",
+            message="No devices were removed"
+        )
+        
+        assert response.status == "warning"
+        assert "No devices" in response.message
+
+    def test_remove_devices_from_group_response_error_scenario(self):
+        """Test RemoveDevicesFromGroupResponse for error scenarios"""
+        error_response = RemoveDevicesFromGroupResponse(
+            status="error",
+            message="Failed to remove devices due to access restrictions"
+        )
+        
+        assert error_response.status == "error"
+        assert "Failed to remove" in error_response.message
+
+    def test_remove_devices_from_group_response_partial_removal(self):
+        """Test RemoveDevicesFromGroupResponse for partial removal"""
+        partial_response = RemoveDevicesFromGroupResponse(
+            status="partial",
+            message="2 of 5 devices removed successfully"  # Out of 5 requested
+        )
+        
+        assert partial_response.status == "partial"
+        assert "2 of 5" in partial_response.message
+
+    def test_remove_devices_from_group_response_field_validation(self):
+        """Test RemoveDevicesFromGroupResponse field type validation"""
+        # Test non-string message
+        with pytest.raises(ValidationError):
+            RemoveDevicesFromGroupResponse(
+                status="success",
+                message=123  # Should be string
+            )
+        
+        # Test non-string status
+        with pytest.raises(ValidationError):
+            RemoveDevicesFromGroupResponse(
+                status=200,  # Should be string
+                message="Test message"
+            )
+
+    def test_remove_devices_from_group_response_error_message(self):
+        """Test RemoveDevicesFromGroupResponse with error message"""
+        # Error message for failed operation
+        response = RemoveDevicesFromGroupResponse(
+            status="error",
+            message="Failed to remove devices: insufficient permissions"
+        )
+        
+        assert response.status == "error"
+        assert "Failed to remove" in response.message
+
+    def test_remove_devices_from_group_response_unicode_status(self):
+        """Test RemoveDevicesFromGroupResponse with Unicode status and message"""
+        response = RemoveDevicesFromGroupResponse(
+            status="删除成功",
+            message="5 台设备已成功移除 ✅"
+        )
+        
+        assert response.status == "删除成功"
+        assert "5 台设备" in response.message
+        assert "✅" in response.message
+
+    def test_remove_devices_from_group_response_serialization(self):
+        """Test RemoveDevicesFromGroupResponse serialization"""
+        response = RemoveDevicesFromGroupResponse(
+            status="success",
+            message="7 devices removed successfully"
+        )
+        
+        expected_dict = {
+            "status": "success",
+            "message": "7 devices removed successfully"
+        }
+        
+        assert response.model_dump() == expected_dict
+
+
+class TestModelInteroperability:
+    """Test cases for model interoperability and edge cases"""
+
+    def test_all_models_have_proper_field_descriptions(self):
+        """Test that all models have proper field descriptions"""
+        models_to_test = [
+            DeviceGroupElement,
+            CreateDeviceGroupResponse,
+            AddDevicesToGroupResponse,
+            RemoveDevicesFromGroupResponse
+        ]
+        
+        for model_class in models_to_test:
+            schema = model_class.model_json_schema()
+            properties = schema["properties"]
+            
+            for field_name, field_info in properties.items():
+                assert "description" in field_info
+                assert len(field_info["description"]) > 0
+
+    def test_json_schema_generation(self):
+        """Test JSON schema generation for all models"""
+        models = [
+            DeviceGroupElement,
+            GetDeviceGroupsResponse,
+            CreateDeviceGroupResponse,
+            AddDevicesToGroupResponse,
+            RemoveDevicesFromGroupResponse
+        ]
+        
+        for model_class in models:
+            schema = model_class.model_json_schema()
+            assert "type" in schema
+            
+            # RootModels have different schema structure
+            if model_class == GetDeviceGroupsResponse:
+                assert "items" in schema
+            else:
+                assert "properties" in schema
+
+    def test_model_equality(self):
+        """Test model equality behavior"""
+        group1 = DeviceGroupElement(
+            id="test-id", name="test", devices=["dev1"], description="test"
+        )
+        group2 = DeviceGroupElement(
+            id="test-id", name="test", devices=["dev1"], description="test"
+        )
+        group3 = DeviceGroupElement(
+            id="different-id", name="test", devices=["dev1"], description="test"
+        )
+        
+        assert group1 == group2
+        assert group1 != group3
+
+    def test_object_id_alias_consistency(self):
+        """Test that object_id alias works consistently across models"""
+        models_with_object_id = [DeviceGroupElement, CreateDeviceGroupResponse]
+        
+        for model_class in models_with_object_id:
+            # Create instance with object_id parameter
+            instance = model_class(
+                id="test-id-123",
+                name="test-name",
+                **({"devices": [], "description": "test"} if model_class == DeviceGroupElement 
+                   else {"message": "test", "status": "test"})
+            )
+            
+            # Verify object_id is accessible
+            assert instance.object_id == "test-id-123"
+            
+            # Verify serialization without alias uses object_id
+            model_dict = instance.model_dump()
+            assert "object_id" in model_dict
+            assert "id" not in model_dict
+            
+            # Verify serialization with alias uses id
+            alias_dict = instance.model_dump(by_alias=True)
+            assert "id" in alias_dict
+            assert "object_id" not in alias_dict
+            assert alias_dict["id"] == "test-id-123"
+
+
+class TestModelValidationEdgeCases:
+    """Test edge cases and validation scenarios"""
+
+    def test_extremely_long_field_values(self):
+        """Test models with extremely long field values"""
+        long_string = "x" * 10000
+        
+        group = DeviceGroupElement(
+            id=long_string,
+            name=long_string,
+            devices=[long_string] * 100,
+            description=long_string
+        )
+        
+        assert len(group.object_id) == 10000
+        assert len(group.name) == 10000
+        assert len(group.devices) == 100
+        assert len(group.description) == 10000
+
+    def test_special_characters_in_fields(self):
+        """Test models with special characters in fields"""
+        special_chars = "!@#$%^&*()[]{}|;':\",./<>?"
+        
+        create_response = CreateDeviceGroupResponse(
+            id=special_chars,
+            name=special_chars,
+            message=special_chars,
+            status=special_chars
+        )
+        
+        assert create_response.object_id == special_chars
+        assert create_response.name == special_chars
+
+    def test_empty_and_whitespace_strings(self):
+        """Test models with empty and whitespace-only strings"""
+        add_response = AddDevicesToGroupResponse(
+            status="",
+            message="   \t\n   "
+        )
+        
+        assert add_response.status == ""
+        assert add_response.message == "   \t\n   "
+
+    def test_response_models_with_json_data(self):
+        """Test response models that might contain JSON-like data in strings"""
+        json_like_message = '{"result": "success", "devices_added": 5, "warnings": []}'
+        
+        response = AddDevicesToGroupResponse(
+            status="success",
+            message=json_like_message
+        )
+        
+        assert response.message == json_like_message
+        assert '"result": "success"' in response.message

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -474,6 +474,11 @@ class TestConfigurationManagerService:
         assert hasattr(service, "describe_golden_config_tree_version")
         assert hasattr(service, "set_golden_config_template")
         assert hasattr(service, "add_golden_config_node")
+        assert hasattr(service, "describe_device_group")
+        assert hasattr(service, "get_device_groups")
+        assert hasattr(service, "create_device_group")
+        assert hasattr(service, "add_devices_to_group")
+        assert hasattr(service, "remove_devices_from_group")
 
     def test_service_methods_are_async(self, service):
         """Test that all service methods are async."""
@@ -484,3 +489,558 @@ class TestConfigurationManagerService:
         assert asyncio.iscoroutinefunction(service.describe_golden_config_tree_version)
         assert asyncio.iscoroutinefunction(service.set_golden_config_template)
         assert asyncio.iscoroutinefunction(service.add_golden_config_node)
+        assert asyncio.iscoroutinefunction(service.describe_device_group)
+        assert asyncio.iscoroutinefunction(service.get_device_groups)
+        assert asyncio.iscoroutinefunction(service.create_device_group)
+        assert asyncio.iscoroutinefunction(service.add_devices_to_group)
+        assert asyncio.iscoroutinefunction(service.remove_devices_from_group)
+
+
+class TestConfigurationManagerDeviceGroups:
+    """Test cases for Configuration Manager Device Group methods."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock AsyncPlatform client."""
+        return AsyncMock(spec=ipsdk.platform.AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create a Configuration Manager Service instance."""
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_describe_device_group_success(self, service, mock_client):
+        """Test successful device group description retrieval."""
+        expected_data = {
+            "id": "group-123",
+            "name": "Production Routers",
+            "devices": ["router1", "router2", "router3"],
+            "description": "Production network routers"
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_data
+        mock_client._send_request.return_value = mock_response
+
+        result = await service.describe_device_group("Production Routers")
+
+        mock_client._send_request.assert_called_once_with(
+            "GET",
+            "/configuration_manager/name/devicegroups",
+            json={"groupName": "Production Routers"}
+        )
+        assert result == expected_data
+
+    @pytest.mark.asyncio
+    async def test_describe_device_group_empty_devices(self, service, mock_client):
+        """Test describing a device group with empty devices list."""
+        expected_data = {
+            "id": "group-456",
+            "name": "Empty Group",
+            "devices": [],
+            "description": "Group with no devices"
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_data
+        mock_client._send_request.return_value = mock_response
+
+        result = await service.describe_device_group("Empty Group")
+
+        mock_client._send_request.assert_called_once_with(
+            "GET",
+            "/configuration_manager/name/devicegroups",
+            json={"groupName": "Empty Group"}
+        )
+        assert result == expected_data
+        assert result["devices"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_device_groups_success(self, service, mock_client):
+        """Test successful retrieval of all device groups."""
+        expected_data = [
+            {
+                "id": "group-1",
+                "name": "Production Routers",
+                "devices": ["router1", "router2", "router3"],
+                "description": "Production network routers"
+            },
+            {
+                "id": "group-2", 
+                "name": "Test Switches",
+                "devices": ["switch1", "switch2"],
+                "description": "Test environment switches"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_data
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_device_groups()
+
+        mock_client.get.assert_called_once_with("/configuration_manager/deviceGroups")
+        assert result == expected_data
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_device_groups_empty_response(self, service, mock_client):
+        """Test get_device_groups with empty response."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_device_groups()
+
+        mock_client.get.assert_called_once_with("/configuration_manager/deviceGroups")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_success(self, service, mock_client):
+        """Test successful device group creation."""
+        # Mock get_device_groups to return existing groups (for duplicate check)
+        existing_groups = [
+            {"id": "group-1", "name": "Existing Group", "devices": [], "description": "Already exists"}
+        ]
+        service.get_device_groups = AsyncMock(return_value=existing_groups)
+
+        expected_response = {
+            "id": "new-group-123",
+            "name": "New Production Group",
+            "message": "Device group created successfully",
+            "status": "active"
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.post.return_value = mock_response
+
+        result = await service.create_device_group(
+            name="New Production Group",
+            devices=["router1", "router2"],
+            description="A new production device group"
+        )
+
+        # Verify duplicate check was performed
+        service.get_device_groups.assert_called_once()
+
+        # Verify API call
+        expected_body = {
+            "groupName": "New Production Group",
+            "groupDescription": "A new production device group",
+            "deviceNames": "router1,router2"
+        }
+        mock_client.post.assert_called_once_with(
+            "/configuration_manager/devicegroup",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_no_devices(self, service, mock_client):
+        """Test creating device group with no devices."""
+        service.get_device_groups = AsyncMock(return_value=[])
+
+        expected_response = {
+            "id": "empty-group-456",
+            "name": "Empty Group", 
+            "message": "Empty device group created",
+            "status": "active"
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.post.return_value = mock_response
+
+        result = await service.create_device_group(
+            name="Empty Group",
+            devices=[],
+            description="An empty device group"
+        )
+
+        # Verify empty deviceNames was sent
+        expected_body = {
+            "groupName": "Empty Group",
+            "groupDescription": "An empty device group",
+            "deviceNames": ""
+        }
+        mock_client.post.assert_called_once_with(
+            "/configuration_manager/devicegroup",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_no_description(self, service, mock_client):
+        """Test creating device group with no description."""
+        service.get_device_groups = AsyncMock(return_value=[])
+
+        expected_response = {
+            "id": "no-desc-group",
+            "name": "No Description Group",
+            "message": "Group created without description",
+            "status": "active"
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.post.return_value = mock_response
+
+        result = await service.create_device_group(
+            name="No Description Group",
+            devices=["device1", "device2"]
+        )
+
+        # Verify None description was passed
+        expected_body = {
+            "groupName": "No Description Group",
+            "groupDescription": None,
+            "deviceNames": "device1,device2"
+        }
+        mock_client.post.assert_called_once_with(
+            "/configuration_manager/devicegroup",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_duplicate_name_error(self, service, mock_client):
+        """Test creating device group with duplicate name raises error."""
+        # Mock get_device_groups to return existing group with same name
+        existing_groups = [
+            {"id": "existing-123", "name": "Existing Group", "devices": ["device1"], "description": "Already exists"}
+        ]
+        service.get_device_groups = AsyncMock(return_value=existing_groups)
+
+        with pytest.raises(ValueError, match="device group Existing Group already exists"):
+            await service.create_device_group(
+                name="Existing Group",
+                devices=["device2"],
+                description="Duplicate group"
+            )
+
+        # Verify get_device_groups was called but post was not
+        service.get_device_groups.assert_called_once()
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_success(self, service, mock_client):
+        """Test successfully adding devices to a group."""
+        # Mock describe_device_group response
+        mock_group_data = {
+            "id": "group-123",
+            "name": "Test Group",
+            "devices": ["device1"],
+            "description": "Test device group"
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "success"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.add_devices_to_group(
+            name="Test Group",
+            devices=["device1", "device2", "device3"]
+        )
+
+        # Verify describe_device_group was called
+        service.describe_device_group.assert_called_once_with("Test Group")
+
+        # Verify API call
+        expected_body = {
+            "details": {
+                "devices": ["device1", "device2", "device3"]
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-123",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_empty_list(self, service, mock_client):
+        """Test adding empty devices list to a group."""
+        mock_group_data = {
+            "id": "group-789",
+            "name": "Empty Add Group", 
+            "devices": ["device1"],
+            "description": "Test group"
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "success"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.add_devices_to_group(
+            name="Empty Add Group",
+            devices=[]
+        )
+
+        # Verify empty devices list was handled
+        expected_body = {
+            "details": {
+                "devices": []
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-789",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_success(self, service, mock_client):
+        """Test successfully removing devices from a group."""
+        # Mock describe_device_group response
+        mock_group_data = {
+            "id": "group-123",
+            "devices": ["device1", "device2", "device3", "device4", "device5"]
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "success"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.remove_devices_from_group(
+            name="Test Group",
+            devices=["device2", "device4"]  # Remove 2 devices
+        )
+
+        # Verify describe_device_group was called
+        service.describe_device_group.assert_called_once_with("Test Group")
+
+        # Verify API call - should contain remaining devices
+        expected_body = {
+            "details": {
+                "devices": ["device1", "device3", "device5"]  # Remaining devices
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-123",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_remove_all(self, service, mock_client):
+        """Test removing all devices from a group."""
+        mock_group_data = {
+            "id": "group-456",
+            "devices": ["device1", "device2"]
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "success"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.remove_devices_from_group(
+            name="Empty Group",
+            devices=["device1", "device2"]  # Remove all devices
+        )
+
+        # Verify empty devices list was sent
+        expected_body = {
+            "details": {
+                "devices": []  # No remaining devices
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-456",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_nonexistent_devices(self, service, mock_client):
+        """Test removing devices that are not in the group."""
+        mock_group_data = {
+            "id": "group-789",
+            "devices": ["device1", "device2", "device3"]
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "success"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.remove_devices_from_group(
+            name="Test Group",
+            devices=["device4", "device5"]  # Devices not in group
+        )
+
+        # Verify all original devices remain (no devices actually removed)
+        expected_body = {
+            "details": {
+                "devices": ["device1", "device2", "device3"]  # All original devices remain
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-789", 
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio 
+    async def test_remove_devices_from_group_partial_removal(self, service, mock_client):
+        """Test removing devices with partial matches."""
+        mock_group_data = {
+            "id": "group-mixed",
+            "devices": ["device1", "device2", "device3", "device4"]
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "partial"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.remove_devices_from_group(
+            name="Mixed Group",
+            devices=["device2", "device5"]  # device2 exists, device5 doesn't
+        )
+
+        # Verify only device2 was removed from the list
+        expected_body = {
+            "details": {
+                "devices": ["device1", "device3", "device4"]  # device2 removed, device5 wasn't there
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-mixed",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_empty_group(self, service, mock_client):
+        """Test removing devices from empty group."""
+        mock_group_data = {
+            "id": "empty-group",
+            "devices": []
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "warning"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        result = await service.remove_devices_from_group(
+            name="Empty Group",
+            devices=["device1"]
+        )
+
+        # Verify empty devices list remains empty
+        expected_body = {
+            "details": {
+                "devices": []
+            }
+        }
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/empty-group",
+            json=expected_body
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_device_groups_error_handling(self, service, mock_client):
+        """Test error handling for device group operations."""
+        # Test client error in get_device_groups
+        mock_client.get.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception, match="API Error"):
+            await service.get_device_groups()
+
+        # Reset side effect for other operations
+        mock_client.get.side_effect = None
+
+        # Test client error in describe_device_group
+        mock_client._send_request.side_effect = Exception("Group not found")
+
+        with pytest.raises(Exception, match="Group not found"):
+            await service.describe_device_group("NonExistent Group")
+
+    @pytest.mark.asyncio
+    async def test_device_group_integration_workflow(self, service, mock_client):
+        """Test integration workflow: create group, add devices, remove devices."""
+        # Step 1: Create device group
+        service.get_device_groups = AsyncMock(return_value=[])  # No existing groups
+
+        create_response = {"id": "workflow-group", "name": "Workflow Test Group", "message": "Created successfully", "status": "active"}
+        mock_response = Mock()
+        mock_response.json.return_value = create_response
+        mock_client.post.return_value = mock_response
+
+        create_result = await service.create_device_group(
+            name="Workflow Test Group",
+            devices=["device1"],
+            description="Test workflow integration"
+        )
+
+        assert create_result["id"] == "workflow-group"
+
+        # Step 2: Add more devices to the created group
+        service.describe_device_group = AsyncMock(return_value={"id": "workflow-group", "devices": ["device1"]})
+
+        add_response = {"status": "success"}
+        mock_response.json.return_value = add_response
+        mock_client.put.return_value = mock_response
+
+        add_result = await service.add_devices_to_group(
+            name="Workflow Test Group", 
+            devices=["device1", "device2", "device3"]
+        )
+
+        assert add_result["status"] == "success"
+
+        # Step 3: Remove a device from the group
+        service.describe_device_group = AsyncMock(return_value={"id": "workflow-group", "devices": ["device1", "device2", "device3"]})
+
+        remove_response = {"status": "success"}
+        mock_response.json.return_value = remove_response
+
+        remove_result = await service.remove_devices_from_group(
+            name="Workflow Test Group",
+            devices=["device2"]
+        )
+
+        assert remove_result["status"] == "success"
+
+        # Verify the final put call had correct remaining devices
+        expected_body = {
+            "details": {
+                "devices": ["device1", "device3"]  # device2 removed
+            }
+        }
+        mock_client.put.assert_called_with(
+            "/configuration_manager/deviceGroups/workflow-group",
+            json=expected_body
+        )

--- a/tests/test_tools_device_groups.py
+++ b/tests/test_tools_device_groups.py
@@ -1,0 +1,744 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastmcp import Context
+
+from itential_mcp.tools import device_groups
+from itential_mcp.models.device_groups import (
+    DeviceGroupElement,
+    GetDeviceGroupsResponse,
+    CreateDeviceGroupResponse,
+    AddDevicesToGroupResponse,
+    RemoveDevicesFromGroupResponse
+)
+
+
+class TestModule:
+    """Test the device_groups tools module"""
+
+    def test_module_tags(self):
+        """Test module has correct tags"""
+        assert hasattr(device_groups, '__tags__')
+        assert device_groups.__tags__ == ("configuration_manager",)
+
+    def test_module_functions_exist(self):
+        """Test all expected functions exist in the module"""
+        expected_functions = [
+            'get_device_groups',
+            'create_device_group',
+            'add_devices_to_group',
+            'remove_devices_from_group'
+        ]
+        
+        for func_name in expected_functions:
+            assert hasattr(device_groups, func_name)
+            assert callable(getattr(device_groups, func_name))
+
+    def test_functions_are_async(self):
+        """Test that all functions are async"""
+        import inspect
+        
+        functions_to_test = [
+            device_groups.get_device_groups,
+            device_groups.create_device_group,
+            device_groups.add_devices_to_group,
+            device_groups.remove_devices_from_group
+        ]
+        
+        for func in functions_to_test:
+            assert inspect.iscoroutinefunction(func), f"{func.__name__} should be async"
+
+
+class TestGetDeviceGroups:
+    """Test the get_device_groups tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+        
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+        
+        # Mock request context and lifespan context
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+        
+        return context
+
+    @pytest.mark.asyncio
+    async def test_get_device_groups_success(self, mock_context):
+        """Test get_device_groups with successful response"""
+        mock_data = [
+            {
+                "id": "group-1",
+                "name": "Production Routers",
+                "devices": ["router1", "router2", "router3"],
+                "description": "Production network routers"
+            },
+            {
+                "id": "group-2", 
+                "name": "Test Switches",
+                "devices": ["switch1", "switch2"],
+                "description": "Test environment switches"
+            }
+        ]
+        
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=mock_data)
+        
+        result = await device_groups.get_device_groups(mock_context)
+        
+        # Verify API call
+        mock_client.configuration_manager.get_device_groups.assert_called_once()
+        
+        # Verify result type and structure
+        assert isinstance(result, GetDeviceGroupsResponse)
+        assert len(result.root) == 2
+        
+        # Verify first device group
+        first_group = result.root[0]
+        assert isinstance(first_group, DeviceGroupElement)
+        assert first_group.object_id == "group-1"
+        assert first_group.name == "Production Routers"
+        assert first_group.devices == ["router1", "router2", "router3"]
+        assert first_group.description == "Production network routers"
+        
+        # Verify second device group
+        second_group = result.root[1]
+        assert second_group.object_id == "group-2"
+        assert second_group.name == "Test Switches"
+        assert second_group.devices == ["switch1", "switch2"]
+
+    @pytest.mark.asyncio
+    async def test_get_device_groups_empty_response(self, mock_context):
+        """Test get_device_groups with empty response"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=[])
+        
+        result = await device_groups.get_device_groups(mock_context)
+        
+        assert isinstance(result, GetDeviceGroupsResponse)
+        assert len(result.root) == 0
+        assert result.root == []
+
+    @pytest.mark.asyncio
+    async def test_get_device_groups_logs_info(self, mock_context):
+        """Test get_device_groups logs info message"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=[])
+        
+        await device_groups.get_device_groups(mock_context)
+        
+        mock_context.info.assert_called_once_with("inside get_device_groups(...)")
+
+    @pytest.mark.asyncio
+    async def test_get_device_groups_handles_missing_fields(self, mock_context):
+        """Test get_device_groups handles missing optional fields gracefully"""
+        mock_data = [
+            {
+                "id": "group-1",
+                "name": "Minimal Group",
+                "devices": [],
+                "description": "A minimal device group"
+            }
+        ]
+        
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=mock_data)
+        
+        result = await device_groups.get_device_groups(mock_context)
+        
+        assert isinstance(result, GetDeviceGroupsResponse)
+        assert len(result.root) == 1
+        assert result.root[0].devices == []
+
+
+class TestCreateDeviceGroup:
+    """Test the create_device_group tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+        
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        
+        # Mock request context and lifespan context
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+        
+        return context
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_success(self, mock_context):
+        """Test create_device_group with successful creation"""
+        # Mock get_device_groups to return existing groups
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([])  # No existing groups
+            
+            # Mock create response
+            mock_response = MagicMock()
+            mock_response_data = {
+                "id": "new-group-123",
+                "name": "New Production Group",
+                "message": "Device group created successfully",
+                "status": "active"
+            }
+            mock_response.json.return_value = mock_response_data
+            
+            mock_client = mock_context.request_context.lifespan_context.get.return_value
+            mock_client.post.return_value = mock_response
+            
+            result = await device_groups.create_device_group(
+                mock_context,
+                name="New Production Group",
+                description="A new production device group",
+                devices=["router1", "router2"]
+            )
+            
+            # Verify get_device_groups was called to check for duplicates
+            mock_get.assert_called_once_with(mock_context)
+            
+            # Verify API call
+            expected_body = {
+                "groupName": "New Production Group",
+                "groupDescription": "A new production device group",
+                "deviceNames": "router1,router2"
+            }
+            mock_client.post.assert_called_once_with(
+                "/configuration_manager/devicegroup",
+                json=expected_body
+            )
+            
+            # Verify result
+            assert isinstance(result, CreateDeviceGroupResponse)
+            assert result.object_id == "new-group-123"
+            assert result.name == "New Production Group"
+            assert result.message == "Device group created successfully"
+            assert result.status == "active"
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_no_devices(self, mock_context):
+        """Test create_device_group with no devices specified"""
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([])
+            
+            mock_response = MagicMock()
+            mock_response_data = {
+                "id": "empty-group-456",
+                "name": "Empty Group",
+                "message": "Empty device group created",
+                "status": "active"
+            }
+            mock_response.json.return_value = mock_response_data
+            
+            mock_client = mock_context.request_context.lifespan_context.get.return_value
+            mock_client.post.return_value = mock_response
+            
+            result = await device_groups.create_device_group(
+                mock_context,
+                name="Empty Group",
+                description="An empty device group"
+            )
+            
+            # Verify empty deviceNames was sent
+            expected_body = {
+                "groupName": "Empty Group",
+                "groupDescription": "An empty device group",
+                "deviceNames": ""
+            }
+            mock_client.post.assert_called_once_with(
+                "/configuration_manager/devicegroup",
+                json=expected_body
+            )
+            
+            assert result.object_id == "empty-group-456"
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_duplicate_name_error(self, mock_context):
+        """Test create_device_group raises error for duplicate name"""
+        # Mock get_device_groups to return existing group with same name
+        existing_group = DeviceGroupElement(
+            id="existing-123",
+            name="Existing Group",
+            devices=["device1"],
+            description="Already exists"
+        )
+        
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([existing_group])
+            
+            with pytest.raises(ValueError, match="device group Existing Group already exists"):
+                await device_groups.create_device_group(
+                    mock_context,
+                    name="Existing Group",
+                    description="Duplicate group"
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_no_description(self, mock_context):
+        """Test create_device_group with no description"""
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([])
+            
+            mock_response = MagicMock()
+            mock_response_data = {
+                "id": "no-desc-group",
+                "name": "No Description Group",
+                "message": "Group created without description",
+                "status": "active"
+            }
+            mock_response.json.return_value = mock_response_data
+            
+            mock_client = mock_context.request_context.lifespan_context.get.return_value
+            mock_client.post.return_value = mock_response
+            
+            await device_groups.create_device_group(
+                mock_context,
+                name="No Description Group"
+            )
+            
+            # Verify None description was passed
+            expected_body = {
+                "groupName": "No Description Group",
+                "groupDescription": None,
+                "deviceNames": ""
+            }
+            mock_client.post.assert_called_once_with(
+                "/configuration_manager/devicegroup",
+                json=expected_body
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_device_group_logs_info(self, mock_context):
+        """Test create_device_group logs info message"""
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([])
+            
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "id": "test", "name": "test", "message": "test", "status": "test"
+            }
+            
+            mock_client = mock_context.request_context.lifespan_context.get.return_value
+            mock_client.post.return_value = mock_response
+            
+            await device_groups.create_device_group(mock_context, name="Test")
+            
+            mock_context.info.assert_called_once_with("inside create_device_group(...)")
+
+
+class TestAddDevicesToGroup:
+    """Test the add_devices_to_group tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+        
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.put = AsyncMock()
+        
+        # Mock request context and lifespan context
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+        
+        return context
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_success(self, mock_context):
+        """Test add_devices_to_group with successful addition"""
+        mock_response_data = {
+            "status": "success"
+        }
+        
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.add_devices_to_group = AsyncMock(return_value=mock_response_data)
+        
+        result = await device_groups.add_devices_to_group(
+            mock_context,
+            name="Test Group",
+            devices=["device1", "device2", "device3"]
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.add_devices_to_group.assert_called_once_with(
+            "Test Group", ["device1", "device2", "device3"]
+        )
+            
+        # Verify result
+        assert isinstance(result, AddDevicesToGroupResponse)
+        assert result.status == "success"
+        assert result.message == "Devices added successfully"
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_with_message(self, mock_context):
+        """Test add_devices_to_group when API returns a message"""
+        mock_response_data = {
+            "status": "partial",
+            "message": "2 of 3 devices added successfully"
+        }
+        
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.add_devices_to_group = AsyncMock(return_value=mock_response_data)
+        
+        result = await device_groups.add_devices_to_group(
+            mock_context,
+            name="Partial Group",
+            devices=["device1", "device2", "device3"]
+        )
+        
+        assert result.status == "partial"
+        assert result.message == "2 of 3 devices added successfully"
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_no_devices(self, mock_context):
+        """Test add_devices_to_group with no devices specified"""
+        mock_response_data = {"status": "success"}
+        
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.add_devices_to_group = AsyncMock(return_value=mock_response_data)
+        
+        await device_groups.add_devices_to_group(
+            mock_context,
+            name="No Devices Group"
+        )
+        
+        # Verify None devices was handled
+        mock_client.configuration_manager.add_devices_to_group.assert_called_once_with(
+            "No Devices Group", None
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_logs_info(self, mock_context):
+        """Test add_devices_to_group logs info message"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.add_devices_to_group = AsyncMock(return_value={"status": "test"})
+        
+        await device_groups.add_devices_to_group(mock_context, name="Test")
+        
+        mock_context.info.assert_called_once_with("inside add_devices_to_group(...)")
+
+
+class TestRemoveDevicesFromGroup:
+    """Test the remove_devices_from_group tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+        
+        # Mock client with configuration_manager
+        mock_client = MagicMock()
+        mock_client.put = AsyncMock()
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.describe_device_group = AsyncMock()
+        
+        # Mock request context and lifespan context
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+        
+        return context
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_success(self, mock_context):
+        """Test remove_devices_from_group with successful removal"""
+        mock_response_data = {
+            "status": "success"
+        }
+        
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value=mock_response_data)
+        
+        result = await device_groups.remove_devices_from_group(
+            mock_context,
+            name="Test Group",
+            devices=["device2", "device4"]  # Remove 2 devices
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.remove_devices_from_group.assert_called_once_with(
+            "Test Group", ["device2", "device4"]
+        )
+        
+        # Verify result
+        assert isinstance(result, RemoveDevicesFromGroupResponse)
+        assert result.status == "success"
+        assert result.message == "Devices removed successfully"
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_remove_all(self, mock_context):
+        """Test remove_devices_from_group removing all devices"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value={"status": "success"})
+        
+        result = await device_groups.remove_devices_from_group(
+            mock_context,
+            name="Empty Group",
+            devices=["device1", "device2"]  # Remove all devices
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.remove_devices_from_group.assert_called_once_with(
+            "Empty Group", ["device1", "device2"]
+        )
+        
+        assert result.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_nonexistent_devices(self, mock_context):
+        """Test remove_devices_from_group with devices not in group"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value={"status": "success"})
+        
+        result = await device_groups.remove_devices_from_group(
+            mock_context,
+            name="Test Group",
+            devices=["device4", "device5"]  # Devices not in group
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.remove_devices_from_group.assert_called_once_with(
+            "Test Group", ["device4", "device5"]
+        )
+        
+        assert result.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_partial_removal(self, mock_context):
+        """Test remove_devices_from_group with partial device removal"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value={"status": "partial"})
+        
+        result = await device_groups.remove_devices_from_group(
+            mock_context,
+            name="Mixed Group", 
+            devices=["device2", "device5"]  # device2 exists, device5 doesn't
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.remove_devices_from_group.assert_called_once_with(
+            "Mixed Group", ["device2", "device5"]
+        )
+        
+        assert result.status == "partial"
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_no_devices_specified(self, mock_context):
+        """Test remove_devices_from_group with no devices specified"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value={"status": "success"})
+        
+        result = await device_groups.remove_devices_from_group(
+            mock_context,
+            name="No Remove Group",
+            devices=[]
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.remove_devices_from_group.assert_called_once_with(
+            "No Remove Group", []
+        )
+        
+        assert result.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_empty_group(self, mock_context):
+        """Test remove_devices_from_group with empty group"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value={"status": "warning"})
+        
+        result = await device_groups.remove_devices_from_group(
+            mock_context,
+            name="Empty Group",
+            devices=["device1"]
+        )
+        
+        # Verify service method was called
+        mock_client.configuration_manager.remove_devices_from_group.assert_called_once_with(
+            "Empty Group", ["device1"]
+        )
+        
+        assert result.status == "warning"
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_logs_info(self, mock_context):
+        """Test remove_devices_from_group logs info message"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(return_value={"status": "test"})
+        
+        await device_groups.remove_devices_from_group(mock_context, name="Test", devices=[])
+        
+        mock_context.info.assert_called_once_with("inside remove_devices_from_group(...)")
+
+
+class TestToolsIntegration:
+    """Test integration scenarios between tools functions"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+        
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        mock_client.put = AsyncMock()
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.describe_device_group = AsyncMock()
+        
+        # Mock request context and lifespan context
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+        
+        return context
+
+    @pytest.mark.asyncio
+    async def test_create_then_add_devices_workflow(self, mock_context):
+        """Test workflow: create device group then add devices to it"""
+        # Step 1: Create device group
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([])  # No existing groups
+            
+            create_response = MagicMock()
+            create_response.json.return_value = {
+                "id": "workflow-group",
+                "name": "Workflow Test Group",
+                "message": "Created successfully",
+                "status": "active"
+            }
+            
+            mock_client = mock_context.request_context.lifespan_context.get.return_value
+            mock_client.post.return_value = create_response
+            
+            create_result = await device_groups.create_device_group(
+                mock_context,
+                name="Workflow Test Group",
+                description="Test workflow integration"
+            )
+            
+            assert create_result.object_id == "workflow-group"
+            assert create_result.status == "active"
+        
+        # Step 2: Add devices to the created group
+        mock_client.configuration_manager.add_devices_to_group = AsyncMock(return_value={"status": "success"})
+        
+        add_result = await device_groups.add_devices_to_group(
+            mock_context,
+            name="Workflow Test Group",
+            devices=["device1", "device2", "device3"]
+        )
+        
+        assert add_result.status == "success"
+        assert "successfully" in add_result.message
+
+    @pytest.mark.asyncio
+    async def test_list_create_list_workflow(self, mock_context):
+        """Test workflow: list groups, create new one, list again to verify"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        
+        # Step 1: List existing groups (empty)
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=[])
+        
+        initial_groups = await device_groups.get_device_groups(mock_context)
+        assert len(initial_groups.root) == 0
+        
+        # Step 2: Create new group
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([])  # For duplicate check
+            
+            create_response = MagicMock()
+            create_response.json.return_value = {
+                "id": "new-workflow-group",
+                "name": "New Workflow Group",
+                "message": "Created in workflow",
+                "status": "active"
+            }
+            mock_client.post.return_value = create_response
+            
+            create_result = await device_groups.create_device_group(
+                mock_context,
+                name="New Workflow Group",
+                description="Created in integration test"
+            )
+            
+            assert create_result.object_id == "new-workflow-group"
+        
+        # Step 3: List groups again (should include new one)
+        updated_data = [{
+            "id": "new-workflow-group",
+            "name": "New Workflow Group",
+            "devices": [],
+            "description": "Created in integration test"
+        }]
+        mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=updated_data)
+        
+        updated_groups = await device_groups.get_device_groups(mock_context)
+        assert len(updated_groups.root) == 1
+        assert updated_groups.root[0].name == "New Workflow Group"
+
+    @pytest.mark.asyncio
+    async def test_error_handling_consistency(self, mock_context):
+        """Test that all functions handle errors consistently"""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        
+        # Test get_device_groups with client error
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.get_device_groups = AsyncMock(side_effect=Exception("API Error"))
+        
+        with pytest.raises(Exception, match="API Error"):
+            await device_groups.get_device_groups(mock_context)
+        
+        # Test create_device_group with duplicate name detection
+        existing_group = DeviceGroupElement(
+            id="existing",
+            name="Existing Group",
+            devices=[],
+            description="Exists"
+        )
+        
+        with patch('itential_mcp.tools.device_groups.get_device_groups') as mock_get:
+            mock_get.return_value = GetDeviceGroupsResponse([existing_group])
+            
+            with pytest.raises(ValueError, match="already exists"):
+                await device_groups.create_device_group(
+                    mock_context,
+                    name="Existing Group",
+                    description="Should fail"
+                )


### PR DESCRIPTION
This adds two new tools to the application for adding and removing devices from named device groups.  The `add_devices_to_group` will add devicees to a named device group and the `remove_devices_from_group` will remove devices from a named group.