### PR TITLE
Fix license identifier in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = [ "version" ]
 
 requires-python = ">=3.10"
 readme = "README.md"
-license = "Apache-2.0"
+license = "GPL-3.0-or-later"
 
 keywords = [
     "mcp",
@@ -25,7 +25,7 @@ keywords = [
 
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
The `pyproject.toml` had the worng license identifier listed in the metadata.  This fixes the metadata to now reference the correct license for the project.