### PR TITLE
Removes created and update metdata from tools results

### DIFF
--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -6,8 +6,6 @@ from pydantic import Field
 
 from fastmcp import Context
 
-from itential_mcp import timeutils
-
 
 __tags__ = ("automation_studio",)
 
@@ -63,10 +61,6 @@ async def get_command_templates(
             - description: Template description
             - namespace: Project namespace (null for global templates)
             - passRule: Pass rule configuration (True=all must pass, False=one must pass)
-            - created: ISO 8601 creation timestamp
-            - createdBy: Creator account name
-            - updated: ISO 8601 last update timestamp
-            - updatedBy: Last updater account name
     """
     await ctx.info("inside get_command_templates(...)")
 
@@ -83,10 +77,6 @@ async def get_command_templates(
             "description": item["description"],
             "namespace": item["namespace"],
             "passRule": item["passRule"],
-            "created": timeutils.epoch_to_timestamp(item["created"]),
-            "createdBy": item["createdBy"],
-            "updated": timeutils.epoch_to_timestamp(item["lastUpdated"]),
-            "updatedBy": item["lastUpdatedBy"],
         })
 
     return results
@@ -118,10 +108,6 @@ async def describe_command_template(
             - commands: List of commands and associated rules
             - namespace: Project namespace (null for global templates)
             - passRule: Pass rule configuration (True=all must pass, False=one must pass)
-            - created: ISO 8601 creation timestamp
-            - createdBy: Creator account name
-            - updated: ISO 8601 last update timestamp
-            - updatedBy: Last updater account name
     """
     await ctx.info("inside describe_command_template(...)")
 
@@ -140,10 +126,6 @@ async def describe_command_template(
         "name": data["name"],
         "passRule": data["passRule"],
         "commands": data["commands"],
-        "created": timeutils.epoch_to_timestamp(data["created"]),
-        "createdBy": data["createdBy"],
-        "updated": timeutils.epoch_to_timestamp(data["lastUpdated"]),
-        "updatedBy": data["lastUpdatedBy"],
         "namespace": data["namespace"]
     }
 

--- a/src/itential_mcp/tools/jobs.py
+++ b/src/itential_mcp/tools/jobs.py
@@ -41,11 +41,7 @@ async def get_jobs(
     Returns:
         list[dict]: List of job objects with the following fields:
             - _id: Unique job identifier
-            - created: Job creation timestamp
-            - created_by: ID of user who created the job
             - description: Job description
-            - updated: Last update timestamp
-            - updated_by: ID of user who last updated the job
             - name: Job name
             - status: Current job status (error, complete, running, cancelled, incomplete, paused)
     """
@@ -81,10 +77,6 @@ async def get_jobs(
         for item in data.get("data") or list():
             results.append({
                 "_id": item.get("_id"),
-                "created": item.get("created"),
-                "created_by": item.get("created_by"),
-                "updated": item.get("last_updated"),
-                "updated_by": item.get("last_updated_by"),
                 "name": item.get("name"),
                 "description": item.get("description"),
                 "status": item.get("status")

--- a/src/itential_mcp/tools/workflows.py
+++ b/src/itential_mcp/tools/workflows.py
@@ -37,10 +37,6 @@ async def get_workflows(
             - description: Workflow description
             - schema: Input schema for workflow parameters (JSON Schema draft-07 format)
             - routeName: API route name for triggering the workflow (use with `start_workflow`)
-            - created: ISO 8601 creation timestamp
-            - createdBy: Account name that created the workflow
-            - updated: ISO 8601 last update timestamp
-            - updatedBy: Account name that last updated the workflow
             - lastExecuted: ISO 8601 timestamp of last execution (null if never executed)
 
     Notes:
@@ -88,10 +84,6 @@ async def get_workflows(
                 "description": item.get("description"),
                 "schema": item.get("schema"),
                 "routeName": item.get("routeName"),
-                "created": item.get("created"),
-                "createdBy": item.get("createdBy"),
-                "updated": item.get("lastUpdated"),
-                "updatedBy": item.get("lastUpdatedBy"),
                 "lastExecuted": lastExecuted,
             })
 
@@ -136,10 +128,6 @@ async def start_workflow(
             - tasks: Complete set of tasks to be executed in the workflow
             - status: Current job status (error, complete, running, canceled, incomplete, paused)
             - metrics: Job execution metrics including start_time, end_time, and user
-            - created: Job creation timestamp
-            - created_by: Account that created the job
-            - updated: Last update timestamp
-            - updated_by: Account that last updated the job
 
     Notes:
         - Use the returned '_id' field with `describe_job` to monitor workflow progress
@@ -147,7 +135,7 @@ async def start_workflow(
         - Job status can be monitored using the `get_jobs` or `describe_job` functions
         - Workflow schemas are available via the `get_workflows` function
     """
-    await ctx.info("inside run_workflow(...)")
+    await ctx.info("inside start_workflow(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -178,8 +166,4 @@ async def start_workflow(
         "tasks": data["tasks"],
         "status": data["status"],
         "metrics": metrics,
-        "updated": data["last_updated"],
-        "updated_by": data["last_updated_by"],
-        "created": data["created"],
-        "created_by": data["created_by"],
     }


### PR DESCRIPTION
This removes the following fields from the results metadata for a number of tools:

- `created`
- `createdBy`
- `updated`
- `updatedBy`

These fields could pose a potential security violiation when working with LLMs so they have been removed from the results.