### PR TITLE
feat: optimize device_groups.py docstrings for LLM consumption

### DIFF
--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -14,34 +14,21 @@ async def get_device_groups(
     )],
 ) -> list[dict]:
     """
-    Get all device groups from Itential Platform server
+    Get all device groups from Itential Platform.
 
-    This tool will retrieve all of the configured device groups from
-    Itential Platform server.  The response includes a list of elements
-    where each element represents a unique device group.
-
-    Each element has the following fields:
-
-        * id: The unique identifier for the group
-        * name: The name of the device group
-        * devices: The list of device names that comprise this group
-        * description: A short description of this device group
-        * created: ISO 8601 timestamp of when the trigger was created
-        * createdBy: Account name that created the trigger
-        * updated: ISO 8601 timestamp of when the trigger was last updated
-        * updatedBy: Account name that last updated the trigger
-        * gbac: Returns the groups that have read and write access to this
-            device group
+    Device groups are logical collections of network devices that can be managed 
+    together for configuration, compliance, and automation tasks. They provide 
+    an organizational structure for grouping devices by function, location, or type.
 
     Args:
         ctx (Context): The FastMCP Context object
 
     Returns:
-        dict: A Python list of dict objects that represents the list
-            of device groups configured on Itential Platform
-
-    Raises:
-        None
+        list[dict]: List of device group objects with the following fields:
+            - id: Unique identifier for the group
+            - name: Device group name
+            - devices: List of device names in this group
+            - description: Device group description
     """
     await ctx.info("inside get_device_groups(...)")
 
@@ -89,46 +76,26 @@ async def create_device_group(
     )]
 ) -> dict:
     """
-    Create a new device group on Itential Server
+    Create a new device group on Itential Platform.
 
-    This tool will create a new device group on the server.  It has one
-    required argument `name` which defines the name of the group to
-    create.  If a group with the same name already exists, an
-    error is returned, otherwise the group is created.
-
-    The optional `description` argument sets a short description of
-    the device group.
-
-    The optional `devices` argument configures the list of devices to
-    include in the device group.  The list of devices should be devices
-    known to Itential Platform.  The list of devices can be found
-    using the `get_devices` tool.
-
-    This tool will return a message to indicate the device was created
-    successfully.
-
-        * id: The unqiue identifer for this device group
-        * name: The name of the device group
-        * message: Short status message describing the create operation
-        * status: Current status of the device group.
+    Device groups enable logical organization of network devices for streamlined 
+    management, configuration deployment, and automation workflows.
 
     Args:
         ctx (Context): The FastMCP Context object
-
-        name (str): The name of the device group to create
-
-        description (str): Short description of the device group
-
-        devices: (list): List of devices to add to the group when it is
-            created
+        name (str): Name of the device group to create
+        description (str | None): Short description of the device group (optional)
+        devices (list | None): List of device names to include in the group. Use `get_devices` to see available devices. (optional)
 
     Returns:
-        dict: An object that provides the status of the device group
-            create operation
+        dict: Creation operation result with the following fields:
+            - id: Unique identifier for the created device group
+            - name: Name of the device group
+            - message: Status message describing the create operation
+            - status: Current status of the device group
 
     Raises:
-        ValueError: Raised if a device group by the same name already
-            exists on the server
+        ValueError: If a device group with the same name already exists
     """
     await ctx.info("inside create_device_group(...)")
 


### PR DESCRIPTION
- Fix typo (unqiue→unique) and correct return type description from dict to list[dict]
- Add comprehensive device group definition and network organization context
- Remove unnecessary "Raises: None" section and verbose repetition
- Enhance parameter descriptions and cross-references to get_devices
- Remove documented fields not actually returned by the code
- Improve LLM understanding of device grouping for network automation and management workflows