### PR TITLE
Add tags to tools modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,35 +141,8 @@ to lowest:
 
 
 ## 💡 Available Tools
-The MCP server provides the following tools for interaction with Itential Platform:
-
-### System Tools
-- `get_health`: Retrieve platform health status including memory, CPU usage, and service status
-
-### Workflow Engine Tools
-- `get_job_metrics`: Get aggregated workflow job metrics
-- `get_task_metrics`: Get aggregated workflow task metrics
-
-### Workflow Management Tools
-- `get_workflows`: List available workflows
-- `start_workflow`: Start a workflow with provided variables and permissions
-
-### Job Tools
-- `get_jobs`: List all jobs (with optional filtering)
-- `describe_job`: Get details about a specific job (based on job_id)
-
-### Command Template Tools
-- `get_command_templates`: List all configured command templates
-- `describe_command_template`: Get details about a specific command template
-- `run_command_template`: Run a command template against a set of devices
-
-### Device Tools
-- `get_devices`: Get a list of devices from Itential Platform
-- `run_command`: Run a command against one or more devices
-
-
-Note: See [here](docs/exposing-workflows.md) for information about how to
-properly expose workflows to the MCP server
+The entire list of availablle tools can be found in the [tools](docs/tools.md)
+file along with the tag groups assoicated with those tools.
 
 ## 🛠️ Adding new Tools
 Adding a new tool is simple:

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -15,7 +15,14 @@ appropriate configuration option or command line option.
 There are standard tags that are also recognized in the Itential MCP server.
 by default, all tools with the tag `experimental` or `beta` are excluded from
 being registered by default.   This behavior can be changed by modifying the
-exludde tags configuration option.
+exclude tags configuration option.
+
+# Tag Groups
+
+The server now supports tag groups.  Tag groups will apply a tag to a group
+of tools so they can all be excluded or included with a single tag.  See the
+[tools](tools.md) file for a list of all avaiable groups and which tools
+are assoicated with those groups.
 
 To add tags to function there is a new decorator available.   For instance,
 this below example will add the tags "public", "released" to the tool call
@@ -53,3 +60,5 @@ async def my_new_tool(ctx: Context) -> dict:
 Using the `tags` decorator will attach the tags `public` and `released` to the
 tool and those tags can now be used in include and/or exclude tags
 configuration options to control tool registration with the server.
+
+

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,59 @@
+# Tools
+
+The full list of available tools and group can be found below.
+
+- `adapters`
+    - `get_adapters`
+    - `restart_adapter`
+    - `start_adapter`
+    - `stop_adapter`
+    -
+- `applications`
+    - `get_applications`
+    - `restart_application`
+    - `start_application`
+    - `stop_application`
+
+- `automation_studio`
+    - `describe_command_template`
+    - `get_command_template`
+    - `run_command`
+    - `run_command_template`
+
+- `configuration_manager`
+    - `get_compliance_plans`
+    - `run_compliance_plan`
+    - `describe_compliance_report`
+    - `render_template`
+    - `create_device_group`
+    - `get_device_groups`
+    - `apply_device_configuration`
+    - `backup_device_configuration`
+    - `get_device_configuration`
+    - `get_devices`
+
+- `integrations`
+    - `create_integration_model`
+    - `get_integration_models`
+
+- `lifecycle_manager`
+    - `create_resource`
+    - `describe_resource`
+    - `get_instances`
+    - `get_resources`
+
+- `workflow_engine`
+    - `get_job_metrics`
+    - `get_task_metrics`
+    - `get_task_merics_for_app`
+    - `get_task_metrics_for_task`
+    - `get_task_metrics_for workflow`
+
+- `system`
+    - `get_health`
+
+- `operations_manager`
+    - `describe_job`
+    - `get_jobs`
+    - `get_workflows`
+    - `start_workflow`

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -107,8 +107,8 @@ def register_tools(mcp: FastMCP) -> None:
                     # create a new tags set for the module and add any tags
                     # that have been configured using the `__tags__` variable
                     tags = set()
-                    if hasattr(f, "__tags__"):
-                        tags.union(f.__tags__)
+                    if hasattr(module, "__tags__"):
+                        tags = tags.union(set(module.__tags__))
 
                     # add the function name to the set of tags
                     tags.add(name)
@@ -121,7 +121,7 @@ def register_tools(mcp: FastMCP) -> None:
 
                     # add the function as a new mcp tool along with the set of
                     # tags associated with the function.
-                    mcp.tool(f, tags=list(tags))
+                    mcp.tool(f, tags=tags)
 
 
 async def run() -> int:

--- a/src/itential_mcp/tools/adapters.py
+++ b/src/itential_mcp/tools/adapters.py
@@ -12,6 +12,9 @@ from fastmcp import Context
 from itential_mcp import errors
 
 
+__tags__ = ("adapters",)
+
+
 async def _get_adapter_health(
     ctx: Context,
     name: str
@@ -21,7 +24,7 @@ async def _get_adapter_health(
 
     Args:
         ctx (Context): The FastMCP Context object
-        name (str): The case-sensitive name of the adapter. Use `get_adapters` 
+        name (str): The case-sensitive name of the adapter. Use `get_adapters`
             to see available adapters.
 
     Returns:

--- a/src/itential_mcp/tools/applications.py
+++ b/src/itential_mcp/tools/applications.py
@@ -12,6 +12,9 @@ from fastmcp import Context
 from itential_mcp import errors
 
 
+__tags__ = ("applications",)
+
+
 async def _get_application_health(
     ctx: Context,
     name: str
@@ -21,7 +24,7 @@ async def _get_application_health(
 
     Args:
         ctx (Context): The FastMCP Context object
-        name (str): The case-sensitive name of the application. Use `get_applications` 
+        name (str): The case-sensitive name of the application. Use `get_applications`
             to see available applications.
 
     Returns:

--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -9,6 +9,9 @@ from fastmcp import Context
 from itential_mcp import timeutils
 
 
+__tags__ = ("automation_studio",)
+
+
 async def _get_project_id_from_name(ctx: Context, name: str) -> str:
     """
     Get the project ID for a specified project name.
@@ -46,8 +49,8 @@ async def get_command_templates(
     """
     Get all command templates from Itential Platform.
 
-    Command Templates are run-time templates that actively pass commands to devices 
-    and evaluate responses against defined rules. Retrieves templates from both 
+    Command Templates are run-time templates that actively pass commands to devices
+    and evaluate responses against defined rules. Retrieves templates from both
     global space and projects.
 
     Args:
@@ -163,10 +166,10 @@ async def run_command_template(
     """
     Execute a command template against specified devices with rule evaluation.
 
-    Command Templates are run-time templates that actively pass commands to a list 
-    of specified devices during their runtime. After all responses are collected, 
-    the output set is evaluated against a set of defined rules. These executed 
-    templates are typically used as Pre and Post steps, which are usually separated 
+    Command Templates are run-time templates that actively pass commands to a list
+    of specified devices during their runtime. After all responses are collected,
+    the output set is evaluated against a set of defined rules. These executed
+    templates are typically used as Pre and Post steps, which are usually separated
     by a procedure (router upgrade, service migration, etc.).
 
     Args:

--- a/src/itential_mcp/tools/compliance_plans.py
+++ b/src/itential_mcp/tools/compliance_plans.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("configuration_manager",)
+
+
 async def get_compliance_plans(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -16,7 +19,7 @@ async def get_compliance_plans(
     """
     Get all compliance plans from Itential Platform.
 
-    Compliance plans define configuration validation rules and checks that can be 
+    Compliance plans define configuration validation rules and checks that can be
     executed against network devices to ensure they meet organizational standards.
 
     Args:
@@ -83,8 +86,8 @@ async def run_compliance_plan(
     """
     Execute a compliance plan against network devices.
 
-    Compliance plans validate device configurations against organizational standards 
-    by running predefined checks and rules. This function starts a compliance plan 
+    Compliance plans validate device configurations against organizational standards
+    by running predefined checks and rules. This function starts a compliance plan
     execution and returns the running instance details.
 
     Args:

--- a/src/itential_mcp/tools/compliance_reports.py
+++ b/src/itential_mcp/tools/compliance_reports.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("configuration_manager",)
+
+
 async def describe_compliance_report(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -19,8 +22,8 @@ async def describe_compliance_report(
     """
     Retrieve detailed compliance report results from Itential Platform.
 
-    Compliance reports contain the results of executing compliance plans against 
-    network devices, showing configuration validation outcomes, rule violations, 
+    Compliance reports contain the results of executing compliance plans against
+    network devices, showing configuration validation outcomes, rule violations,
     and compliance status for each checked device.
 
     Args:
@@ -28,8 +31,8 @@ async def describe_compliance_report(
         report_id (str): Unique identifier of the compliance report to retrieve
 
     Returns:
-        dict: Compliance report details containing validation results, device 
-            compliance status, rule violations, and configuration analysis from 
+        dict: Compliance report details containing validation results, device
+            compliance status, rule violations, and configuration analysis from
             running compliance checks against network infrastructure
     """
     await ctx.info("inside describe_compliance_report(...)")

--- a/src/itential_mcp/tools/configuration_manager.py
+++ b/src/itential_mcp/tools/configuration_manager.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("configuration_manager",)
+
+
 async def render_template(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -23,8 +26,8 @@ async def render_template(
     """
     Render a Jinja2 template with provided variables.
 
-    Jinja2 templates are commonly used in network automation for generating 
-    device configurations, commands, and other text-based content by combining 
+    Jinja2 templates are commonly used in network automation for generating
+    device configurations, commands, and other text-based content by combining
     template structures with dynamic variable values.
 
     Args:

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("configuration_manager", "devices")
+
+
 async def get_device_groups(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -16,8 +19,8 @@ async def get_device_groups(
     """
     Get all device groups from Itential Platform.
 
-    Device groups are logical collections of network devices that can be managed 
-    together for configuration, compliance, and automation tasks. They provide 
+    Device groups are logical collections of network devices that can be managed
+    together for configuration, compliance, and automation tasks. They provide
     an organizational structure for grouping devices by function, location, or type.
 
     Args:
@@ -78,7 +81,7 @@ async def create_device_group(
     """
     Create a new device group on Itential Platform.
 
-    Device groups enable logical organization of network devices for streamlined 
+    Device groups enable logical organization of network devices for streamlined
     management, configuration deployment, and automation workflows.
 
     Args:

--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("configuration_manager",)
+
+
 async def get_devices(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -16,8 +19,8 @@ async def get_devices(
     """
     Get all devices known to Itential Platform.
 
-    Itential Platform federates device information from multiple sources and makes 
-    it available for network automation workflows. Devices represent physical or 
+    Itential Platform federates device information from multiple sources and makes
+    it available for network automation workflows. Devices represent physical or
     virtual network infrastructure that can be managed, configured, and monitored.
 
     Args:
@@ -114,7 +117,7 @@ async def backup_device_configuration(
     """
     Create a backup of a device configuration in Itential Platform.
 
-    Configuration backups provide recovery points and change tracking for network 
+    Configuration backups provide recovery points and change tracking for network
     devices, enabling rollback capabilities and configuration management workflows.
 
     Args:
@@ -163,7 +166,7 @@ async def apply_device_configuration(
     """
     Apply configuration commands to a network device through Itential Platform.
 
-    Configuration deployment enables automated provisioning and updates of network 
+    Configuration deployment enables automated provisioning and updates of network
     device settings, supporting configuration management and infrastructure automation.
 
     Args:

--- a/src/itential_mcp/tools/integrations.py
+++ b/src/itential_mcp/tools/integrations.py
@@ -10,6 +10,9 @@ from fastmcp import Context
 from itential_mcp import errors
 
 
+__tags__ = ("integrations",)
+
+
 async def get_integration_models(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -18,8 +21,8 @@ async def get_integration_models(
     """
     Get all integration models from Itential Platform.
 
-    Integration models define API specifications for external systems and services 
-    that can be integrated with Itential Platform. They are based on OpenAPI 
+    Integration models define API specifications for external systems and services
+    that can be integrated with Itential Platform. They are based on OpenAPI
     specifications and enable automated interaction with third-party systems.
 
     Args:
@@ -64,8 +67,8 @@ async def create_integration_model(
     """
     Create a new integration model on Itential Platform from an OpenAPI specification.
 
-    Integration models enable Itential Platform to interact with external systems 
-    by defining their API structure and capabilities. The model must be a valid 
+    Integration models enable Itential Platform to interact with external systems
+    by defining their API structure and capabilities. The model must be a valid
     OpenAPI specification document.
 
     Args:

--- a/src/itential_mcp/tools/jobs.py
+++ b/src/itential_mcp/tools/jobs.py
@@ -10,6 +10,9 @@ from fastmcp import Context
 from itential_mcp import functions
 
 
+__tags__ = ("operations_manager",)
+
+
 async def get_jobs(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -26,8 +29,8 @@ async def get_jobs(
     """
     Get all jobs from Itential Platform.
 
-    Jobs represent workflow execution instances that track the status, progress, 
-    and results of automated tasks. They provide visibility into workflow 
+    Jobs represent workflow execution instances that track the status, progress,
+    and results of automated tasks. They provide visibility into workflow
     execution and enable monitoring of automation operations.
 
     Args:
@@ -106,8 +109,8 @@ async def describe_job(
     """
     Get detailed information about a specific job from Itential Platform.
 
-    Jobs are created automatically when workflows are executed and contain 
-    comprehensive information about the workflow execution including status, 
+    Jobs are created automatically when workflows are executed and contain
+    comprehensive information about the workflow execution including status,
     tasks, metrics, and results.
 
     Args:

--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -10,6 +10,9 @@ from fastmcp import Context
 from itential_mcp import functions
 
 
+__tags__ = ("lifecycle_manager",)
+
+
 async def get_resources(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -18,8 +21,8 @@ async def get_resources(
     """
     Get all Lifecycle Manager resource models from Itential Platform.
 
-    Lifecycle Manager resources define data models and workflows for managing 
-    network services and infrastructure components throughout their lifecycle. 
+    Lifecycle Manager resources define data models and workflows for managing
+    network services and infrastructure components throughout their lifecycle.
     They provide structured templates for creating and managing resource instances.
 
     Args:
@@ -85,14 +88,14 @@ async def create_resource(
     """
     Create a new Lifecycle Manager resource model on Itential Platform.
 
-    Resource models define the structure, validation rules, and lifecycle workflows 
-    for network services and infrastructure components. They serve as templates 
+    Resource models define the structure, validation rules, and lifecycle workflows
+    for network services and infrastructure components. They serve as templates
     for creating and managing resource instances.
 
     Args:
         ctx (Context): The FastMCP Context object
         name (str): Name of the resource model to create
-        schema (dict): JSON Schema definition for resource structure and validation. 
+        schema (dict): JSON Schema definition for resource structure and validation.
             Should include type, properties, and required fields without metadata.
         description (str | None): Human-readable description of the resource (optional)
 
@@ -223,8 +226,8 @@ async def get_instances(
     """
     Get all instances of a Lifecycle Manager resource from Itential Platform.
 
-    Resource instances represent actual network services or infrastructure 
-    components created from resource models. They contain the specific data 
+    Resource instances represent actual network services or infrastructure
+    components created from resource models. They contain the specific data
     and state information for managed resources.
 
     Args:

--- a/src/itential_mcp/tools/system.py
+++ b/src/itential_mcp/tools/system.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("system",)
+
+
 async def get_health(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -16,11 +19,11 @@ async def get_health(
     """
     Get comprehensive health information from Itential Platform.
 
-    System health monitoring provides visibility into platform performance, 
-    resource utilization, and component status. This enables proactive 
+    System health monitoring provides visibility into platform performance,
+    resource utilization, and component status. This enables proactive
     monitoring and troubleshooting of the automation infrastructure.
 
-    Note: This function also provides a complete list of all applications 
+    Note: This function also provides a complete list of all applications
     and adapters running on the platform as part of the health data.
 
     Args:

--- a/src/itential_mcp/tools/workflow_engine.py
+++ b/src/itential_mcp/tools/workflow_engine.py
@@ -8,6 +8,9 @@ from pydantic import Field
 from fastmcp import Context
 
 
+__tags__ = ("workflow_engine",)
+
+
 async def get_job_metrics(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"

--- a/src/itential_mcp/tools/workflows.py
+++ b/src/itential_mcp/tools/workflows.py
@@ -11,6 +11,9 @@ from itential_mcp import timeutils
 from itential_mcp import functions
 
 
+__tags__ = ("operations_manager",)
+
+
 async def get_workflows(
     ctx: Annotated[Context, Field(
         description="The FastMCP Context object"
@@ -19,9 +22,9 @@ async def get_workflows(
     """
     Get all workflow API endpoints from Itential Platform.
 
-    Workflows are the core automation engine of Itential Platform, defining 
-    executable processes that orchestrate network operations, device management, 
-    and service provisioning. Each workflow exposes an API endpoint that can be 
+    Workflows are the core automation engine of Itential Platform, defining
+    executable processes that orchestrate network operations, device management,
+    and service provisioning. Each workflow exposes an API endpoint that can be
     triggered by external systems or other platform components.
 
     Args:
@@ -115,14 +118,14 @@ async def start_workflow(
     """
     Execute a workflow by triggering its API endpoint.
 
-    Workflows are the core automation processes in Itential Platform. This function 
-    initiates workflow execution and returns a job object that can be monitored 
+    Workflows are the core automation processes in Itential Platform. This function
+    initiates workflow execution and returns a job object that can be monitored
     for progress and results.
 
     Args:
         ctx (Context): The FastMCP Context object
         route_name (str): API route name for the workflow. Use the 'routeName' field from `get_workflows`.
-        data (dict | None): Input data for workflow execution. Structure must match the workflow's 
+        data (dict | None): Input data for workflow execution. Structure must match the workflow's
             input schema (available in the 'schema' field from `get_workflows`).
 
     Returns:


### PR DESCRIPTION
This adds module level tags to the internal modules.  The tags can be used to include or exclude all tools in the module.  For instance, when configuring MCP, the entire set of Automation Studio tools can be excluded using `--exclude-tag automation_studio`