### PR TITLE
Fixes issue with AlreadyExistsError

### DIFF
--- a/src/itential_mcp/errors.py
+++ b/src/itential_mcp/errors.py
@@ -48,3 +48,4 @@ class AlreadyExistsError(ItentialMcpError):
     with the same identifier already exists on the server and therefore
     cannot be created.
     """
+    pass


### PR DESCRIPTION
The AlreadyExistsError was missing the pass directive in the class definition.  This change fixes that issue so the exception can be used in the application.