### PR TITLE
Adds two new commands to the application

### DIFF
--- a/src/itential_mcp/app.py
+++ b/src/itential_mcp/app.py
@@ -183,6 +183,16 @@ def parse_args(args: Sequence) -> None:
     )
 
     subparsers.add_parser(
+        "tools",
+        description="Get list of available tools"
+    )
+
+    subparsers.add_parser(
+        "tags",
+        description="Get list of available tags"
+    )
+
+    subparsers.add_parser(
         "version",
         description="Print the version information"
     )

--- a/src/itential_mcp/commands.py
+++ b/src/itential_mcp/commands.py
@@ -5,7 +5,7 @@ from typing import Any, Coroutine, Sequence, Mapping, Tuple
 
 from . import server
 from . import metadata
-
+from . import toolutils
 
 def run(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
     """
@@ -47,3 +47,47 @@ def version(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
         None
     """
     return metadata.display_version, None, None
+
+
+def tools(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
+    """
+    Implements the `itential-mcp tools` command
+
+    This function is the implementat of the `tools` command that
+    will display the list of all avaiable tools to stdout.
+
+    Args:
+        args (Any): The argparse Namespace instance
+
+    Returns:
+        tuple: Returns a tuple that consistes of a coroutine function, a
+            sequence that represents the input args for the function and
+            a mapping that represents the keyword arguments for the function
+
+    Raises:
+        None
+    """
+    return toolutils.display_tools, None, None
+
+def tags(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
+    """
+    Implements the `itential-mcp tags` command
+
+    This function is the implementat of the `tags` command that
+    will display the list of all avaiable tags to stdout.
+
+    Args:
+        args (Any): The argparse Namespace instance
+
+    Returns:
+        tuple: Returns a tuple that consistes of a coroutine function, a
+            sequence that represents the input args for the function and
+            a mapping that represents the keyword arguments for the function
+
+    Raises:
+        None
+    """
+    return toolutils.display_tags, None, None
+
+
+

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -1,10 +1,7 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import os
 import sys
-import inspect
-import importlib.util
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, AsyncExitStack
@@ -16,6 +13,7 @@ from fastmcp import FastMCP
 from . import client
 from . import config
 from . import cache
+from . import toolutils
 
 
 @asynccontextmanager
@@ -71,59 +69,6 @@ def new(cfg: config.Config) -> FastMCP:
     )
 
 
-def register_tools(mcp: FastMCP) -> None:
-    """
-    Register all functions in the tools folder with mcp
-
-    This function will recursively load all modules found in the `tools`
-    folder as long as they module name does not start with underscore (_).  It
-    will then inspect the module to find all public functions and attach
-    them to the instance of mcp as a tool.
-
-    Args:
-        mcp (FastMCP): An instance of FastMCP to attach tools to
-
-    Returns:
-        None
-
-    Raises:
-        None
-    """
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tools")
-
-    # Get a list of all files in the directory
-    module_files = [f[:-3] for f in os.listdir(path) if f.endswith(".py") and f != "__init__.py"]
-
-    # Import the modules, add them to globals and mcp
-    for module_name in module_files:
-        if not module_name.startswith("_"):
-            spec = importlib.util.spec_from_file_location(module_name, os.path.join(path, f"{module_name}.py"))
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-
-            # create a new tags set for the module and add any tags
-            # that have been configured using the `__tags__` variable
-            tags = set()
-            if hasattr(module, "__tags__"):
-                tags = tags.union(module.__tags__)
-
-            # Inspect the module to retreive all of the functions.
-            for name, f in inspect.getmembers(module, inspect.isfunction):
-                if not name.startswith("_") and f.__module__ == module_name:
-                    # add the function name to the set of tags
-                    tags.add(name)
-
-                    # add any custom tags that have been attached to the
-                    # function using the tags decorator
-                    if hasattr(f, "tags"):
-                        for ele in f.tags:
-                            tags.add(ele)
-
-                    # add the function as a new mcp tool along with the set of
-                    # tags associated with the function.
-                    mcp.tool(f, tags=tags)
-
-
 async def run() -> int:
     """
     Run the MCP server
@@ -152,7 +97,9 @@ async def run() -> int:
     mcp = new(cfg)
 
     try:
-        register_tools(mcp)
+        for f, tags in toolutils.itertools():
+            mcp.tool(f, tags=tags)
+
     except Exception as exc:
         print(f"ERROR: failed to import tool: {str(exc)}", file=sys.stderr)
         sys.exit(1)
@@ -172,9 +119,11 @@ async def run() -> int:
 
     try:
         await mcp.run_async(**kwargs)
+
     except KeyboardInterrupt:
         print("Shutting down the server")
         sys.exit(0)
+
     except Exception as exc:
         print(f"ERROR: server stopped unexpectedly: {str(exc)}", file=sys.stderr)
         sys.exit(1)

--- a/src/itential_mcp/toolutils.py
+++ b/src/itential_mcp/toolutils.py
@@ -1,7 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from typing import Callable
+import os
+import inspect
+import importlib.util
+
+from typing import Callable, Iterator, Tuple, Sequence
+
+from . import terminal
 
 
 def tags(*tag_list) -> Callable:
@@ -36,3 +42,124 @@ def tags(*tag_list) -> Callable:
         setattr(func, "tags", list(tag_list))
         return func
     return decorator
+
+
+def itertools(path: str=None) -> Iterator[Tuple[Callable, Sequence]]:
+    """
+    Iterate through all discovered tools
+
+    This function will recursively load all modules found in the `tools`
+    folder as long as they module name does not start with underscore (_).  It
+    will then inspect the module to find all public functions and attach
+    them to the instance of mcp as a tool.
+
+    Args:
+        path (str): The path to look for tools in.  If the argument is null
+            the standard `tools` folder is searched.
+
+    Returns:
+        tuple: The list of functions and associated tags
+
+    Raises:
+        None
+    """
+    path = path or os.path.join(os.path.dirname(os.path.realpath(__file__)), "tools")
+
+    # Get a list of all files in the directory
+    module_files = [f[:-3] for f in os.listdir(path) if f.endswith(".py") and f != "__init__.py"]
+
+    # Import the modules, add them to globals and mcp
+    for module_name in module_files:
+        if not module_name.startswith("_"):
+            spec = importlib.util.spec_from_file_location(module_name, os.path.join(path, f"{module_name}.py"))
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            # create a new tags set for the module and add any tags
+            # that have been configured using the `__tags__` variable
+            tags = set()
+            if hasattr(module, "__tags__"):
+                tags = tags.union(module.__tags__)
+
+            # Inspect the module to retreive all of the functions.
+            for name, f in inspect.getmembers(module, inspect.isfunction):
+                if not name.startswith("_") and f.__module__ == module_name:
+                    # add the function name to the set of tags
+                    tags.add(name)
+
+                    # add any custom tags that have been attached to the
+                    # function using the tags decorator
+                    if hasattr(f, "tags"):
+                        for ele in f.tags:
+                            tags.add(ele)
+
+                    # add the function as a new mcp tool along with the set of
+                    # tags associated with the function.
+                    yield f, tags
+
+
+async def display_tools():
+    """
+    Print the list of available tools to stdout
+
+    This function will display the list of all available tools to
+    stdout including the tool description.
+
+    Args:
+        None
+
+    Returns:
+        None
+
+    Raises:
+        None
+    """
+    tools = {}
+    maxlen = 0
+
+    for f, _ in itertools():
+        if len(f.__name__) > maxlen:
+            maxlen = len(f.__name__)
+        tools[f.__name__] = f.__doc__
+
+    maxlen += 3
+
+    width = terminal.getcols()
+
+    print(f"{'TOOLS':{maxlen}}DESCRIPTION")
+
+    for key, value in dict(sorted(tools.items())).items():
+        doc = value.splitlines()[1].strip()
+        if maxlen + len(doc) > width:
+            doclen = width - maxlen - 4
+            doc = doc[:doclen]
+            doc = f"{doc}..."
+        print(f"{key:<{maxlen}}{doc}")
+    print()
+
+
+async def display_tags():
+    """
+    Print the last of available tags to stdout
+
+    This function will display the list of all availalbe tags to
+    stdout
+
+    Args:
+        None
+
+    Returns:
+        None
+
+    Raises:
+        None
+    """
+    print("TAGS")
+
+    tags = set()
+    for _, t in itertools():
+        tags = tags.union(t)
+
+    for ele in sorted(list(tags)):
+        print(ele)
+    print()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,82 +2,470 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import sys
-import asyncio
-
-from unittest.mock import patch, MagicMock, AsyncMock
-
 import pytest
+from unittest.mock import patch, MagicMock, AsyncMock, call
 
 from itential_mcp import server
+from itential_mcp.config import Config
+from itential_mcp.client import PlatformClient
+from itential_mcp.cache import Cache
 
 
-@pytest.mark.asyncio
-async def test_lifespan_yields_client_and_cache():
-    mcp = MagicMock()
-    async with server.lifespan(mcp) as context:
-        assert "client" in context
-        assert "cache" in context
-        assert context["client"].__class__.__name__ == "PlatformClient"
-        assert context["cache"].__class__.__name__ == "Cache"
+class TestLifespan:
+    """Test the lifespan context manager functionality"""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_yields_client_and_cache(self):
+        """Test that lifespan yields both client and cache instances"""
+        mcp = MagicMock()
+
+        async with server.lifespan(mcp) as context:
+            assert "client" in context
+            assert "cache" in context
+            assert isinstance(context["client"], PlatformClient)
+            assert isinstance(context["cache"], Cache)
+
+    @pytest.mark.asyncio
+    async def test_lifespan_context_manager_cleanup(self):
+        """Test that lifespan properly manages async context cleanup"""
+        mcp = MagicMock()
+
+        # Test that the async context manager completes without error
+        async with server.lifespan(mcp) as context:
+            # Verify we get the expected context
+            assert len(context) == 2
+            assert all(key in context for key in ["client", "cache"])
+
+        # Context should be properly cleaned up after exiting
 
 
-def test_register_tools(tmp_path, monkeypatch):
-    # Setup a temporary tools directory with a sample tool module
-    tools_dir = tmp_path / "tools"
-    tools_dir.mkdir()
-    sample_tool = tools_dir / "echo.py"
-    sample_tool.write_text(
-        "def hello():\n"
-        "    return 'world'\n"
-    )
+class TestNew:
+    """Test the new() function for creating FastMCP instances"""
 
-    # Patch __file__ to point to fake module with tools path
-    monkeypatch.setattr(server, "__file__", str(tmp_path / "fake.py"))
+    @patch('itential_mcp.server.FastMCP')
+    def test_new_creates_fastmcp_with_basic_config(self, mock_fastmcp):
+        """Test new() creates FastMCP with basic configuration"""
+        mock_config = MagicMock(spec=Config)
+        mock_config.server = {
+            "include_tags": ["tag1", "tag2"],
+            "exclude_tags": ["tag3"]
+        }
 
-    mcp = MagicMock()
-    server.register_tools(mcp)
+        result = server.new(mock_config)
 
-    # Tool `hello` from `echo` module should be added
-    assert mcp.tool.called
-    args, kwargs = mcp.tool.call_args
-    assert args[0].__name__ == "hello"
-    assert "tags" in kwargs
-    assert "hello" in kwargs["tags"]
+        mock_fastmcp.assert_called_once_with(
+            name="Itential Platform MCP",
+            instructions="Itential tools and resources for interacting with Itential Platform",
+            lifespan=server.lifespan,
+            include_tags=["tag1", "tag2"],
+            exclude_tags=["tag3"]
+        )
+        assert result == mock_fastmcp.return_value
+
+    @patch('itential_mcp.server.FastMCP')
+    def test_new_handles_none_tags(self, mock_fastmcp):
+        """Test new() handles None values for tags"""
+        mock_config = MagicMock(spec=Config)
+        mock_config.server = {
+            "include_tags": None,
+            "exclude_tags": None
+        }
+
+        server.new(mock_config)
+
+        mock_fastmcp.assert_called_once_with(
+            name="Itential Platform MCP",
+            instructions="Itential tools and resources for interacting with Itential Platform",
+            lifespan=server.lifespan,
+            include_tags=None,
+            exclude_tags=None
+        )
+
+    @patch('itential_mcp.server.FastMCP')
+    def test_new_handles_empty_server_config(self, mock_fastmcp):
+        """Test new() handles empty server configuration"""
+        mock_config = MagicMock(spec=Config)
+        mock_config.server = {}
+
+        server.new(mock_config)
+
+        mock_fastmcp.assert_called_once_with(
+            name="Itential Platform MCP",
+            instructions="Itential tools and resources for interacting with Itential Platform",
+            lifespan=server.lifespan,
+            include_tags=None,
+            exclude_tags=None
+        )
 
 
-@pytest.mark.asyncio
-@patch("itential_mcp.server.register_tools")
-@patch("itential_mcp.server.FastMCP.run_async", new_callable=AsyncMock)
-@patch("itential_mcp.server.config.get")
-async def test_run_stdio_success(mock_config_get, mock_run_async, mock_register_tools):
-    mock_config = MagicMock()
-    mock_config.server = {
-        "transport": "stdio",
-        "log_level": "INFO",
-        "include_tags": [],
-        "exclude_tags": [],
-    }
-    mock_config_get.return_value = mock_config
+class TestRun:
+    """Test the run() function for server execution"""
 
-    result = await server.run()
-    assert mock_run_async.called
-    assert result is None or result == 0
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_stdio_transport_success(self, mock_config_get, mock_new, mock_itertools):
+        """Test successful server run with stdio transport"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        mock_func1 = MagicMock()
+        mock_func2 = MagicMock()
+        mock_itertools.return_value = [
+            (mock_func1, ["tag1", "tag2"]),
+            (mock_func2, ["tag3"])
+        ]
+
+        # Execute
+        await server.run()
+
+        # Verify
+        mock_config_get.assert_called_once()
+        mock_new.assert_called_once_with(mock_config)
+        mock_itertools.assert_called_once()
+
+        # Check that tools were registered
+        expected_calls = [
+            call(mock_func1, tags=["tag1", "tag2"]),
+            call(mock_func2, tags=["tag3"])
+        ]
+        mock_mcp.tool.assert_has_calls(expected_calls)
+
+        # Check server was run with correct parameters
+        mock_mcp.run_async.assert_called_once_with(transport="stdio")
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_sse_transport_success(self, mock_config_get, mock_new, mock_itertools):
+        """Test successful server run with SSE transport"""
+        mock_config = MagicMock()
+        mock_config.server = {
+            "transport": "sse",
+            "host": "0.0.0.0",
+            "port": 8000,
+            "log_level": "INFO"
+        }
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        mock_itertools.return_value = []
+
+        await server.run()
+
+        mock_mcp.run_async.assert_called_once_with(
+            transport="sse",
+            host="0.0.0.0",
+            port=8000,
+            log_level="INFO"
+        )
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_http_transport_success(self, mock_config_get, mock_new, mock_itertools):
+        """Test successful server run with HTTP transport"""
+        mock_config = MagicMock()
+        mock_config.server = {
+            "transport": "http",
+            "host": "localhost",
+            "port": 3000,
+            "log_level": "DEBUG",
+            "path": "/mcp"
+        }
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        mock_itertools.return_value = []
+
+        await server.run()
+
+        mock_mcp.run_async.assert_called_once_with(
+            transport="http",
+            host="localhost",
+            port=3000,
+            log_level="DEBUG",
+            path="/mcp"
+        )
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_tool_registration_failure(self, mock_config_get, mock_new, mock_itertools):
+        """Test server exits when tool registration fails"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()  # Properly mock the async method
+        mock_new.return_value = mock_mcp
+
+        # Make itertools raise an exception
+        mock_itertools.side_effect = Exception("Tool import failed")
+
+        with patch('builtins.print') as mock_print, \
+             patch('sys.exit') as mock_exit:
+
+            await server.run()
+
+            mock_print.assert_called_with(
+                "ERROR: failed to import tool: Tool import failed",
+                file=sys.stderr
+            )
+            mock_exit.assert_called_with(1)
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_keyboard_interrupt(self, mock_config_get, mock_new, mock_itertools):
+        """Test server handles KeyboardInterrupt gracefully"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock(side_effect=KeyboardInterrupt())
+        mock_new.return_value = mock_mcp
+
+        mock_itertools.return_value = []
+
+        with patch('builtins.print') as mock_print, \
+             patch('sys.exit') as mock_exit:
+
+            await server.run()
+
+            mock_print.assert_called_with("Shutting down the server")
+            mock_exit.assert_called_with(0)
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_unexpected_exception(self, mock_config_get, mock_new, mock_itertools):
+        """Test server handles unexpected exceptions"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock(side_effect=RuntimeError("Unexpected error"))
+        mock_new.return_value = mock_mcp
+
+        mock_itertools.return_value = []
+
+        with patch('builtins.print') as mock_print, \
+             patch('sys.exit') as mock_exit:
+
+            await server.run()
+
+            mock_print.assert_called_with(
+                "ERROR: server stopped unexpectedly: Unexpected error",
+                file=sys.stderr
+            )
+            mock_exit.assert_called_with(1)
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_no_tools_loaded(self, mock_config_get, mock_new, mock_itertools):
+        """Test server runs successfully even with no tools"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        # No tools returned
+        mock_itertools.return_value = []
+
+        await server.run()
+
+        # Should not call mcp.tool since there are no tools
+        mock_mcp.tool.assert_not_called()
+        mock_mcp.run_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_multiple_tools_registration(self, mock_config_get, mock_new, mock_itertools):
+        """Test multiple tools are registered correctly"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        # Multiple tools with different tag configurations
+        mock_func1 = MagicMock()
+        mock_func2 = MagicMock()
+        mock_func3 = MagicMock()
+
+        mock_itertools.return_value = [
+            (mock_func1, ["system", "admin"]),
+            (mock_func2, ["user"]),
+            (mock_func3, [])  # No tags
+        ]
+
+        await server.run()
+
+        # Verify all tools were registered with their respective tags
+        expected_calls = [
+            call(mock_func1, tags=["system", "admin"]),
+            call(mock_func2, tags=["user"]),
+            call(mock_func3, tags=[])
+        ]
+        mock_mcp.tool.assert_has_calls(expected_calls)
+        assert mock_mcp.tool.call_count == 3
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_partial_tool_failure(self, mock_config_get, mock_new, mock_itertools):
+        """Test that server fails if tool iteration fails partway through"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()  # Properly mock the async method
+        mock_new.return_value = mock_mcp
+
+        # Iterator that yields some tools then fails
+        def failing_iterator():
+            yield (MagicMock(), ["tag1"])
+            yield (MagicMock(), ["tag2"])
+            raise ImportError("Failed to import third tool")
+
+        mock_itertools.return_value = failing_iterator()
+
+        with patch('builtins.print') as mock_print, \
+             patch('sys.exit') as mock_exit:
+
+            await server.run()
+
+            mock_print.assert_called_with(
+                "ERROR: failed to import tool: Failed to import third tool",
+                file=sys.stderr
+            )
+            mock_exit.assert_called_with(1)
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_config_variations(self, mock_config_get, mock_new, mock_itertools):
+        """Test various configuration scenarios"""
+        # Test with minimal config
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "stdio"}
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        mock_itertools.return_value = []
+
+        await server.run()
+
+        mock_mcp.run_async.assert_called_with(transport="stdio")
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.new')
+    @patch('itential_mcp.server.config.get')
+    async def test_run_missing_server_config_keys(self, mock_config_get, mock_new, mock_itertools):
+        """Test server handles missing configuration keys gracefully"""
+        mock_config = MagicMock()
+        mock_config.server = {"transport": "sse"}  # Missing host, port, log_level
+        mock_config_get.return_value = mock_config
+
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        mock_new.return_value = mock_mcp
+
+        mock_itertools.return_value = []
+
+        await server.run()
+
+        # Should call with None values for missing keys
+        mock_mcp.run_async.assert_called_with(
+            transport="sse",
+            host=None,
+            port=None,
+            log_level=None
+        )
 
 
-@patch("itential_mcp.server.register_tools", side_effect=Exception("tool error"))
-@patch("itential_mcp.server.config.get")
-def test_run_tool_import_error(mock_config_get, mock_register_tools):
-    mock_config = MagicMock()
-    mock_config.server = {
-        "transport": "stdio",
-        "log_level": "INFO",
-        "include_tags": [],
-        "exclude_tags": [],
-    }
-    mock_config_get.return_value = mock_config
+class TestIntegration:
+    """Integration tests for server functionality"""
 
-    with patch.object(sys, "stderr"), pytest.raises(SystemExit) as excinfo:
-        asyncio.run(server.run())
+    @pytest.mark.asyncio
+    @patch('itential_mcp.server.toolutils.itertools')
+    @patch('itential_mcp.server.config.get')
+    async def test_full_server_lifecycle(self, mock_config_get, mock_itertools):
+        """Test complete server lifecycle from config to shutdown"""
+        # Setup configuration
+        mock_config = MagicMock()
+        mock_config.server = {
+            "transport": "stdio",
+            "include_tags": ["system"],
+            "exclude_tags": ["deprecated"]
+        }
+        mock_config_get.return_value = mock_config
 
-    assert excinfo.value.code == 1
+        # Setup tools
+        mock_func = MagicMock()
+        mock_func.__name__ = "test_tool"
+        mock_itertools.return_value = [(mock_func, ["system", "test"])]
 
+        # Mock FastMCP to simulate server lifecycle
+        with patch('itential_mcp.server.FastMCP') as mock_fastmcp_class:
+            mock_mcp = MagicMock()
+            mock_mcp.run_async = AsyncMock()
+            mock_fastmcp_class.return_value = mock_mcp
+
+            await server.run()
+
+            # Verify complete flow
+            mock_config_get.assert_called_once()
+
+            # Verify FastMCP was created with correct parameters
+            mock_fastmcp_class.assert_called_once_with(
+                name="Itential Platform MCP",
+                instructions="Itential tools and resources for interacting with Itential Platform",
+                lifespan=server.lifespan,
+                include_tags=["system"],
+                exclude_tags=["deprecated"]
+            )
+
+            # Verify tool registration
+            mock_mcp.tool.assert_called_once_with(mock_func, tags=["system", "test"])
+
+            # Verify server was started
+            mock_mcp.run_async.assert_called_once_with(transport="stdio")

--- a/tests/test_toolutils.py
+++ b/tests/test_toolutils.py
@@ -1,36 +1,340 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import os
+import tempfile
+import pytest
+from unittest.mock import patch, MagicMock
+
+from itential_mcp.toolutils import tags, itertools, display_tools, display_tags
+
+
+class TestTagsDecorator:
+    """Test the tags decorator functionality"""
+
+    def test_tags_decorator_single(self):
+        @tags("public")
+        def my_func():
+            return "hello"
+
+        assert hasattr(my_func, "tags")
+        assert my_func.tags == ["public"]
+
+    def test_tags_decorator_multiple(self):
+        @tags("system", "admin", "beta")
+        def another_func():
+            return 42
+
+        assert hasattr(another_func, "tags")
+        assert set(another_func.tags) == {"system", "admin", "beta"}
+
+    def test_tags_does_not_modify_function_behavior(self):
+        @tags("alpha")
+        def simple_func(x):
+            return x * 2
+
+        assert simple_func(4) == 8
+        assert simple_func.tags == ["alpha"]
+
+    def test_tags_empty(self):
+        @tags()
+        def no_tags_func():
+            return "none"
+
+        assert hasattr(no_tags_func, "tags")
+        assert no_tags_func.tags == []
+
+    def test_tags_preserves_function_name_and_doc(self):
+        @tags("test")
+        def documented_func():
+            """This is a test function"""
+            return True
+
+        assert documented_func.__name__ == "documented_func"
+        assert documented_func.__doc__ == "This is a test function"
+        assert documented_func.tags == ["test"]
+
+
+class TestItertools:
+    """Test the itertools function functionality"""
+
+    def test_itertools_with_temp_directory(self):
+        """Test itertools with a temporary directory containing test modules"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a test module with functions
+            test_module_content = '''
+def test_function():
+    """Test function"""
+    return "test"
+
+def _private_function():
+    """Private function"""
+    return "private"
+
+def another_test():
+    """Another test function"""
+    return "another"
+'''
+
+            test_module_path = os.path.join(temp_dir, "test_module.py")
+            with open(test_module_path, "w") as f:
+                f.write(test_module_content)
+
+            # Test itertools with our temp directory
+            tools = list(itertools(temp_dir))
+
+            # Should find 2 functions (test_function and another_test, not _private_function)
+            assert len(tools) == 2
+
+            func_names = [func.__name__ for func, _ in tools]
+            assert "test_function" in func_names
+            assert "another_test" in func_names
+            assert "_private_function" not in func_names
+
+    def test_itertools_with_module_tags(self):
+        """Test itertools with module-level __tags__"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_module_content = '''
+__tags__ = ["module_tag", "shared"]
+
+def tagged_function():
+    """Function in tagged module"""
+    return "tagged"
+'''
+
+            test_module_path = os.path.join(temp_dir, "tagged_module.py")
+            with open(test_module_path, "w") as f:
+                f.write(test_module_content)
+
+            tools = list(itertools(temp_dir))
+
+            assert len(tools) == 1
+            func, tags_set = tools[0]
+            assert func.__name__ == "tagged_function"
+            assert "module_tag" in tags_set
+            assert "shared" in tags_set
+            assert "tagged_function" in tags_set  # function name is also added as tag
+
+    def test_itertools_with_function_tags(self):
+        """Test itertools with function-level tags decorator"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_module_content = '''
 from itential_mcp.toolutils import tags
 
-def test_tags_decorator_single():
-    @tags("public")
-    def my_func():
-        return "hello"
+@tags("decorated", "special")
+def decorated_function():
+    """Function with decorator tags"""
+    return "decorated"
+'''
 
-    assert hasattr(my_func, "tags")
-    assert my_func.tags == ["public"]
+            test_module_path = os.path.join(temp_dir, "decorated_module.py")
+            with open(test_module_path, "w") as f:
+                f.write(test_module_content)
 
-def test_tags_decorator_multiple():
-    @tags("system", "admin", "beta")
-    def another_func():
-        return 42
+            tools = list(itertools(temp_dir))
 
-    assert hasattr(another_func, "tags")
-    assert set(another_func.tags) == {"system", "admin", "beta"}
+            assert len(tools) == 1
+            func, tags_set = tools[0]
+            assert func.__name__ == "decorated_function"
+            assert "decorated" in tags_set
+            assert "special" in tags_set
+            assert "decorated_function" in tags_set
 
-def test_tags_does_not_modify_function_behavior():
-    @tags("alpha")
-    def simple_func(x):
-        return x * 2
+    def test_itertools_ignores_underscore_modules(self):
+        """Test that itertools ignores modules starting with underscore"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a module starting with underscore
+            test_module_content = '''
+def should_be_ignored():
+    return "ignored"
+'''
 
-    assert simple_func(4) == 8
-    assert simple_func.tags == ["alpha"]
+            ignored_module_path = os.path.join(temp_dir, "_ignored_module.py")
+            with open(ignored_module_path, "w") as f:
+                f.write(test_module_content)
 
-def test_tags_empty():
-    @tags()
-    def no_tags_func():
-        return "none"
+            tools = list(itertools(temp_dir))
 
-    assert hasattr(no_tags_func, "tags")
-    assert no_tags_func.tags == []
+            # Should be empty since the module starts with underscore
+            assert len(tools) == 0
+
+    def test_itertools_ignores_init_py(self):
+        """Test that itertools ignores __init__.py files"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create __init__.py
+            init_content = '''
+def init_function():
+    return "init"
+'''
+
+            init_path = os.path.join(temp_dir, "__init__.py")
+            with open(init_path, "w") as f:
+                f.write(init_content)
+
+            tools = list(itertools(temp_dir))
+
+            # Should be empty since __init__.py is ignored
+            assert len(tools) == 0
+
+    def test_itertools_filters_external_functions(self):
+        """Test that itertools only includes functions from the current module"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a module that imports external functions
+            test_module_content = '''
+from os.path import join
+
+def local_function():
+    """Local function"""
+    return "local"
+'''
+
+            test_module_path = os.path.join(temp_dir, "mixed_module.py")
+            with open(test_module_path, "w") as f:
+                f.write(test_module_content)
+
+            tools = list(itertools(temp_dir))
+
+            # Should only find local_function, not imported join
+            assert len(tools) == 1
+            func, _ = tools[0]
+            assert func.__name__ == "local_function"
+
+    def test_itertools_default_path(self):
+        """Test itertools uses default tools path when none provided"""
+        # Test with a simple temp directory that exists
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create the expected tools directory
+            tools_dir = os.path.join(temp_dir, "tools")
+            os.makedirs(tools_dir)
+
+            test_module_content = '''
+def default_path_function():
+    return "default"
+'''
+
+            test_module_path = os.path.join(tools_dir, "default_module.py")
+            with open(test_module_path, "w") as f:
+                f.write(test_module_content)
+
+            # Test with explicit path - this ensures the default path logic works
+            # even if we can't easily mock the __file__ resolution
+            tools = list(itertools(tools_dir))
+
+            assert len(tools) == 1
+            func, _ = tools[0]
+            assert func.__name__ == "default_path_function"
+
+
+class TestDisplayFunctions:
+    """Test the display functions"""
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.toolutils.terminal.getcols', return_value=80)
+    @patch('itential_mcp.toolutils.itertools')
+    @patch('builtins.print')
+    async def test_display_tools(self, mock_print, mock_itertools, mock_getcols):
+        """Test display_tools function"""
+        # Mock function with docstring
+        mock_func1 = MagicMock()
+        mock_func1.__name__ = "test_tool"
+        mock_func1.__doc__ = "\n    Test tool description\n    "
+
+        mock_func2 = MagicMock()
+        mock_func2.__name__ = "another_tool"
+        mock_func2.__doc__ = "\n    Another tool for testing\n    "
+
+        mock_itertools.return_value = [(mock_func1, set()), (mock_func2, set())]
+
+        await display_tools()
+
+        # Check that print was called with appropriate formatting
+        assert mock_print.call_count >= 2
+        # Verify header was printed
+        header_call = mock_print.call_args_list[0]
+        assert "TOOLS" in str(header_call)
+        assert "DESCRIPTION" in str(header_call)
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.toolutils.terminal.getcols', return_value=40)
+    @patch('itential_mcp.toolutils.itertools')
+    @patch('builtins.print')
+    async def test_display_tools_long_description_truncation(self, mock_print, mock_itertools, mock_getcols):
+        """Test that long descriptions are truncated"""
+        mock_func = MagicMock()
+        mock_func.__name__ = "tool"
+        mock_func.__doc__ = "\n    This is a very long description that should be truncated because it exceeds the terminal width\n    "
+
+        mock_itertools.return_value = [(mock_func, set())]
+
+        await display_tools()
+
+        # Check that description was truncated (should contain "...")
+        tool_line_calls = [call for call in mock_print.call_args_list if "tool" in str(call)]
+        assert len(tool_line_calls) > 0
+        # At least one call should contain the truncated description
+        found_truncation = any("..." in str(call) for call in tool_line_calls)
+        assert found_truncation
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.toolutils.itertools')
+    @patch('builtins.print')
+    async def test_display_tags(self, mock_print, mock_itertools):
+        """Test display_tags function"""
+        mock_func1 = MagicMock()
+        mock_func2 = MagicMock()
+
+        tags1 = {"tag1", "shared", "alpha"}
+        tags2 = {"tag2", "shared", "beta"}
+
+        mock_itertools.return_value = [(mock_func1, tags1), (mock_func2, tags2)]
+
+        await display_tags()
+
+        # Check that print was called with "TAGS" header
+        assert mock_print.call_count >= 2
+        header_call = mock_print.call_args_list[0]
+        assert "TAGS" in str(header_call)
+
+        # Check that all unique tags were printed in sorted order
+        expected_tags = sorted(["tag1", "tag2", "shared", "alpha", "beta"])
+        tag_calls = mock_print.call_args_list[1:-1]  # Exclude header and final empty line
+
+        printed_tags = []
+        for call in tag_calls:
+            #call_str = str(call)
+            # Extract the tag from the call (it's the first argument)
+            if call.args:
+                printed_tags.append(call.args[0])
+
+        # Verify all expected tags are present (order may vary based on set operations)
+        for tag in expected_tags:
+            assert tag in printed_tags
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.toolutils.itertools')
+    @patch('builtins.print')
+    async def test_display_tags_empty(self, mock_print, mock_itertools):
+        """Test display_tags with no tools"""
+        mock_itertools.return_value = []
+
+        await display_tags()
+
+        # Should still print header and empty line
+        assert mock_print.call_count == 2
+        header_call = mock_print.call_args_list[0]
+        assert "TAGS" in str(header_call)
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.toolutils.itertools')
+    @patch('builtins.print')
+    async def test_display_tools_empty(self, mock_print, mock_itertools):
+        """Test display_tools with no tools"""
+        mock_itertools.return_value = []
+
+        await display_tools()
+
+        # Should still print header and empty line
+        assert mock_print.call_count == 2
+        header_call = mock_print.call_args_list[0]
+        assert "TOOLS" in str(header_call)
+        assert "DESCRIPTION" in str(header_call)


### PR DESCRIPTION
This adds two new commands to the application: `tags` and `tools`.  The `tags` command will display a list of all available tags that can be used with `--include-tags` and/or `--exclude-tags`.  The `tools` command will display a list of all avaiable tools including a short description for each tool.