### PR TITLE
Adds module tag to all tools

### DIFF
--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -104,7 +104,7 @@ def register_tools(mcp: FastMCP) -> None:
             # Inspect the module to retreive all of the functions.
             for name, f in inspect.getmembers(module, inspect.isfunction):
                 if not name.startswith("_") and f.__module__ == module_name:
-                    kwargs = {"tags": {name}}
+                    kwargs = {"tags": {name, f.__module__}}
                     if hasattr(f, "tags"):
                         tags = kwargs["tags"]
                         for ele in f.tags:


### PR DESCRIPTION
This adds a module tag to tools when they are loaded to the server.  By adding module tools, it allows an entire group of modules to be included
or excluded from the server.   For instance, all adapter tools can now
be excluded using `--exclude-tag adapters`