### PR TITLE
Adding new command for calling tools

### DIFF
--- a/src/itential_mcp/app.py
+++ b/src/itential_mcp/app.py
@@ -4,16 +4,13 @@
 import os
 import sys
 import asyncio
-import argparse
 import traceback
 import inspect
 
 from collections.abc import Sequence
-from dataclasses import fields
 
-from . import config
-from . import terminal
 from . import commands
+from . import cli
 
 
 LEGACY_ENV_VARS = frozenset((
@@ -24,126 +21,9 @@ LEGACY_ENV_VARS = frozenset((
 ))
 
 
-
-class Cli(argparse.ArgumentParser):
-
-    def print_app_help(self, file=None):
-        """
-        """
-        print(self.description)
-        print(f"\nUsage:\n  {self.prog} <command> [options]")
-
-        print("\nCommands:")
-        commands = dict(sorted(self._subparsers._group_actions[0].choices.items()))
-        for key, value in commands.items():
-            print(f"  {key:<20}{value.description}")
-
-        print("\nOptions:")
-
-        actions = {}
-
-        for index, action in enumerate(self._actions):
-            if not isinstance(action, argparse._SubParsersAction):
-                actions[action.option_strings[0]] = action
-
-
-        for key, value in dict(sorted(actions.items())).items():
-            helpstr = value.help or "NO HELP AVAILABLE!!"
-            if len(value.option_strings) == 1:
-                print(f"      {value.option_strings[0]:<16}{helpstr}")
-            else:
-                print(f"  {', '.join(value.option_strings):<20}{helpstr}")
-
-        print("\nUse \"itential-mcp <command> --help\" for more information about a command.\n")
-
-
-    def print_help(self, file=None):
-        """
-        """
-        print(self.description)
-        print(f"\nUsage:\n  {self.prog} [options]\n")
-
-        actions = {}
-
-        for index, action in enumerate(self._actions):
-            if not isinstance(action, argparse._SubParsersAction):
-                if action.container.title not in actions:
-                    actions[action.container.title] = {}
-                actions[action.container.title][action.option_strings[0]] = action
-
-        options = actions.pop("options")
-
-        for key, value in dict(sorted(actions.items())).items():
-            print(f"{key}")
-
-            for k, v in value.items():
-                helpstr = v.help or "NO HELP AVAILABLE!!"
-
-                if len(v.option_strings) == 1:
-                    if v.metavar is not None:
-                        option = f"{v.option_strings[0]} {v.metavar}"
-                    else:
-                        option = v.option_strings[0]
-
-                    if len(option) > 21:
-                        n = terminal.getcols()
-                        helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
-                        print(f"{' ':6}{option:<22}")
-                        for s in helpstr:
-                            print(f"{' ':28}{s}")
-                    else:
-                        print(f"{' ':6}{option:<22}{helpstr}")
-
-                else:
-                    option = f"{', '.join(value.option_strings)} {value.metavar}"
-                    if len(option) > 15:
-                        n = terminal.getcols()
-                        helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
-                        print(f"      {option:<22}")
-                        for s in helpstr:
-                            print(f"{' ':28}{s}")
-                    else:
-                        print(f"      {option:<22}{helpstr}")
-
-
-
-        print("\nGlobal Options")
-
-        for key, value in dict(sorted(options.items())).items():
-            helpstr = value.help or "NO HELP AVAILABLE!!"
-
-            if len(value.option_strings) == 1:
-                if value.metavar is not None:
-                    option = f"{value.option_strings[0]} {value.metavar}"
-                else:
-                    option = value.option_strings[0]
-
-                if len(option) > 15:
-                    n = terminal.getcols()
-                    helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
-                    print(f"{' ':6}{option:<22}")
-                    for s in helpstr:
-                        print(f"{' ':28}{s}")
-                else:
-                    print(f"{' ':10}{option:<18}{helpstr}")
-
-            else:
-                option = f"{', '.join(value.option_strings)} {value.metavar}"
-                if len(option) > 15:
-                    n = terminal.getcols()
-                    helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
-                    print(f"{' ':6}{option:<22}")
-                    for s in helpstr:
-                        print(f"{' ':28}{s}")
-                else:
-                    print(f"{' ':6}{option:<22}{helpstr}")
-
-        print("\nUse \"itential-mcp <command> --help\" for more information about a command.\n")
-
-
 def parse_args(args: Sequence) -> None:
     """
-    Parses any arguments
+    Parses command line arguments
 
     This function will parse the arguments identified by the `args` argument
     and return a Namespace object with the values. Typically this is used
@@ -158,7 +38,7 @@ def parse_args(args: Sequence) -> None:
     Raises:
         None
     """
-    parser = Cli(
+    parser = cli.Parser(
         prog="itential-mcp",
         add_help=False,
         description="Itential MCP\n\n  Find more information at: https://github.com/itential/itential-mcp"
@@ -182,6 +62,27 @@ def parse_args(args: Sequence) -> None:
         description="Run the MCP server"
     )
 
+    cli.add_server_group(run_cmd)
+    cli.add_platform_group(run_cmd)
+
+    call_cmd = subparsers.add_parser(
+        "call",
+        description="Call a tool and return the results"
+    )
+
+    call_cmd.add_argument(
+        "tool",
+        help="Name of the tool call"
+    )
+
+    call_cmd.add_argument(
+        "--params",
+        metavar="<object>",
+        help="Parameters to pass to the tool"
+    )
+
+    cli.add_platform_group(call_cmd)
+
     subparsers.add_parser(
         "tools",
         description="Get list of available tools"
@@ -201,44 +102,6 @@ def parse_args(args: Sequence) -> None:
         "--config",
         help="The Itential MCP configuration file"
     )
-
-    # MCP Server arguments
-    server_group = run_cmd.add_argument_group(
-        "MCP Server Options",
-        "Configuration options for the MCP Server instance"
-    )
-
-    # Itential Platform arguments
-    platform_group = run_cmd.add_argument_group(
-        "Itential Platform Options",
-        "Configuration options for connecting to Itential Platform API"
-    )
-
-    data = [f for f in fields(config.Config)]
-
-    for ele in data:
-        attrs = ele.default.json_schema_extra
-        if attrs and attrs.get("x-itential-mcp-cli-enabled"):
-            helpstr = ele.default.description
-            if helpstr is not None:
-                helpstr += f" (default={ele.default.default})"
-            else:
-                helpstr = "NO HELP AVAILABLE!!"
-
-            kwargs = {
-                "dest": ele.name,
-                "help": helpstr
-            }
-
-            kwargs.update(attrs.get("x-itential-mcp-options") or {})
-            posargs = attrs.get("x-itential-mcp-arguments")
-
-
-        if ele.name.startswith("server"):
-            server_group.add_argument(*posargs, **kwargs)
-        elif ele.name.startswith("platform"):
-            platform_group.add_argument(*posargs, **kwargs)
-
 
     args = parser.parse_args(args=args)
 

--- a/src/itential_mcp/cli.py
+++ b/src/itential_mcp/cli.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import sys
+import argparse
+
+from typing import Sequence, Tuple, Mapping, IO
+from dataclasses import fields
+from functools import lru_cache
+
+from . import terminal
+from . import config
+
+
+class Parser(argparse.ArgumentParser):
+
+    def print_app_help(self, file: IO | None=None) -> None:
+        """
+        Print help for the root application
+
+        This method will print the help message for the root application.  It
+        is triggered with `itential-mcp --help` and displays the list of
+        available commands and global options.
+
+        Args:
+            file (IO): The file to print the ouptut to.  The default is stdout
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        file = file or sys.stdout
+
+        print(self.description, file=file)
+        print(f"\nUsage:\n  {self.prog} <COMMAND> [OPTIONS]", file=file)
+
+        print("\nCommands:", file=file)
+        commands = dict(sorted(self._subparsers._group_actions[0].choices.items()))
+        for key, value in commands.items():
+            print(f"  {key:<20}{value.description}")
+
+        print("\nOptions:", file=file)
+
+        actions = {}
+
+        for index, action in enumerate(self._actions):
+            if not isinstance(action, argparse._SubParsersAction):
+                actions[action.option_strings[0]] = action
+
+        for key, value in dict(sorted(actions.items())).items():
+            helpstr = value.help or "NO HELP AVAILABLE!!"
+            if len(value.option_strings) == 1:
+                print(f"{' ':<6}{value.option_strings[0]:<16}{helpstr}", file=file)
+            else:
+                print(f"{' ':<2}{', '.join(value.option_strings):<20}{helpstr}", file=file)
+
+        print("\nUse \"itential-mcp <COMMAND> --help\" for more information about a command.\n", file=file)
+
+
+    def print_help(self, file: IO | None=None) -> None:
+        """
+        Print hep for an application command
+
+        This method will print the help message for an application command
+        such as `run` or `call`.   The help message is printed to stdout
+        by default
+
+        Args:
+            file (IO): The file to print the ouptut to.  The default is stdout
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        print(self.description, file=file)
+
+        actions = {}
+        positional = list()
+
+        for index, action in enumerate(self._actions):
+            if not isinstance(action, argparse._SubParsersAction):
+                if action.option_strings:
+                    if action.container.title not in actions:
+                        actions[action.container.title] = {}
+                    actions[action.container.title][action.option_strings[0]] = action
+                else:
+                    positional.append(action.dest)
+
+        args = list()
+        for item in positional:
+            args.append(f"<{item}>")
+
+        args = " ".join(args)
+
+        print(f"\nUsage:\n  {self.prog} {args} [OPTIONS]\n", file=file)
+
+        options = actions.pop("options")
+
+        for key, value in dict(sorted(actions.items())).items():
+            print(f"{key}")
+
+            for k, v in value.items():
+                helpstr = v.help or "NO HELP AVAILABLE!!"
+
+                if len(v.option_strings) == 1:
+                    if v.metavar is not None:
+                        option = f"{v.option_strings[0]} {v.metavar.upper()}"
+                    else:
+                        option = v.option_strings[0]
+
+                    if len(option) > 21:
+                        n = terminal.getcols()
+                        helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
+                        print(f"{' ':6}{option:<22}", file=file)
+                        for s in helpstr:
+                            print(f"{' ':28}{s}", file=file)
+                    else:
+                        print(f"{' ':6}{option:<22}{helpstr}", file=file)
+
+                else:
+                    option = f"{', '.join(v.option_strings)} {v.metavar.upper()}"
+                    if len(option) > 15:
+                        n = terminal.getcols()
+                        helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
+                        print(f"{' ':<6}{option:<22}", file=file)
+                        for s in helpstr:
+                            print(f"{' ':28}{s}", file=file)
+                    else:
+                        print(f"{' ':<6}{option:<22}{helpstr}", file=file)
+
+        print("\nOptions", file=file)
+
+        for key, value in dict(sorted(options.items())).items():
+            helpstr = value.help or "NO HELP AVAILABLE!!"
+
+            if len(value.option_strings) == 1:
+                if value.metavar is not None:
+                    option = f"{value.option_strings[0]} {value.metavar.upper()}"
+                else:
+                    option = value.option_strings[0]
+
+                if len(option) > 15:
+                    n = terminal.getcols()
+                    helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
+                    print(f"{' ':6}{option:<22}", file=file)
+                    for s in helpstr:
+                        print(f"{' ':28}{s}", file=file)
+                else:
+                    print(f"{' ':10}{option:<18}{helpstr}", file=file)
+
+            else:
+                if value.metavar is not None:
+                    option = f"{', '.join(value.option_strings)} {value.metavar.upper()}"
+                else:
+                    option = ', '.join(value.option_strings)
+
+                if len(option) > 15:
+                    n = terminal.getcols()
+                    helpstr = [helpstr[i:i+n] for i in range(0, len(helpstr), n)]
+                    print(f"{' ':6}{option:<22}", file=file)
+                    for s in helpstr:
+                        print(f"{' ':28}{s}", file=file)
+                else:
+                    print(f"{' ':6}{option:<22}{helpstr}", file=file)
+
+        print("\nUse \"itential-mcp <COMMAND> --help\" for more information about a command.\n", file=file)
+
+
+@lru_cache(maxsize=None)
+def _get_arguments_from_config() -> Sequence[Tuple[str, Sequence, Mapping]]:
+    """
+    Get the CLI options from the Config
+
+    This function will iterate over the fields in the Config object and
+    return the set of configuration options to be provided as CLI optional
+    arguments.
+
+    Args:
+        None
+
+    Returns:
+        Sequence: Returns a sequence of tuples where each element contains
+            the option name, sequence of arguments, and mapping of keyword
+            options
+
+    Raises:
+        None
+    """
+    data = [f for f in fields(config.Config)]
+    response = list()
+
+    for ele in data:
+        attrs = ele.default.json_schema_extra
+        if attrs and attrs.get("x-itential-mcp-cli-enabled"):
+            helpstr = ele.default.description
+            if helpstr is not None:
+                helpstr += f" (default={ele.default.default})"
+            else:
+                helpstr = "NO HELP AVAILABLE!!"
+
+            kwargs = {
+                "dest": ele.name,
+                "help": helpstr
+            }
+
+            kwargs.update(attrs.get("x-itential-mcp-options") or {})
+            posargs = attrs.get("x-itential-mcp-arguments")
+
+            response.append((ele.name, posargs, kwargs))
+
+    return response
+
+
+def add_platform_group(cmd: argparse.ArgumentParser):
+    """
+    Add the optional Platform group command line options
+
+    This function will add the Itential Platform command line options to
+    the command.  The Platform command line options group provides options
+    for configuration the connection to Itential Platform.
+
+    Args:
+        cmd (argparse.ArgumentParser): The argument parser to add the group to
+
+    Returns:
+        None
+
+    Raises:
+        None
+    """
+    # Itential Platform arguments
+    platform_group = cmd.add_argument_group(
+        "Itential Platform Options",
+        "Configuration options for connecting to Itential Platform API"
+    )
+
+    for ele, posargs, kwargs in _get_arguments_from_config():
+        if ele.startswith("platform"):
+            platform_group.add_argument(*posargs, **kwargs)
+
+
+def add_server_group(cmd: argparse.ArgumentParser):
+    """
+    Add the optional Platform group command line options
+
+    This function will add the Itential Platform command line options to
+    the command.  The Platform command line options group provides options
+    for configuration the connection to Itential Platform.
+
+    Args:
+        cmd (argparse.ArgumentParser): The argument parser to add the group to
+
+    Returns:
+        None
+
+    Raises:
+        None
+    """
+    # MCP Server arguments
+    server_group = cmd.add_argument_group(
+        "MCP Server Options",
+        "Configuration options for the MCP Server instance"
+    )
+
+    for ele, posargs, kwargs in _get_arguments_from_config():
+        if ele.startswith("server"):
+            server_group.add_argument(*posargs, **kwargs)

--- a/src/itential_mcp/commands.py
+++ b/src/itential_mcp/commands.py
@@ -6,10 +6,12 @@ from typing import Any, Coroutine, Sequence, Mapping, Tuple
 from . import server
 from . import metadata
 from . import toolutils
+from . import runner
+
 
 def run(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
     """
-    Implements the `itential-mcp run` command
+    Implement the `itential-mcp run` command
 
     This function implements the run command and returns the `run` function
     from the `server` module.
@@ -30,7 +32,7 @@ def run(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
 
 def version(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
     """
-    Implements the `itential-mcp run` command
+    Implement the `itential-mcp run` command
 
     This function implements the run command and returns the `run` function
     from the `server` module.
@@ -51,7 +53,7 @@ def version(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
 
 def tools(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
     """
-    Implements the `itential-mcp tools` command
+    Implement the `itential-mcp tools` command
 
     This function is the implementat of the `tools` command that
     will display the list of all avaiable tools to stdout.
@@ -71,7 +73,7 @@ def tools(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
 
 def tags(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
     """
-    Implements the `itential-mcp tags` command
+    Implement the `itential-mcp tags` command
 
     This function is the implementat of the `tags` command that
     will display the list of all avaiable tags to stdout.
@@ -90,4 +92,23 @@ def tags(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
     return toolutils.display_tags, None, None
 
 
+def call(args: Any) -> Tuple[Coroutine, Sequence, Mapping]:
+    """
+    Implement the `itential-mcp call` command
 
+    This function provides the implementation of the `call` command that
+    will invoke a tool with (or without) parameters.  The tool function
+    executes and returns the result.
+
+    Args:
+        args (Any): The argparse Namespace instance
+
+    Returns:
+        tuple: Returns a tuple that consistes of a coroutine function, a
+            sequence that represents the input args for the function and
+            a mapping that represents the keyword arguments for the function
+
+    Raises:
+        None
+    """
+    return runner.run, (args.tool, args.params), None

--- a/src/itential_mcp/runner.py
+++ b/src/itential_mcp/runner.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+
+from typing import Mapping, Any
+
+from fastmcp import Client
+
+from itential_mcp import config
+from itential_mcp import server
+
+
+async def run(tool: str, params: Mapping[str, Any] | None=None) -> None:
+    """
+    Run the specified tool and return the results
+
+    This function will invoke the tool as identified by the `tool` argument
+    and return the results.  Additional paramters can be specified using the
+    `params` argument.
+
+    If the tool is not a valid tool name (or has been excluded) this function
+    will raise an exception.  Additionally, if any required properties are
+    missing or invalid, an exception will be raised.
+
+    The tool function will be invoked and the result will be sent as a JSON
+    string to stdout
+
+    Args:
+        tool (str): The name of the tool to invoke
+
+        params (dict): The set of properties to pass to the tool as keyword
+            arguments when the function is invoked
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If the tool does not exist
+
+        ValueError: The one or more required parameters are missing
+
+        ValueError: If there are invalid parameters
+    """
+    async with Client(server.new(config.get())) as client:
+        # Basic server interaction
+        if await client.ping() is False:
+            raise ValueError("ERROR: cannot reach the server")
+
+        tools = {}
+
+        res = await client.list_tools_mcp()
+
+        for t in res.tools:
+            tools[t.name] = t.inputSchema
+
+        kwargs = {
+            "arguments": json.loads(params) if params else None
+        }
+
+        if tool not in tools:
+            raise ValueError(f"invalid tool: {tool}")
+
+        required = tools[tool].get("required") or list()
+
+        if required and set(required).difference((kwargs["arguments"] or {})):
+            for item in required:
+                if kwargs["arguments"] is None or item not in kwargs["arguments"]:
+                    raise ValueError(f"missing required property: {item}")
+
+        if kwargs["arguments"]:
+            if set(kwargs["arguments"]).difference(tools[tool]["properties"]):
+                for item in kwargs["arguments"]:
+                    if item not in tools[tool]["properties"]:
+                        raise ValueError(f"invalid argument: {item}")
+
+
+        # Execute operations
+        result = await client.call_tool(tool, **kwargs)
+
+        data = json.loads(result[0].text)
+        print(f"\n{json.dumps(data, indent=4)}")

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -58,13 +58,18 @@ def new(cfg: config.Config) -> FastMCP:
         This function should only be called once during server initialization.
     """
     # Initialize FastMCP server
-    return FastMCP(
+    srv = FastMCP(
         name="Itential Platform MCP",
         instructions="Tools for Itential - a network and infrastructure automation and orchestration platform. First, examine your available tools to understand your assigned persona: Platform SRE (platform administration, adapter/integration management, health monitoring), Platform Builder (asset development and promotion with full resource creation), Automation Developer (focused code asset development), Platform Operator (execute jobs, run compliance, consume data) or a Custom set of tools. Based on your tool access, adapt your approach - whether monitoring platform health, building automation assets, developing code resources, or operating established workflows. Key tools like get_health, get_workflows, run_command or create_resource will indicate your operational scope.",
         lifespan=lifespan,
         include_tags=cfg.server.get("include_tags"),
         exclude_tags=cfg.server.get("exclude_tags")
     )
+
+    for f, tags in toolutils.itertools():
+        srv.tool(f, tags=tags)
+
+    return srv
 
 
 async def run() -> int:
@@ -101,32 +106,24 @@ async def run() -> int:
         # Streamable HTTP transport
         $ itential-mcp --transport http --host 0.0.0.0 --port 8000 --path /mcp
     """
-    cfg = config.get()
-
-    mcp = new(cfg)
-
     try:
-        for f, tags in toolutils.itertools():
-            mcp.tool(f, tags=tags)
+        cfg = config.get()
 
-    except Exception as exc:
-        print(f"ERROR: failed to import tool: {str(exc)}", file=sys.stderr)
-        sys.exit(1)
+        mcp = new(cfg)
 
-    kwargs = {
-        "transport": cfg.server.get("transport")
-    }
+        kwargs = {
+            "transport": cfg.server.get("transport")
+        }
 
-    if kwargs["transport"] in ("sse", "http"):
-        kwargs.update({
-            "host": cfg.server.get("host"),
-            "port": cfg.server.get("port"),
-            "log_level": cfg.server.get("log_level")
-        })
-        if kwargs["transport"] == "http":
-            kwargs["path"] = cfg.server.get("path")
+        if kwargs["transport"] in ("sse", "http"):
+            kwargs.update({
+                "host": cfg.server.get("host"),
+                "port": cfg.server.get("port"),
+                "log_level": cfg.server.get("log_level")
+            })
+            if kwargs["transport"] == "http":
+                kwargs["path"] = cfg.server.get("path")
 
-    try:
         await mcp.run_async(**kwargs)
 
     except KeyboardInterrupt:

--- a/src/itential_mcp/toolutils.py
+++ b/src/itential_mcp/toolutils.py
@@ -140,7 +140,7 @@ async def display_tools():
 
 async def display_tags():
     """
-    Print the last of available tags to stdout
+    Print the last of available tags to stdout.
 
     This function will display the list of all availalbe tags to
     stdout
@@ -153,6 +153,7 @@ async def display_tags():
 
     Raises:
         None
+
     """
     print("TAGS")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,283 +9,197 @@ from io import StringIO
 import pytest
 
 from itential_mcp import app
-
-
-class TestCli:
-    """Test cases for the Cli class"""
-
-    def test_cli_init(self):
-        """Test Cli class initialization"""
-        cli = app.Cli(
-            prog="test-prog",
-            add_help=False,
-            description="Test description"
-        )
-        assert cli.prog == "test-prog"
-        assert cli.description == "Test description"
-
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_print_app_help(self, mock_stdout):
-        """Test print_app_help method"""
-        cli = app.Cli(
-            prog="test-prog",
-            description="Test description"
-        )
-        
-        # Add a subparser to test command display
-        subparsers = cli.add_subparsers(dest="command")
-        subparsers.add_parser("run", description="Run the server")
-        
-        # Add an argument to test options display
-        cli.add_argument("--config", help="Configuration file")
-        
-        cli.print_app_help()
-        
-        output = mock_stdout.getvalue()
-        assert "Test description" in output
-        assert "Usage:" in output
-        assert "test-prog <command> [options]" in output
-        assert "Commands:" in output
-        assert "run" in output
-        assert "Options:" in output
-        assert "--config" in output
-
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_print_help(self, mock_stdout):
-        """Test print_help method"""
-        cli = app.Cli(
-            prog="test-prog",
-            description="Test description"
-        )
-        
-        # Add arguments to test different scenarios
-        cli.add_argument("--config", help="Configuration file")
-        cli.add_argument("--verbose", action="store_true", help="Verbose output")
-        
-        cli.print_help()
-        
-        output = mock_stdout.getvalue()
-        assert "Test description" in output
-        assert "Usage:" in output
-        assert "test-prog [options]" in output
-        assert "Global Options" in output
-        assert "--config" in output
-        assert "--verbose" in output
-
-    @patch('itential_mcp.terminal.getcols')
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_print_help_with_long_option(self, mock_stdout, mock_getcols):
-        """Test print_help with long option names"""
-        mock_getcols.return_value = 80
-        
-        cli = app.Cli(
-            prog="test-prog",
-            description="Test description"
-        )
-        
-        # Add a long option to test wrapping
-        cli.add_argument("--very-long-option-name", metavar="VALUE", help="A very long help string that should wrap")
-        
-        cli.print_help()
-        
-        output = mock_stdout.getvalue()
-        assert "very-long-option-name" in output
-
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_print_help_with_argument_groups(self, mock_stdout):
-        """Test print_help with argument groups"""
-        cli = app.Cli(
-            prog="test-prog",
-            description="Test description"
-        )
-        
-        # Add argument groups
-        server_group = cli.add_argument_group("Server Options")
-        server_group.add_argument("--host", help="Server host")
-        
-        platform_group = cli.add_argument_group("Platform Options")
-        platform_group.add_argument("--username", help="Platform username")
-        
-        cli.print_help()
-        
-        output = mock_stdout.getvalue()
-        assert "Server Options" in output
-        assert "Platform Options" in output
-        assert "--host" in output
-        assert "--username" in output
+from itential_mcp.cli import Parser
 
 
 class TestParseArgs:
     """Test cases for parse_args function"""
 
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_basic(self, mock_fields):
-        """Test basic argument parsing"""
-        # Mock config fields
-        mock_field = Mock()
-        mock_field.name = "server_host"
-        mock_field.default = Mock()
-        mock_field.default.json_schema_extra = {
-            "x-itential-mcp-cli-enabled": True,
-            "x-itential-mcp-arguments": ["--host"],
-            "x-itential-mcp-options": {"type": str}
-        }
-        mock_field.default.description = "Server host"
-        mock_field.default.default = "localhost"
-        mock_fields.return_value = [mock_field]
+    @patch('itential_mcp.commands.run')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_run_command(self, mock_config_args, mock_run_cmd):
+        """Test parsing run command"""
+        mock_config_args.return_value = []
         
         async def mock_async_func():
             return 0
         
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (mock_async_func, [], {})
-            
-            result = app.parse_args(["run", "--host", "example.com"])
-            
-            assert result is not None
-            assert len(result) == 3
-            func, args, kwargs = result
-            assert callable(func)
-            assert inspect.iscoroutinefunction(func)
+        mock_run_cmd.return_value = (mock_async_func, None, None)
+        
+        result = app.parse_args(["run"])
+        
+        assert result is not None
+        assert len(result) == 3
+        func, args, kwargs = result
+        assert callable(func)
+        assert inspect.iscoroutinefunction(func)
+        assert args == ()
+        assert kwargs == {}
 
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_help(self, mock_fields):
+    @patch('itential_mcp.cli.Parser.print_app_help')
+    @patch('sys.exit')
+    def test_parse_args_help(self, mock_exit, mock_print_help):
         """Test help argument parsing"""
-        mock_fields.return_value = []
+        mock_exit.side_effect = SystemExit(0)
         
-        with patch.object(app.Cli, 'print_app_help') as mock_print_help:
-            with patch('sys.exit') as mock_exit:
-                mock_exit.side_effect = SystemExit(0)
-                with pytest.raises(SystemExit):
-                    app.parse_args(["--help"])
-                mock_print_help.assert_called_once()
-                mock_exit.assert_called_once_with(0)
+        with pytest.raises(SystemExit):
+            app.parse_args(["--help"])
+        
+        mock_print_help.assert_called_once()
+        mock_exit.assert_called_once_with(0)
 
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_no_command(self, mock_fields):
+    @patch('itential_mcp.cli.Parser.print_app_help')
+    @patch('sys.exit')
+    def test_parse_args_no_command(self, mock_exit, mock_print_help):
         """Test parsing with no command"""
-        mock_fields.return_value = []
+        mock_exit.side_effect = SystemExit(0)
         
-        with patch.object(app.Cli, 'print_app_help') as mock_print_help:
-            with patch('sys.exit') as mock_exit:
-                mock_exit.side_effect = SystemExit(0)
-                with pytest.raises(SystemExit):
-                    app.parse_args([])
-                mock_print_help.assert_called_once()
-                mock_exit.assert_called_once_with(0)
+        with pytest.raises(SystemExit):
+            app.parse_args([])
+        
+        mock_print_help.assert_called_once()
+        mock_exit.assert_called_once_with(0)
 
-    @patch('os.environ', {})
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_environment_variables(self, mock_fields):
-        """Test environment variable setting"""
-        mock_field = Mock()
-        mock_field.name = "server_host"
-        mock_field.default = Mock()
-        mock_field.default.json_schema_extra = {
-            "x-itential-mcp-cli-enabled": True,
-            "x-itential-mcp-arguments": ["--host"],
-            "x-itential-mcp-options": {"type": str}
-        }
-        mock_field.default.description = "Server host"
-        mock_field.default.default = "localhost"
-        mock_fields.return_value = [mock_field]
+    @patch('itential_mcp.commands.version')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_version_command(self, mock_config_args, mock_version_cmd):
+        """Test version command parsing"""
+        mock_config_args.return_value = []
         
         async def mock_async_func():
             return 0
         
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (mock_async_func, [], {})
-            
-            app.parse_args(["run", "--host", "example.com"])
-            
-            assert os.environ.get("ITENTIAL_MCP_SERVER_HOST") == "example.com"
+        mock_version_cmd.return_value = (mock_async_func, None, None)
+        
+        result = app.parse_args(["version"])
+        
+        assert result is not None
+        mock_version_cmd.assert_called_once()
+
+    @patch('itential_mcp.commands.tools')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_tools_command(self, mock_config_args, mock_tools_cmd):
+        """Test tools command parsing"""
+        mock_config_args.return_value = []
+        
+        async def mock_async_func():
+            return 0
+        
+        mock_tools_cmd.return_value = (mock_async_func, None, None)
+        
+        result = app.parse_args(["tools"])
+        
+        assert result is not None
+        mock_tools_cmd.assert_called_once()
+
+    @patch('itential_mcp.commands.tags')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_tags_command(self, mock_config_args, mock_tags_cmd):
+        """Test tags command parsing"""
+        mock_config_args.return_value = []
+        
+        async def mock_async_func():
+            return 0
+        
+        mock_tags_cmd.return_value = (mock_async_func, None, None)
+        
+        result = app.parse_args(["tags"])
+        
+        assert result is not None
+        mock_tags_cmd.assert_called_once()
+
+    @patch('itential_mcp.commands.call')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_call_command(self, mock_config_args, mock_call_cmd):
+        """Test call command parsing"""
+        mock_config_args.return_value = []
+        
+        async def mock_async_func(tool, params):
+            return 0
+        
+        mock_call_cmd.return_value = (mock_async_func, ("test_tool", None), None)
+        
+        result = app.parse_args(["call", "test_tool"])
+        
+        assert result is not None
+        mock_call_cmd.assert_called_once()
 
     @patch('os.environ', {})
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_config_file(self, mock_fields):
+    @patch('itential_mcp.commands.run')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_config_file(self, mock_config_args, mock_run_cmd):
         """Test config file argument"""
-        mock_fields.return_value = []
+        mock_config_args.return_value = []
         
         async def mock_async_func():
             return 0
         
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (mock_async_func, [], {})
-            
-            app.parse_args(["run", "--config", "/path/to/config.ini"])
-            
-            assert os.environ.get("ITENTIAL_MCP_CONFIG") == "/path/to/config.ini"
+        mock_run_cmd.return_value = (mock_async_func, None, None)
+        
+        app.parse_args(["run", "--config", "/path/to/config.ini"])
+        
+        assert os.environ.get("ITENTIAL_MCP_CONFIG") == "/path/to/config.ini"
 
     @patch('os.environ', {"ITENTIAL_MCP_TRANSPORT": "sse"})
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_legacy_environment_variables(self, mock_fields):
+    @patch('itential_mcp.commands.run')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_legacy_environment_variables(self, mock_config_args, mock_run_cmd):
         """Test legacy environment variable migration"""
-        mock_fields.return_value = []
+        mock_config_args.return_value = []
         
         async def mock_async_func():
             return 0
         
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (mock_async_func, [], {})
+        mock_run_cmd.return_value = (mock_async_func, None, None)
+        
+        app.parse_args(["run"])
+        
+        # Legacy var should be moved to new var
+        assert "ITENTIAL_MCP_TRANSPORT" not in os.environ
+        assert os.environ.get("ITENTIAL_MCP_SERVER_TRANSPORT") == "sse"
+
+    @patch('itential_mcp.commands.run')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_invalid_handler(self, mock_config_args, mock_run_cmd):
+        """Test error handling for invalid command handler"""
+        mock_config_args.return_value = []
+        mock_run_cmd.return_value = (lambda: None, None, None)  # Not async
+        
+        with pytest.raises(TypeError, match="handler must be callable and awaitable"):
+            app.parse_args(["run"])
+
+    @patch('os.environ', {})
+    @patch('itential_mcp.commands.run')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_parse_args_environment_variable_setting(self, mock_config_args, mock_run_cmd):
+        """Test environment variable setting for server and platform args"""
+        # Mock config that would return server and platform arguments
+        mock_config_args.return_value = []
+        
+        async def mock_async_func():
+            return 0
+        
+        mock_run_cmd.return_value = (mock_async_func, None, None)
+        
+        # Create a mock namespace that includes server_ and platform_ attributes
+        with patch('itential_mcp.cli.Parser.parse_args') as mock_parse:
+            mock_args = Mock()
+            mock_args.help = False
+            mock_args.command = "run"
+            mock_args.config = None
+            mock_args._get_kwargs.return_value = [
+                ("server_host", "example.com"),
+                ("platform_username", "testuser"),
+                ("other_arg", "value")
+            ]
+            mock_parse.return_value = mock_args
             
             app.parse_args(["run"])
             
-            # Legacy var should be moved to new var
-            assert "ITENTIAL_MCP_TRANSPORT" not in os.environ
-            assert os.environ.get("ITENTIAL_MCP_SERVER_TRANSPORT") == "sse"
-
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_version_command(self, mock_fields):
-        """Test version command parsing"""
-        mock_fields.return_value = []
-        
-        async def mock_async_func():
-            return 0
-        
-        with patch('itential_mcp.commands.version') as mock_version_cmd:
-            mock_version_cmd.return_value = (mock_async_func, [], {})
-            
-            result = app.parse_args(["version"])
-            
-            assert result is not None
-            mock_version_cmd.assert_called_once()
-
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_invalid_handler(self, mock_fields):
-        """Test error handling for invalid command handler"""
-        mock_fields.return_value = []
-        
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (lambda: None, [], {})  # Not async
-            
-            with pytest.raises(TypeError, match="handler must be callable and awaitable"):
-                app.parse_args(["run"])
-
-    @patch('itential_mcp.app.fields')
-    def test_parse_args_string_value_processing(self, mock_fields):
-        """Test string value processing for comma-separated values"""
-        mock_field = Mock()
-        mock_field.name = "server_tags"
-        mock_field.default = Mock()
-        mock_field.default.json_schema_extra = {
-            "x-itential-mcp-cli-enabled": True,
-            "x-itential-mcp-arguments": ["--tags"],
-            "x-itential-mcp-options": {"type": str}
-        }
-        mock_field.default.description = "Server tags"
-        mock_field.default.default = ""
-        mock_fields.return_value = [mock_field]
-        
-        async def mock_async_func():
-            return 0
-        
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (mock_async_func, [], {})
-            
-            app.parse_args(["run", "--tags", "tag1,tag2,tag3"])
-            
-            # Should process comma-separated values
-            assert os.environ.get("ITENTIAL_MCP_SERVER_TAGS") == "tag1, tag2, tag3"
+            # Only server_ and platform_ args should be set as env vars
+            assert os.environ.get("ITENTIAL_MCP_SERVER_HOST") == "example.com"
+            assert os.environ.get("ITENTIAL_MCP_PLATFORM_USERNAME") == "testuser"
+            assert "ITENTIAL_MCP_OTHER_ARG" not in os.environ
 
 
 class TestLegacyEnvVars:
@@ -318,33 +232,31 @@ class TestRun:
         async def mock_func():
             return 0
         
-        mock_parse_args.return_value = (mock_func, [], {})
+        mock_parse_args.return_value = (mock_func, (), {})
         mock_asyncio_run.return_value = 0
         
         result = app.run()
         
         assert result == 0
         mock_parse_args.assert_called_once_with(['run'])
-        # Check that asyncio.run was called with the function
-        assert mock_asyncio_run.call_count == 1
+        mock_asyncio_run.assert_called_once()
 
     @patch('asyncio.run')
     @patch('itential_mcp.app.parse_args')
-    @patch('sys.argv', ['itential-mcp', 'run', '--host', 'example.com'])
+    @patch('sys.argv', ['itential-mcp', 'run', '--config', '/path/config.ini'])
     def test_run_with_args(self, mock_parse_args, mock_asyncio_run):
         """Test run with arguments"""
         async def mock_func(*args, **kwargs):
             return 0
         
-        mock_parse_args.return_value = (mock_func, ['arg1'], {'key': 'value'})
+        mock_parse_args.return_value = (mock_func, ('arg1',), {'key': 'value'})
         mock_asyncio_run.return_value = 0
         
         result = app.run()
         
         assert result == 0
-        mock_parse_args.assert_called_once_with(['run', '--host', 'example.com'])
-        # Check that asyncio.run was called with the function and args
-        assert mock_asyncio_run.call_count == 1
+        mock_parse_args.assert_called_once_with(['run', '--config', '/path/config.ini'])
+        mock_asyncio_run.assert_called_once()
 
     @patch('traceback.print_exc')
     @patch('sys.exit')
@@ -367,61 +279,94 @@ class TestRun:
         async def mock_func():
             return 0
         
-        mock_parse_args.return_value = (mock_func, [], {})
+        mock_parse_args.return_value = (mock_func, (), {})
         mock_asyncio_run.return_value = 0
         
         result = app.run()
         
         assert result == 0
         mock_parse_args.assert_called_once_with(['version'])
-        # Check that asyncio.run was called with the function
-        assert mock_asyncio_run.call_count == 1
+        mock_asyncio_run.assert_called_once()
+
+
+class TestParser:
+    """Test cases for CLI Parser functionality"""
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_parser_print_app_help(self, mock_stdout):
+        """Test Parser print_app_help method"""
+        parser = Parser(
+            prog="test-prog",
+            description="Test description"
+        )
+        
+        # Add a subparser to test command display
+        subparsers = parser.add_subparsers(dest="command")
+        subparsers.add_parser("run", description="Run the server")
+        
+        # Add an argument to test options display
+        parser.add_argument("--config", help="Configuration file")
+        
+        parser.print_app_help()
+        
+        output = mock_stdout.getvalue()
+        assert "Test description" in output
+        assert "Usage:" in output
+        assert "test-prog <COMMAND> [OPTIONS]" in output
+        assert "Commands:" in output
+        assert "run" in output
+        assert "Options:" in output
+        assert "--config" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_parser_print_help(self, mock_stdout):
+        """Test Parser print_help method"""
+        parser = Parser(
+            prog="test-prog",
+            description="Test description"
+        )
+        
+        # Add arguments to test different scenarios
+        parser.add_argument("--config", help="Configuration file")
+        parser.add_argument("--verbose", action="store_true", help="Verbose output")
+        
+        parser.print_help()
+        
+        output = mock_stdout.getvalue()
+        assert "Test description" in output
+        assert "Usage:" in output
+        assert "--config" in output
+        assert "--verbose" in output
 
 
 class TestIntegration:
     """Integration test cases"""
 
     @patch('os.environ', {})
-    @patch('itential_mcp.app.fields')
-    def test_full_argument_processing_integration(self, mock_fields):
+    @patch('itential_mcp.commands.run')
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_full_argument_processing_integration(self, mock_config_args, mock_run_cmd):
         """Test full argument processing flow"""
-        # Mock multiple config fields
-        server_field = Mock()
-        server_field.name = "server_host"
-        server_field.default = Mock()
-        server_field.default.json_schema_extra = {
-            "x-itential-mcp-cli-enabled": True,
-            "x-itential-mcp-arguments": ["--host"],
-            "x-itential-mcp-options": {"type": str}
-        }
-        server_field.default.description = "Server host"
-        server_field.default.default = "localhost"
-        
-        platform_field = Mock()
-        platform_field.name = "platform_username"
-        platform_field.default = Mock()
-        platform_field.default.json_schema_extra = {
-            "x-itential-mcp-cli-enabled": True,
-            "x-itential-mcp-arguments": ["--username"],
-            "x-itential-mcp-options": {"type": str}
-        }
-        platform_field.default.description = "Platform username"
-        platform_field.default.default = "admin"
-        
-        mock_fields.return_value = [server_field, platform_field]
+        mock_config_args.return_value = []
         
         async def mock_async_func():
             return 0
         
-        with patch('itential_mcp.commands.run') as mock_run_cmd:
-            mock_run_cmd.return_value = (mock_async_func, [], {})
+        mock_run_cmd.return_value = (mock_async_func, None, None)
+        
+        # Mock the argument parsing to simulate server and platform arguments
+        with patch('itential_mcp.cli.Parser.parse_args') as mock_parse:
+            mock_args = Mock()
+            mock_args.help = False
+            mock_args.command = "run"
+            mock_args.config = "/path/to/config.ini"
+            mock_args._get_kwargs.return_value = [
+                ("server_host", "example.com"),
+                ("platform_username", "testuser"),
+            ]
+            mock_parse.return_value = mock_args
             
-            result = app.parse_args([
-                "run",
-                "--host", "example.com",
-                "--username", "testuser",
-                "--config", "/path/to/config.ini"
-            ])
+            result = app.parse_args(["run"])
             
             # Verify function returned
             assert result is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,775 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import argparse
+from unittest.mock import Mock, patch
+from io import StringIO
+
+import pytest
+
+from itential_mcp import cli
+from itential_mcp.cli import Parser
+
+
+class TestParser:
+    """Test cases for the Parser class"""
+
+    def test_parser_inheritance(self):
+        """Test that Parser inherits from argparse.ArgumentParser"""
+        parser = Parser()
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_parser_initialization(self):
+        """Test Parser initialization with various parameters"""
+        # Basic initialization
+        parser = Parser()
+        assert parser is not None
+
+        # Initialization with parameters
+        parser = Parser(
+            prog="test-prog",
+            description="Test description",
+            add_help=False
+        )
+        assert parser.prog == "test-prog"
+        assert parser.description == "Test description"
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_app_help_basic(self, mock_stdout):
+        """Test basic print_app_help functionality"""
+        parser = Parser(
+            prog="test-prog",
+            description="Test CLI application"
+        )
+
+        # Add a basic argument
+        parser.add_argument("--config", help="Configuration file")
+
+        # Add subparsers
+        subparsers = parser.add_subparsers(dest="command")
+        subparsers.add_parser("run", description="Run the server")
+
+        parser.print_app_help()
+
+        output = mock_stdout.getvalue()
+        assert "Test CLI application" in output
+        assert "Usage:" in output
+        assert "test-prog <COMMAND> [OPTIONS]" in output
+        assert "Commands:" in output
+        assert "run" in output
+        assert "Run the server" in output
+        assert "Options:" in output
+        assert "--config" in output
+        assert "Configuration file" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_app_help_multiple_commands(self, mock_stdout):
+        """Test print_app_help with multiple commands"""
+        parser = Parser(prog="test-app", description="Multi-command app")
+
+        subparsers = parser.add_subparsers(dest="command")
+        subparsers.add_parser("start", description="Start the service")
+        subparsers.add_parser("stop", description="Stop the service")
+        subparsers.add_parser("status", description="Check service status")
+
+        parser.print_app_help()
+
+        output = mock_stdout.getvalue()
+        assert "start" in output and "Start the service" in output
+        assert "stop" in output and "Stop the service" in output
+        assert "status" in output and "Check service status" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_app_help_with_options(self, mock_stdout):
+        """Test print_app_help with various option types"""
+        parser = Parser(prog="test-app", description="Test app")
+
+        # Add different types of options
+        parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+        parser.add_argument("--config", help="Configuration file path")
+        parser.add_argument("--port", type=int, help="Port number")
+        parser.add_argument("--no-help-option", help=None)  # Test no help case
+
+        subparsers = parser.add_subparsers(dest="command")
+        subparsers.add_parser("test", description="Test command")
+
+        parser.print_app_help()
+
+        output = mock_stdout.getvalue()
+        assert "--verbose, -v" in output
+        assert "Verbose output" in output
+        assert "--config" in output
+        assert "--port" in output
+        assert "NO HELP AVAILABLE!!" in output  # For option without help
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_basic(self, mock_stdout):
+        """Test basic print_help functionality"""
+        parser = Parser(prog="test-prog", description="Test application")
+
+        # Add some arguments
+        parser.add_argument("--config", help="Configuration file")
+        parser.add_argument("--verbose", action="store_true", help="Verbose mode")
+
+        # Add an argument group
+        group = parser.add_argument_group("Server Options", "Server configuration")
+        group.add_argument("--host", help="Server host")
+        group.add_argument("--port", type=int, help="Server port")
+
+        parser.print_help()
+
+        output = mock_stdout.getvalue()
+        assert "Test application" in output
+        assert "Usage:" in output
+        assert "test-prog" in output
+        assert "Server Options" in output
+        assert "--host" in output
+        assert "--port" in output
+        assert "Options" in output
+        assert "--config" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_with_positional_args(self, mock_stdout):
+        """Test print_help with positional arguments"""
+        parser = Parser(prog="test-prog", description="Test app")
+
+        # Add positional arguments
+        parser.add_argument("command", help="Command to execute")
+        parser.add_argument("target", help="Target for the command")
+
+        # Add optional arguments
+        parser.add_argument("--force", action="store_true", help="Force execution")
+
+        parser.print_help()
+
+        output = mock_stdout.getvalue()
+        assert "<command> <target>" in output
+        assert "test-prog <command> <target> [OPTIONS]" in output
+
+    @patch('itential_mcp.terminal.getcols')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_long_options(self, mock_stdout, mock_getcols):
+        """Test print_help with long option names that require wrapping"""
+        mock_getcols.return_value = 40  # Short line width to force wrapping
+
+        parser = Parser(prog="test-prog", description="Test app")
+
+        # Add argument group with long option names
+        group = parser.add_argument_group("Long Options")
+        group.add_argument("--very-long-option-name", metavar="VALUE",
+                          help="This is a very long help string that should be wrapped")
+
+        parser.add_argument("--config", help="Short help")
+
+        parser.print_help()
+
+        output = mock_stdout.getvalue()
+        assert "very-long-option-name" in output
+        assert "This is a very long help string" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_with_metavar(self, mock_stdout):
+        """Test print_help with metavar options"""
+        parser = Parser(prog="test-prog", description="Test app")
+
+        group = parser.add_argument_group("Test Group")
+        group.add_argument("--file", metavar="PATH", help="File path")
+        group.add_argument("--count", metavar="N", help="Number of items")
+
+        parser.add_argument("--output", metavar="FILE", help="Output file")
+
+        parser.print_help()
+
+        output = mock_stdout.getvalue()
+        assert "--file PATH" in output
+        assert "--count N" in output
+        assert "--output FILE" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_multiple_option_strings_bug(self, mock_stdout):
+        """Test print_help with options that have multiple strings - demonstrates a bug with None metavar"""
+        parser = Parser(prog="test-prog", description="Test app")
+
+        # Add some required arguments to make the options group exist
+        parser.add_argument("--config", help="Config file")
+
+        group = parser.add_argument_group("Multi Options")
+        group.add_argument("--verbose", "-v", action="store_true", help="Verbose mode")  # metavar is None
+        group.add_argument("--output", "-o", metavar="FILE", help="Output file")
+
+        # This test demonstrates that the CLI code has a bug on line 94
+        # It tries to call .upper() on None when metavar is None for multiple option strings
+        with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'upper'"):
+            parser.print_help()
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_multiple_option_strings_with_metavar(self, mock_stdout):
+        """Test print_help with options that have multiple strings and metavar works correctly"""
+        parser = Parser(prog="test-prog", description="Test app")
+
+        # Add some required arguments to make the options group exist
+        parser.add_argument("--config", help="Config file")
+
+        group = parser.add_argument_group("Multi Options")
+        group.add_argument("--output", "-o", metavar="FILE", help="Output file")
+
+        parser.print_help()
+
+        output = mock_stdout.getvalue()
+        # Should contain the multiple option strings with metavar
+        assert "--output, -o FILE" in output or "-o, --output FILE" in output
+        assert "Output file" in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_no_options_group_error(self, mock_stdout):
+        """Test that print_help handles missing 'options' group gracefully"""
+        parser = Parser(prog="test-prog", description="Test app", add_help=False)
+
+        # Add only a custom group, no default 'options' group
+        group = parser.add_argument_group("Custom Group")
+        group.add_argument("--test", help="Test option")
+
+        # The print_help method will fail when there's no 'options' group
+        # because argparse creates 'optional arguments' not 'options'
+        with pytest.raises(KeyError):
+            parser.print_help()
+
+
+class TestGetArgumentsFromConfig:
+    """Test cases for _get_arguments_from_config function"""
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_basic(self, mock_fields):
+        """Test basic functionality of _get_arguments_from_config"""
+        # Mock a config field
+        mock_field = Mock()
+        mock_field.name = "server_host"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            "x-itential-mcp-arguments": ["--host"],
+            "x-itential-mcp-options": {"type": str}
+        }
+        mock_field.default.description = "Server host address"
+        mock_field.default.default = "localhost"
+
+        mock_fields.return_value = [mock_field]
+
+        # Clear the cache to ensure fresh data
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        assert len(result) == 1
+        assert result[0][0] == "server_host"
+        assert result[0][1] == ["--host"]
+        assert result[0][2]["dest"] == "server_host"
+        assert result[0][2]["help"] == "Server host address (default=localhost)"
+        assert result[0][2]["type"] is str
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_no_cli_enabled(self, mock_fields):
+        """Test _get_arguments_from_config with CLI disabled fields"""
+        mock_field = Mock()
+        mock_field.name = "internal_field"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": False
+        }
+
+        mock_fields.return_value = [mock_field]
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        assert len(result) == 0
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_no_schema_extra(self, mock_fields):
+        """Test _get_arguments_from_config with fields having no json_schema_extra"""
+        mock_field = Mock()
+        mock_field.name = "basic_field"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = None
+
+        mock_fields.return_value = [mock_field]
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        assert len(result) == 0
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_no_description(self, mock_fields):
+        """Test _get_arguments_from_config with fields having no description"""
+        mock_field = Mock()
+        mock_field.name = "no_desc_field"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            "x-itential-mcp-arguments": ["--no-desc"]
+        }
+        mock_field.default.description = None
+        mock_field.default.default = "default_value"
+
+        mock_fields.return_value = [mock_field]
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        assert len(result) == 1
+        assert result[0][2]["help"] == "NO HELP AVAILABLE!!"
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_multiple_fields(self, mock_fields):
+        """Test _get_arguments_from_config with multiple valid fields"""
+        # Create multiple mock fields
+        field1 = Mock()
+        field1.name = "server_port"
+        field1.default = Mock()
+        field1.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            "x-itential-mcp-arguments": ["--port", "-p"],
+            "x-itential-mcp-options": {"type": int}
+        }
+        field1.default.description = "Server port"
+        field1.default.default = 8080
+
+        field2 = Mock()
+        field2.name = "platform_username"
+        field2.default = Mock()
+        field2.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            "x-itential-mcp-arguments": ["--username"],
+            "x-itential-mcp-options": {"type": str, "required": True}
+        }
+        field2.default.description = "Platform username"
+        field2.default.default = None
+
+        field3 = Mock()
+        field3.name = "disabled_field"
+        field3.default = Mock()
+        field3.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": False
+        }
+
+        mock_fields.return_value = [field1, field2, field3]
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        assert len(result) == 2
+
+        # Check first field
+        assert result[0][0] == "server_port"
+        assert result[0][1] == ["--port", "-p"]
+        assert result[0][2]["type"] is int
+
+        # Check second field
+        assert result[1][0] == "platform_username"
+        assert result[1][1] == ["--username"]
+        assert result[1][2]["required"] is True
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_caching(self, mock_fields):
+        """Test that _get_arguments_from_config uses LRU caching"""
+        mock_field = Mock()
+        mock_field.name = "test_field"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            "x-itential-mcp-arguments": ["--test"]
+        }
+        mock_field.default.description = "Test field"
+        mock_field.default.default = "test"
+
+        mock_fields.return_value = [mock_field]
+        cli._get_arguments_from_config.cache_clear()
+
+        # Call multiple times
+        result1 = cli._get_arguments_from_config()
+        result2 = cli._get_arguments_from_config()
+
+        # Should only call fields() once due to caching
+        assert mock_fields.call_count == 1
+        assert result1 == result2
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_no_options(self, mock_fields):
+        """Test _get_arguments_from_config when x-itential-mcp-options is None"""
+        mock_field = Mock()
+        mock_field.name = "simple_field"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            "x-itential-mcp-arguments": ["--simple"],
+            "x-itential-mcp-options": None
+        }
+        mock_field.default.description = "Simple field"
+        mock_field.default.default = "simple"
+
+        mock_fields.return_value = [mock_field]
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        assert len(result) == 1
+        # Should only have dest and help, no additional options
+        expected_keys = {"dest", "help"}
+        assert set(result[0][2].keys()) == expected_keys
+
+
+class TestAddPlatformArguments:
+    """Test cases for add_platform_group function"""
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_add_platform_group_basic(self, mock_get_args):
+        """Test basic functionality of add_platform_group"""
+        # Mock config arguments
+        mock_get_args.return_value = [
+            ("platform_host", ["--platform-host"], {"dest": "platform_host", "help": "Platform host"}),
+            ("platform_port", ["--platform-port"], {"dest": "platform_port", "help": "Platform port"}),
+            ("server_host", ["--server-host"], {"dest": "server_host", "help": "Server host"}),
+        ]
+
+        # Create mock command parser
+        mock_cmd = Mock()
+        mock_group = Mock()
+        mock_cmd.add_argument_group.return_value = mock_group
+
+        cli.add_platform_group(mock_cmd)
+
+        # Verify argument group was created
+        mock_cmd.add_argument_group.assert_called_once_with(
+            "Itential Platform Options",
+            "Configuration options for connecting to Itential Platform API"
+        )
+
+        # Verify only platform arguments were added (2 calls for 2 platform args)
+        assert mock_group.add_argument.call_count == 2
+
+        # Check the calls
+        calls = mock_group.add_argument.call_args_list
+        assert calls[0][0] == ("--platform-host",)
+        assert calls[0][1] == {"dest": "platform_host", "help": "Platform host"}
+        assert calls[1][0] == ("--platform-port",)
+        assert calls[1][1] == {"dest": "platform_port", "help": "Platform port"}
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_add_platform_group_no_platform_args(self, mock_get_args):
+        """Test add_platform_group when no platform arguments are available"""
+        # Mock config with no platform arguments
+        mock_get_args.return_value = [
+            ("server_host", ["--server-host"], {"dest": "server_host", "help": "Server host"}),
+            ("other_option", ["--other"], {"dest": "other_option", "help": "Other option"}),
+        ]
+
+        mock_cmd = Mock()
+        mock_group = Mock()
+        mock_cmd.add_argument_group.return_value = mock_group
+
+        cli.add_platform_group(mock_cmd)
+
+        # Argument group should still be created
+        mock_cmd.add_argument_group.assert_called_once()
+
+        # But no arguments should be added
+        mock_group.add_argument.assert_not_called()
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_add_platform_group_multiple_platform_args(self, mock_get_args):
+        """Test add_platform_group with multiple platform arguments"""
+        mock_get_args.return_value = [
+            ("platform_host", ["--platform-host"], {"dest": "platform_host", "help": "Host"}),
+            ("platform_port", ["--platform-port"], {"dest": "platform_port", "help": "Port"}),
+            ("platform_username", ["--platform-user"], {"dest": "platform_username", "help": "Username"}),
+            ("platform_password", ["--platform-pass"], {"dest": "platform_password", "help": "Password"}),
+            ("server_host", ["--server-host"], {"dest": "server_host", "help": "Server host"}),
+        ]
+
+        mock_cmd = Mock()
+        mock_group = Mock()
+        mock_cmd.add_argument_group.return_value = mock_group
+
+        cli.add_platform_group(mock_cmd)
+
+        # Should add 4 platform arguments
+        assert mock_group.add_argument.call_count == 4
+
+
+class TestAddServerArguments:
+    """Test cases for add_server_group function"""
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_add_server_group_basic(self, mock_get_args):
+        """Test basic functionality of add_server_group"""
+        mock_get_args.return_value = [
+            ("server_host", ["--server-host"], {"dest": "server_host", "help": "Server host"}),
+            ("server_port", ["--server-port"], {"dest": "server_port", "help": "Server port"}),
+            ("platform_host", ["--platform-host"], {"dest": "platform_host", "help": "Platform host"}),
+        ]
+
+        mock_cmd = Mock()
+        mock_group = Mock()
+        mock_cmd.add_argument_group.return_value = mock_group
+
+        cli.add_server_group(mock_cmd)
+
+        # Verify argument group was created
+        mock_cmd.add_argument_group.assert_called_once_with(
+            "MCP Server Options",
+            "Configuration options for the MCP Server instance"
+        )
+
+        # Verify only server arguments were added
+        assert mock_group.add_argument.call_count == 2
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_add_server_group_no_server_args(self, mock_get_args):
+        """Test add_server_group when no server arguments are available"""
+        mock_get_args.return_value = [
+            ("platform_host", ["--platform-host"], {"dest": "platform_host", "help": "Platform host"}),
+            ("other_option", ["--other"], {"dest": "other_option", "help": "Other option"}),
+        ]
+
+        mock_cmd = Mock()
+        mock_group = Mock()
+        mock_cmd.add_argument_group.return_value = mock_group
+
+        cli.add_server_group(mock_cmd)
+
+        mock_cmd.add_argument_group.assert_called_once()
+        mock_group.add_argument.assert_not_called()
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_add_server_group_multiple_server_args(self, mock_get_args):
+        """Test add_server_group with multiple server arguments"""
+        mock_get_args.return_value = [
+            ("server_host", ["--host"], {"dest": "server_host", "help": "Host"}),
+            ("server_port", ["--port"], {"dest": "server_port", "help": "Port"}),
+            ("server_transport", ["--transport"], {"dest": "server_transport", "help": "Transport"}),
+            ("server_log_level", ["--log-level"], {"dest": "server_log_level", "help": "Log level"}),
+            ("platform_username", ["--username"], {"dest": "platform_username", "help": "Username"}),
+        ]
+
+        mock_cmd = Mock()
+        mock_group = Mock()
+        mock_cmd.add_argument_group.return_value = mock_group
+
+        cli.add_server_group(mock_cmd)
+
+        # Should add 4 server arguments
+        assert mock_group.add_argument.call_count == 4
+
+
+class TestModuleStructure:
+    """Test cases for overall module structure and imports"""
+
+    def test_module_imports(self):
+        """Test that all required modules are imported"""
+        assert hasattr(cli, 'argparse')
+        assert hasattr(cli, 'terminal')
+        assert hasattr(cli, 'config')
+
+    def test_module_functions_exist(self):
+        """Test that all expected functions exist"""
+        expected_functions = [
+            '_get_arguments_from_config',
+            'add_platform_group',
+            'add_server_group'
+        ]
+
+        for func_name in expected_functions:
+            assert hasattr(cli, func_name)
+            assert callable(getattr(cli, func_name))
+
+    def test_parser_class_exists(self):
+        """Test that Parser class exists and is properly defined"""
+        assert hasattr(cli, 'Parser')
+        assert issubclass(cli.Parser, argparse.ArgumentParser)
+
+    def test_typing_imports(self):
+        """Test that typing imports are available"""
+        assert hasattr(cli, 'Sequence')
+        assert hasattr(cli, 'Tuple')
+        assert hasattr(cli, 'Mapping')
+
+    def test_lru_cache_import(self):
+        """Test that lru_cache is imported"""
+        assert hasattr(cli, 'lru_cache')
+
+    def test_fields_import(self):
+        """Test that dataclasses.fields is imported"""
+        assert hasattr(cli, 'fields')
+
+
+class TestParserIntegration:
+    """Integration tests for Parser class"""
+
+    def test_parser_with_real_arguments(self):
+        """Test Parser with realistic argument setup"""
+        parser = Parser(
+            prog="itential-mcp",
+            description="Itential MCP Server CLI"
+        )
+
+        # Add global arguments
+        parser.add_argument("--config", help="Configuration file")
+        parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+
+        # Add subcommands
+        subparsers = parser.add_subparsers(dest="command")
+
+        run_parser = subparsers.add_parser("run", description="Run the MCP server")
+        run_parser.add_argument("--host", default="localhost", help="Server host")
+        run_parser.add_argument("--port", type=int, default=8080, help="Server port")
+
+        subparsers.add_parser("version", description="Show version info")
+
+        # Test that parser works correctly
+        args = parser.parse_args(["run", "--host", "example.com", "--port", "9000"])
+        assert args.command == "run"
+        assert args.host == "example.com"
+        assert args.port == 9000
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_parser_help_integration(self, mock_stdout):
+        """Test Parser help output integration"""
+        parser = Parser(
+            prog="itential-mcp",
+            description="Itential MCP Server"
+        )
+
+        parser.add_argument("--config", help="Config file")
+
+        # Add server arguments group
+        server_group = parser.add_argument_group(
+            "Server Options",
+            "Options for server configuration"
+        )
+        server_group.add_argument("--host", help="Server host")
+        server_group.add_argument("--port", type=int, help="Server port")
+
+        # Add subcommands
+        subparsers = parser.add_subparsers(dest="command")
+        subparsers.add_parser("run", description="Run server")
+        subparsers.add_parser("stop", description="Stop server")
+
+        # Test app help
+        parser.print_app_help()
+        app_output = mock_stdout.getvalue()
+
+        assert "Itential MCP Server" in app_output
+        assert "run" in app_output and "Run server" in app_output
+        assert "stop" in app_output and "Stop server" in app_output
+        assert "--config" in app_output
+
+        # Clear and test regular help
+        mock_stdout.truncate(0)
+        mock_stdout.seek(0)
+
+        parser.print_help()
+        help_output = mock_stdout.getvalue()
+
+        assert "Server Options" in help_output
+        assert "--host" in help_output
+        assert "--port" in help_output
+
+    @patch('itential_mcp.cli._get_arguments_from_config')
+    def test_argument_functions_integration(self, mock_get_args):
+        """Test integration of add_platform_group and add_server_group"""
+        mock_get_args.return_value = [
+            ("platform_host", ["--platform-host"], {"dest": "platform_host", "help": "Platform host"}),
+            ("platform_port", ["--platform-port"], {"dest": "platform_port", "type": int, "help": "Platform port"}),
+            ("server_host", ["--server-host"], {"dest": "server_host", "help": "Server host"}),
+            ("server_transport", ["--transport"], {"dest": "server_transport", "help": "Transport protocol"}),
+        ]
+
+        parser = Parser(prog="test-app")
+
+        # Add platform arguments
+        cli.add_platform_group(parser)
+
+        # Add server arguments
+        cli.add_server_group(parser)
+
+        # Test parsing
+        args = parser.parse_args([
+            "--platform-host", "platform.example.com",
+            "--platform-port", "443",
+            "--server-host", "0.0.0.0",
+            "--transport", "http"
+        ])
+
+        assert args.platform_host == "platform.example.com"
+        assert args.platform_port == 443
+        assert args.server_host == "0.0.0.0"
+        assert args.server_transport == "http"
+
+
+class TestErrorHandling:
+    """Test error handling and edge cases"""
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_app_help_no_subparsers(self, mock_stdout):
+        """Test print_app_help behavior when no subparsers are defined"""
+        parser = Parser(prog="test-app", description="Test app")
+        parser.add_argument("--config", help="Config file")
+
+        # This should handle the case where there are no subparsers
+        with pytest.raises(AttributeError):
+            parser.print_app_help()
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_print_help_empty_parser(self, mock_stdout):
+        """Test print_help with minimal parser setup"""
+        parser = Parser(prog="minimal", description="Minimal parser", add_help=False)
+
+        # Should handle case with no arguments or groups
+        # This will fail because there's no 'options' group
+        with pytest.raises(KeyError):
+            parser.print_help()
+
+    @patch('itential_mcp.cli.fields')
+    def test_get_arguments_from_config_exception_handling(self, mock_fields):
+        """Test _get_arguments_from_config handles malformed field data"""
+        # Mock a field with missing attributes
+        mock_field = Mock()
+        mock_field.name = "broken_field"
+        mock_field.default = Mock()
+        mock_field.default.json_schema_extra = {
+            "x-itential-mcp-cli-enabled": True,
+            # Missing x-itential-mcp-arguments
+        }
+        mock_field.default.description = "Broken field"
+        mock_field.default.default = "default"
+
+        mock_fields.return_value = [mock_field]
+        cli._get_arguments_from_config.cache_clear()
+
+        result = cli._get_arguments_from_config()
+
+        # Should handle gracefully and include the field
+        assert len(result) == 1
+        assert result[0][1] is None  # No arguments defined
+
+    def test_parser_methods_file_parameter(self):
+        """Test that parser methods accept file parameter"""
+        parser = Parser(prog="test")
+
+        # Methods should accept file parameter without error
+        import io
+        test_file = io.StringIO()
+
+        # These should not raise errors
+        try:
+            parser.print_app_help(file=test_file)
+        except AttributeError:
+            # Expected due to no subparsers
+            pass
+
+        try:
+            parser.print_help(file=test_file)
+        except KeyError:
+            # Expected due to no options group
+            pass

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,169 +1,583 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import Mock, patch
+import inspect
+import asyncio
+from unittest.mock import Mock
 
-from itential_mcp import commands, server
+import pytest
 
-
-def test_run_function_exists():
-    """Test that the run function exists and is callable."""
-    assert hasattr(commands, 'run')
-    assert callable(commands.run)
+from itential_mcp import commands, server, metadata, toolutils, runner
 
 
-def test_run_returns_correct_tuple():
-    """Test that run function returns the expected tuple structure."""
-    args = Mock()
-    result = commands.run(args)
-    
-    # Should return a tuple with server.run function and two None values
-    assert isinstance(result, tuple)
-    assert len(result) == 3
-    assert result[0] == server.run
-    assert result[1] is None
-    assert result[2] is None
+class TestRunCommand:
+    """Test cases for the run command function"""
+
+    def test_run_function_exists(self):
+        """Test that the run function exists and is callable"""
+        assert hasattr(commands, 'run')
+        assert callable(commands.run)
+
+    def test_run_returns_correct_tuple(self):
+        """Test that run function returns the expected tuple structure"""
+        args = Mock()
+        result = commands.run(args)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == server.run
+        assert result[1] is None
+        assert result[2] is None
+
+    def test_run_with_various_args(self):
+        """Test run function with different argument types"""
+        test_cases = [
+            None,
+            {},
+            "test",
+            [],
+            Mock(),
+            object(),
+            42,
+            True
+        ]
+
+        for args in test_cases:
+            result = commands.run(args)
+            assert result == (server.run, None, None)
+
+    def test_run_function_signature(self):
+        """Test that run function has correct signature"""
+        sig = inspect.signature(commands.run)
+        params = list(sig.parameters.keys())
+
+        assert len(params) == 1
+        assert params[0] == 'args'
+
+        # Check parameter type annotation
+        param = sig.parameters['args']
+        assert param.annotation == commands.Any
+
+    def test_run_function_docstring(self):
+        """Test that run function has proper docstring"""
+        assert commands.run.__doc__ is not None
+        assert "Implement the `itential-mcp run` command" in commands.run.__doc__
+        assert "server" in commands.run.__doc__
+
+    def test_run_returns_coroutine_function(self):
+        """Test that the returned function is a coroutine"""
+        args = Mock()
+        result = commands.run(args)
+
+        # The first element should be a coroutine function
+        assert asyncio.iscoroutinefunction(result[0])
+
+    def test_run_function_is_not_async(self):
+        """Test that run command function itself is not async"""
+        assert not asyncio.iscoroutinefunction(commands.run)
+
+    def test_run_return_type_annotation(self):
+        """Test that run function has correct return type annotation"""
+        sig = inspect.signature(commands.run)
+        return_annotation = sig.return_annotation
+
+        # Should be Tuple[Coroutine, Sequence, Mapping]
+        assert return_annotation is not None
 
 
-def test_run_with_various_args():
-    """Test run function with different argument types."""
-    # Test with None
-    result = commands.run(None)
-    assert result == (server.run, None, None)
-    
-    # Test with empty dict
-    result = commands.run({})
-    assert result == (server.run, None, None)
-    
-    # Test with string
-    result = commands.run("test")
-    assert result == (server.run, None, None)
-    
-    # Test with mock object
-    mock_args = Mock()
-    mock_args.transport = "stdio"
-    mock_args.host = "localhost"
-    result = commands.run(mock_args)
-    assert result == (server.run, None, None)
+class TestVersionCommand:
+    """Test cases for the version command function"""
+
+    def test_version_function_exists(self):
+        """Test that the version function exists and is callable"""
+        assert hasattr(commands, 'version')
+        assert callable(commands.version)
+
+    def test_version_returns_correct_tuple(self):
+        """Test that version function returns the expected tuple structure"""
+        args = Mock()
+        result = commands.version(args)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == metadata.display_version
+        assert result[1] is None
+        assert result[2] is None
+
+    def test_version_with_various_args(self):
+        """Test version function with different argument types"""
+        test_cases = [
+            None,
+            {},
+            "test",
+            [],
+            Mock(),
+            object(),
+            42,
+            True
+        ]
+
+        for args in test_cases:
+            result = commands.version(args)
+            assert result == (metadata.display_version, None, None)
+
+    def test_version_function_signature(self):
+        """Test that version function has correct signature"""
+        sig = inspect.signature(commands.version)
+        params = list(sig.parameters.keys())
+
+        assert len(params) == 1
+        assert params[0] == 'args'
+
+        # Check parameter type annotation
+        param = sig.parameters['args']
+        assert param.annotation == commands.Any
+
+    def test_version_function_docstring(self):
+        """Test that version function has proper docstring"""
+        assert commands.version.__doc__ is not None
+        # Note: The docstring currently has a copy-paste error mentioning "run" command
+        assert "itential-mcp" in commands.version.__doc__
+
+    def test_version_returns_coroutine_function(self):
+        """Test that the returned function is a coroutine"""
+        args = Mock()
+        result = commands.version(args)
+
+        # The first element should be a coroutine function
+        assert asyncio.iscoroutinefunction(result[0])
+
+    def test_version_function_is_not_async(self):
+        """Test that version command function itself is not async"""
+        assert not asyncio.iscoroutinefunction(commands.version)
 
 
-def test_run_function_signature():
-    """Test that run function has correct signature."""
-    import inspect
-    
-    sig = inspect.signature(commands.run)
-    params = list(sig.parameters.keys())
-    
-    # Should have exactly one parameter named 'args'
-    assert len(params) == 1
-    assert params[0] == 'args'
+class TestToolsCommand:
+    """Test cases for the tools command function"""
+
+    def test_tools_function_exists(self):
+        """Test that the tools function exists and is callable"""
+        assert hasattr(commands, 'tools')
+        assert callable(commands.tools)
+
+    def test_tools_returns_correct_tuple(self):
+        """Test that tools function returns the expected tuple structure"""
+        args = Mock()
+        result = commands.tools(args)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == toolutils.display_tools
+        assert result[1] is None
+        assert result[2] is None
+
+    def test_tools_with_various_args(self):
+        """Test tools function with different argument types"""
+        test_cases = [
+            None,
+            {},
+            "test",
+            [],
+            Mock(),
+            object(),
+            42,
+            True
+        ]
+
+        for args in test_cases:
+            result = commands.tools(args)
+            assert result == (toolutils.display_tools, None, None)
+
+    def test_tools_function_signature(self):
+        """Test that tools function has correct signature"""
+        sig = inspect.signature(commands.tools)
+        params = list(sig.parameters.keys())
+
+        assert len(params) == 1
+        assert params[0] == 'args'
+
+        # Check parameter type annotation
+        param = sig.parameters['args']
+        assert param.annotation == commands.Any
+
+    def test_tools_function_docstring(self):
+        """Test that tools function has proper docstring"""
+        assert commands.tools.__doc__ is not None
+        assert "Implement the `itential-mcp tools` command" in commands.tools.__doc__
+        assert "display the list of all avaiable tools" in commands.tools.__doc__
+
+    def test_tools_returns_coroutine_function(self):
+        """Test that the returned function is a coroutine"""
+        args = Mock()
+        result = commands.tools(args)
+
+        # The first element should be a coroutine function
+        assert asyncio.iscoroutinefunction(result[0])
+
+    def test_tools_function_is_not_async(self):
+        """Test that tools command function itself is not async"""
+        assert not asyncio.iscoroutinefunction(commands.tools)
 
 
-def test_run_function_docstring():
-    """Test that run function has proper docstring."""
-    assert commands.run.__doc__ is not None
-    assert "Implements the `itential-mcp run` command" in commands.run.__doc__
-    assert "`server` module" in commands.run.__doc__
+class TestTagsCommand:
+    """Test cases for the tags command function"""
+
+    def test_tags_function_exists(self):
+        """Test that the tags function exists and is callable"""
+        assert hasattr(commands, 'tags')
+        assert callable(commands.tags)
+
+    def test_tags_returns_correct_tuple(self):
+        """Test that tags function returns the expected tuple structure"""
+        args = Mock()
+        result = commands.tags(args)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == toolutils.display_tags
+        assert result[1] is None
+        assert result[2] is None
+
+    def test_tags_with_various_args(self):
+        """Test tags function with different argument types"""
+        test_cases = [
+            None,
+            {},
+            "test",
+            [],
+            Mock(),
+            object(),
+            42,
+            True
+        ]
+
+        for args in test_cases:
+            result = commands.tags(args)
+            assert result == (toolutils.display_tags, None, None)
+
+    def test_tags_function_signature(self):
+        """Test that tags function has correct signature"""
+        sig = inspect.signature(commands.tags)
+        params = list(sig.parameters.keys())
+
+        assert len(params) == 1
+        assert params[0] == 'args'
+
+        # Check parameter type annotation
+        param = sig.parameters['args']
+        assert param.annotation == commands.Any
+
+    def test_tags_function_docstring(self):
+        """Test that tags function has proper docstring"""
+        assert commands.tags.__doc__ is not None
+        assert "Implement the `itential-mcp tags` command" in commands.tags.__doc__
+        assert "display the list of all avaiable tags" in commands.tags.__doc__
+
+    def test_tags_returns_coroutine_function(self):
+        """Test that the returned function is a coroutine"""
+        args = Mock()
+        result = commands.tags(args)
+
+        # The first element should be a coroutine function
+        assert asyncio.iscoroutinefunction(result[0])
+
+    def test_tags_function_is_not_async(self):
+        """Test that tags command function itself is not async"""
+        assert not asyncio.iscoroutinefunction(commands.tags)
 
 
-@patch('itential_mcp.server.run')
-def test_run_returns_server_run_function(mock_server_run):
-    """Test that the returned function is indeed server.run."""
-    args = Mock()
-    result = commands.run(args)
-    
-    # The first element should be the server.run function
-    assert result[0] == server.run
-    
-    # Verify it's the actual function we expect
-    assert result[0] == mock_server_run
+class TestCallCommand:
+    """Test cases for the call command function"""
+
+    def test_call_function_exists(self):
+        """Test that the call function exists and is callable"""
+        assert hasattr(commands, 'call')
+        assert callable(commands.call)
+
+    def test_call_returns_correct_tuple_structure(self):
+        """Test that call function returns the expected tuple structure"""
+        args = Mock()
+        args.tool = "test_tool"
+        args.params = '{"key": "value"}'
+
+        result = commands.call(args)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert result[0] == runner.run
+        assert result[1] == (args.tool, args.params)
+        assert result[2] is None
+
+    def test_call_with_tool_and_params(self):
+        """Test call function with tool name and parameters"""
+        args = Mock()
+        args.tool = "get_user"
+        args.params = '{"user_id": "12345"}'
+
+        result = commands.call(args)
+
+        assert result[0] == runner.run
+        assert result[1] == ("get_user", '{"user_id": "12345"}')
+        assert result[2] is None
+
+    def test_call_with_tool_no_params(self):
+        """Test call function with tool name but no parameters"""
+        args = Mock()
+        args.tool = "list_users"
+        args.params = None
+
+        result = commands.call(args)
+
+        assert result[0] == runner.run
+        assert result[1] == ("list_users", None)
+        assert result[2] is None
+
+    def test_call_with_different_tool_names(self):
+        """Test call function with various tool names"""
+        test_cases = [
+            ("simple_tool", None),
+            ("complex-tool-name", '{"param": "value"}'),
+            ("tool_with_underscores", '{}'),
+            ("Tool123", '{"num": 123}'),
+            ("", ""),
+        ]
+
+        for tool_name, params in test_cases:
+            args = Mock()
+            args.tool = tool_name
+            args.params = params
+
+            result = commands.call(args)
+
+            assert result[0] == runner.run
+            assert result[1] == (tool_name, params)
+            assert result[2] is None
+
+    def test_call_function_signature(self):
+        """Test that call function has correct signature"""
+        sig = inspect.signature(commands.call)
+        params = list(sig.parameters.keys())
+
+        assert len(params) == 1
+        assert params[0] == 'args'
+
+        # Check parameter type annotation
+        param = sig.parameters['args']
+        assert param.annotation == commands.Any
+
+    def test_call_function_docstring(self):
+        """Test that call function has proper docstring"""
+        assert commands.call.__doc__ is not None
+        assert "Implement the `itential-mcp call` command" in commands.call.__doc__
+        assert "invoke a tool" in commands.call.__doc__
+
+    def test_call_returns_coroutine_function(self):
+        """Test that the returned function is a coroutine"""
+        args = Mock()
+        args.tool = "test_tool"
+        args.params = None
+
+        result = commands.call(args)
+
+        # The first element should be a coroutine function
+        assert asyncio.iscoroutinefunction(result[0])
+
+    def test_call_function_is_not_async(self):
+        """Test that call command function itself is not async"""
+        assert not asyncio.iscoroutinefunction(commands.call)
+
+    def test_call_args_attribute_access(self):
+        """Test that call function properly accesses args attributes"""
+        # Test with realistic argparse.Namespace-like object
+        class MockArgs:
+            def __init__(self, tool, params):
+                self.tool = tool
+                self.params = params
+
+        args = MockArgs("my_tool", '{"test": true}')
+        result = commands.call(args)
+
+        assert result[1] == ("my_tool", '{"test": true}')
 
 
-def test_module_imports():
-    """Test that the module imports are correct."""
-    # Test that server is imported correctly
-    assert hasattr(commands, 'server')
-    assert commands.server == server
+class TestModuleStructure:
+    """Test cases for overall module structure and imports"""
 
+    def test_module_imports(self):
+        """Test that all required modules are imported"""
+        assert hasattr(commands, 'server')
+        assert hasattr(commands, 'metadata')
+        assert hasattr(commands, 'toolutils')
+        assert hasattr(commands, 'runner')
 
-def test_run_function_is_not_async():
-    """Test that run function is not async."""
-    import asyncio
-    
-    assert not asyncio.iscoroutinefunction(commands.run)
+        assert commands.server == server
+        assert commands.metadata == metadata
+        assert commands.toolutils == toolutils
+        assert commands.runner == runner
 
+    def test_module_functions_exist(self):
+        """Test that all expected command functions exist"""
+        expected_functions = ['run', 'version', 'tools', 'tags', 'call']
 
-def test_run_function_return_value_immutable():
-    """Test that the return value structure is consistent."""
-    args1 = Mock()
-    args2 = Mock()
-    
-    result1 = commands.run(args1)
-    result2 = commands.run(args2)
-    
-    # Both calls should return the same structure
-    assert result1 == result2
-    assert result1 is not result2  # Different tuple instances
-    assert result1[0] is result2[0]  # Same function reference
+        for func_name in expected_functions:
+            assert hasattr(commands, func_name)
+            assert callable(getattr(commands, func_name))
 
+    def test_module_typing_imports(self):
+        """Test that typing imports are available"""
+        # These should be imported from typing module
+        assert hasattr(commands, 'Any')
+        assert hasattr(commands, 'Coroutine')
+        assert hasattr(commands, 'Sequence')
+        assert hasattr(commands, 'Mapping')
+        assert hasattr(commands, 'Tuple')
 
-def test_commands_module_structure():
-    """Test the overall module structure."""
-    # Check that only expected functions/attributes are present
-    expected_attrs = ['run', 'server']
-    
-    # Get all public attributes (not starting with _)
-    public_attrs = [attr for attr in dir(commands) if not attr.startswith('_')]
-    
-    # Should contain at least our expected attributes
-    for attr in expected_attrs:
-        assert attr in public_attrs
+    def test_all_functions_have_consistent_signature(self):
+        """Test that all command functions have the same signature pattern"""
+        functions = [commands.run, commands.version, commands.tools, commands.tags, commands.call]
+
+        for func in functions:
+            sig = inspect.signature(func)
+            params = list(sig.parameters.keys())
+
+            # All should have exactly one parameter named 'args'
+            assert len(params) == 1
+            assert params[0] == 'args'
+
+            # All should have Any type annotation for args parameter
+            param = sig.parameters['args']
+            assert param.annotation == commands.Any
+
+    def test_all_functions_return_tuple(self):
+        """Test that all command functions return tuples"""
+        functions = [commands.run, commands.version, commands.tools, commands.tags, commands.call]
+        args = Mock()
+        args.tool = "test"
+        args.params = None
+
+        for func in functions:
+            result = func(args)
+            assert isinstance(result, tuple)
+            assert len(result) == 3
+
+    def test_functions_are_not_coroutines(self):
+        """Test that command functions themselves are not coroutines"""
+        functions = [commands.run, commands.version, commands.tools, commands.tags, commands.call]
+
+        for func in functions:
+            assert not asyncio.iscoroutinefunction(func)
+
+    def test_returned_functions_are_coroutines(self):
+        """Test that all command functions return coroutine functions as first element"""
+        args = Mock()
+        args.tool = "test"
+        args.params = None
+
+        functions_and_results = [
+            (commands.run, args),
+            (commands.version, args),
+            (commands.tools, args),
+            (commands.tags, args),
+            (commands.call, args),
+        ]
+
+        for func, test_args in functions_and_results:
+            result = func(test_args)
+            assert asyncio.iscoroutinefunction(result[0])
 
 
 class TestCommandsIntegration:
-    """Integration tests for the commands module."""
-    
+    """Integration tests for the commands module"""
+
     def test_run_with_realistic_args(self):
-        """Test run with realistic argument structure."""
-        # Simulate argparse.Namespace-like object
+        """Test run with realistic argument structure"""
         class MockArgs:
             def __init__(self):
                 self.transport = "stdio"
                 self.host = "localhost"
                 self.port = 8000
                 self.log_level = "INFO"
-        
+
         args = MockArgs()
         result = commands.run(args)
-        
+
         assert result[0] == server.run
         assert result[1] is None
         assert result[2] is None
-    
-    def test_run_function_can_be_called_multiple_times(self):
-        """Test that run function can be called multiple times safely."""
+
+    def test_call_with_realistic_args(self):
+        """Test call with realistic argument structure"""
+        class MockArgs:
+            def __init__(self):
+                self.tool = "get_platform_info"
+                self.params = '{"include_version": true, "format": "json"}'
+
+        args = MockArgs()
+        result = commands.call(args)
+
+        assert result[0] == runner.run
+        assert result[1] == ("get_platform_info", '{"include_version": true, "format": "json"}')
+        assert result[2] is None
+
+    def test_all_commands_can_be_called_multiple_times(self):
+        """Test that all command functions can be called multiple times safely"""
         args = Mock()
-        
-        # Call multiple times
-        results = [commands.run(args) for _ in range(5)]
-        
-        # All results should be identical
-        for result in results:
-            assert result == (server.run, None, None)
-    
-    def test_run_with_edge_case_args(self):
-        """Test run with edge case argument values."""
-        edge_cases = [
-            None,
-            0,
-            "",
-            [],
-            {},
-            False,
-            True,
-            object(),
-        ]
-        
+        args.tool = "test_tool"
+        args.params = "{}"
+
+        functions = [commands.run, commands.version, commands.tools, commands.tags, commands.call]
+
+        for func in functions:
+            # Call multiple times
+            results = [func(args) for _ in range(3)]
+
+            # All results should have the same first element (function reference)
+            first_func = results[0][0]
+            for result in results[1:]:
+                assert result[0] == first_func
+
+    def test_command_function_consistency(self):
+        """Test that command functions are consistent in behavior"""
+        args = Mock()
+        args.tool = "test"
+        args.params = None
+
+        # Test that calling functions multiple times returns same structure
+        for _ in range(5):
+            run_result = commands.run(args)
+            version_result = commands.version(args)
+            tools_result = commands.tools(args)
+            tags_result = commands.tags(args)
+            call_result = commands.call(args)
+
+            # All should return 3-element tuples
+            for result in [run_result, version_result, tools_result, tags_result, call_result]:
+                assert len(result) == 3
+                assert callable(result[0])
+
+    def test_edge_case_arguments(self):
+        """Test all commands with edge case arguments"""
+        edge_cases = [None, 0, "", [], {}, False, True, object()]
+
+        # These functions don't access args attributes
+        simple_functions = [commands.run, commands.version, commands.tools, commands.tags]
+
         for args in edge_cases:
-            result = commands.run(args)
-            assert result == (server.run, None, None)
+            for func in simple_functions:
+                result = func(args)
+                assert isinstance(result, tuple)
+                assert len(result) == 3
+
+    def test_call_command_with_missing_attributes(self):
+        """Test call command behavior when args lacks expected attributes"""
+        # Test with object that doesn't have tool/params attributes
+        with pytest.raises(AttributeError):
+            commands.call(object())
+
+        # Test with object that has only tool attribute
+        class PartialArgs:
+            def __init__(self):
+                self.tool = "test_tool"
+
+        with pytest.raises(AttributeError):
+            commands.call(PartialArgs())

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,598 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from io import StringIO
+
+from itential_mcp import runner
+
+
+class TestRun:
+    """Test cases for the run function"""
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_basic_tool_no_params(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test running a tool without parameters"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {
+            "properties": {"param1": {"type": "string"}},
+            "required": []
+        }
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock tool execution response
+        mock_result_content = MagicMock()
+        mock_result_content.text = json.dumps({"result": "success"})
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute
+        await runner.run("test_tool")
+        
+        # Verify
+        mock_config_get.assert_called_once()
+        mock_server_new.assert_called_once_with(mock_config)
+        mock_client.ping.assert_called_once()
+        mock_client.list_tools_mcp.assert_called_once()
+        mock_client.call_tool.assert_called_once_with("test_tool", arguments=None)
+        
+        # Check stdout output
+        output = mock_stdout.getvalue()
+        assert '"result": "success"' in output
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_tool_with_params(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test running a tool with parameters"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {
+            "properties": {
+                "param1": {"type": "string"},
+                "param2": {"type": "integer"}
+            },
+            "required": ["param1"]
+        }
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock tool execution response
+        mock_result_content = MagicMock()
+        mock_result_content.text = json.dumps({"result": "success", "param1_value": "test"})
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute with parameters
+        params_json = '{"param1": "test", "param2": 42}'
+        await runner.run("test_tool", params_json)
+        
+        # Verify
+        expected_arguments = {"param1": "test", "param2": 42}
+        mock_client.call_tool.assert_called_once_with("test_tool", arguments=expected_arguments)
+        
+        # Check stdout output
+        output = mock_stdout.getvalue()
+        assert '"result": "success"' in output
+        assert '"param1_value": "test"' in output
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_server_ping_failure(self, mock_config_get, mock_server_new, mock_client_class):
+        """Test failure when server ping fails"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = False
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute and verify exception
+        with pytest.raises(ValueError, match="ERROR: cannot reach the server"):
+            await runner.run("test_tool")
+        
+        mock_client.ping.assert_called_once()
+        # Should not proceed to list tools
+        mock_client.list_tools_mcp.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_invalid_tool(self, mock_config_get, mock_server_new, mock_client_class):
+        """Test running an invalid/non-existent tool"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response with different tool
+        mock_tool = MagicMock()
+        mock_tool.name = "other_tool"
+        mock_tool.inputSchema = {"properties": {}, "required": []}
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute and verify exception
+        with pytest.raises(ValueError, match="invalid tool: nonexistent_tool"):
+            await runner.run("nonexistent_tool")
+        
+        mock_client.list_tools_mcp.assert_called_once()
+        # Should not proceed to call tool
+        mock_client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_missing_required_params(self, mock_config_get, mock_server_new, mock_client_class):
+        """Test running a tool with missing required parameters"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response with required parameters
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {
+            "properties": {
+                "required_param": {"type": "string"},
+                "optional_param": {"type": "string"}
+            },
+            "required": ["required_param"]
+        }
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute without required parameter and verify exception
+        with pytest.raises(ValueError, match="missing required property: required_param"):
+            await runner.run("test_tool")
+        
+        # Execute with incomplete parameters and verify exception
+        params_json = '{"optional_param": "test"}'
+        with pytest.raises(ValueError, match="missing required property: required_param"):
+            await runner.run("test_tool", params_json)
+        
+        # Should not proceed to call tool
+        mock_client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_invalid_params(self, mock_config_get, mock_server_new, mock_client_class):
+        """Test running a tool with invalid parameters"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {
+            "properties": {
+                "valid_param": {"type": "string"}
+            },
+            "required": []
+        }
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute with invalid parameter and verify exception
+        params_json = '{"invalid_param": "test"}'
+        with pytest.raises(ValueError, match="invalid argument: invalid_param"):
+            await runner.run("test_tool", params_json)
+        
+        # Should not proceed to call tool
+        mock_client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_tool_no_required_params(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test running a tool that has no required parameters in schema"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response with no required field (None)
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {
+            "properties": {"optional_param": {"type": "string"}},
+            "required": None  # No required parameters
+        }
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock tool execution response
+        mock_result_content = MagicMock()
+        mock_result_content.text = json.dumps({"result": "success"})
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute
+        await runner.run("test_tool")
+        
+        # Verify
+        mock_client.call_tool.assert_called_once_with("test_tool", arguments=None)
+        
+        # Check stdout output
+        output = mock_stdout.getvalue()
+        assert '"result": "success"' in output
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_multiple_tools_available(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test running a specific tool when multiple tools are available"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock multiple tools
+        mock_tool1 = MagicMock()
+        mock_tool1.name = "tool1"
+        mock_tool1.inputSchema = {"properties": {}, "required": []}
+        
+        mock_tool2 = MagicMock()
+        mock_tool2.name = "tool2"
+        mock_tool2.inputSchema = {"properties": {"param": {"type": "string"}}, "required": []}
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool1, mock_tool2]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock tool execution response
+        mock_result_content = MagicMock()
+        mock_result_content.text = json.dumps({"tool": "tool2", "result": "executed"})
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute tool2
+        await runner.run("tool2")
+        
+        # Verify correct tool was called
+        mock_client.call_tool.assert_called_once_with("tool2", arguments=None)
+        
+        # Check stdout output
+        output = mock_stdout.getvalue()
+        assert '"tool": "tool2"' in output
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_invalid_json_params(self, mock_config_get, mock_server_new, mock_client_class):
+        """Test running a tool with invalid JSON parameters"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {"properties": {}, "required": []}
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute with invalid JSON and verify exception
+        invalid_json = '{"param": invalid}'
+        with pytest.raises(json.JSONDecodeError):
+            await runner.run("test_tool", invalid_json)
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_complex_result_formatting(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test that complex results are properly formatted in JSON output"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {"properties": {}, "required": []}
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock complex tool execution response
+        complex_result = {
+            "result": "success",
+            "data": {
+                "items": [{"id": 1, "name": "item1"}, {"id": 2, "name": "item2"}],
+                "metadata": {
+                    "total": 2,
+                    "page": 1
+                }
+            }
+        }
+        mock_result_content = MagicMock()
+        mock_result_content.text = json.dumps(complex_result)
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute
+        await runner.run("test_tool")
+        
+        # Verify formatted output
+        output = mock_stdout.getvalue()
+        assert '"result": "success"' in output
+        assert '"total": 2' in output
+        assert '"name": "item1"' in output
+        # Should have proper indentation (4 spaces)
+        assert '    "result": "success"' in output
+
+
+class TestRunEdgeCases:
+    """Test edge cases and error conditions"""
+
+    @pytest.mark.asyncio
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_empty_tool_list(self, mock_config_get, mock_server_new, mock_client_class):
+        """Test behavior when no tools are available"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock empty tool list response
+        mock_list_response = MagicMock()
+        mock_list_response.tools = []
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute and verify exception
+        with pytest.raises(ValueError, match="invalid tool: any_tool"):
+            await runner.run("any_tool")
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_empty_params_string(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test running a tool with empty parameters string"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {"properties": {}, "required": []}
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock tool execution response
+        mock_result_content = MagicMock()
+        mock_result_content.text = json.dumps({"result": "success"})
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute with empty string for params
+        await runner.run("test_tool", "")
+        
+        # Should still work and pass None as arguments
+        mock_client.call_tool.assert_called_once_with("test_tool", arguments=None)
+
+
+class TestRunIntegration:
+    """Integration-style tests for the run function"""
+
+    @pytest.mark.asyncio
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('itential_mcp.runner.Client')
+    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.config.get')
+    async def test_run_full_workflow(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+        """Test the complete workflow from start to finish"""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+        
+        mock_server = MagicMock()
+        mock_server_new.return_value = mock_server
+        
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+        
+        # Mock realistic tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "get_user_info"
+        mock_tool.inputSchema = {
+            "properties": {
+                "user_id": {"type": "string", "description": "User ID to retrieve"},
+                "include_details": {"type": "boolean", "description": "Include detailed info"}
+            },
+            "required": ["user_id"]
+        }
+        
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+        
+        # Mock realistic tool execution response
+        mock_result_content = MagicMock()
+        result_data = {
+            "user": {
+                "id": "12345",
+                "name": "John Doe",
+                "email": "john@example.com",
+                "details": {
+                    "role": "admin",
+                    "last_login": "2024-01-15T10:30:00Z"
+                }
+            },
+            "status": "success"
+        }
+        mock_result_content.text = json.dumps(result_data)
+        mock_client.call_tool.return_value = [mock_result_content]
+        
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+        
+        # Execute complete workflow
+        params = '{"user_id": "12345", "include_details": true}'
+        await runner.run("get_user_info", params)
+        
+        # Verify complete flow
+        mock_config_get.assert_called_once()
+        mock_server_new.assert_called_once_with(mock_config)
+        mock_client.ping.assert_called_once()
+        mock_client.list_tools_mcp.assert_called_once()
+        
+        expected_args = {"user_id": "12345", "include_details": True}
+        mock_client.call_tool.assert_called_once_with("get_user_info", arguments=expected_args)
+        
+        # Verify output formatting
+        output = mock_stdout.getvalue()
+        assert '"user"' in output
+        assert '"name": "John Doe"' in output
+        assert '"status": "success"' in output
+        assert '"role": "admin"' in output

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,7 @@
 
 import sys
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock, call
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from itential_mcp import server
 from itential_mcp.config import Config
@@ -103,10 +103,9 @@ class TestRun:
     """Test the run() function for server execution"""
 
     @pytest.mark.asyncio
-    @patch('itential_mcp.server.toolutils.itertools')
     @patch('itential_mcp.server.new')
     @patch('itential_mcp.server.config.get')
-    async def test_run_stdio_transport_success(self, mock_config_get, mock_new, mock_itertools):
+    async def test_run_stdio_transport_success(self, mock_config_get, mock_new):
         """Test successful server run with stdio transport"""
         # Setup mocks
         mock_config = MagicMock()
@@ -117,27 +116,12 @@ class TestRun:
         mock_mcp.run_async = AsyncMock()
         mock_new.return_value = mock_mcp
 
-        mock_func1 = MagicMock()
-        mock_func2 = MagicMock()
-        mock_itertools.return_value = [
-            (mock_func1, ["tag1", "tag2"]),
-            (mock_func2, ["tag3"])
-        ]
-
         # Execute
         await server.run()
 
         # Verify
         mock_config_get.assert_called_once()
         mock_new.assert_called_once_with(mock_config)
-        mock_itertools.assert_called_once()
-
-        # Check that tools were registered
-        expected_calls = [
-            call(mock_func1, tags=["tag1", "tag2"]),
-            call(mock_func2, tags=["tag3"])
-        ]
-        mock_mcp.tool.assert_has_calls(expected_calls)
 
         # Check server was run with correct parameters
         mock_mcp.run_async.assert_called_once_with(transport="stdio")
@@ -205,21 +189,16 @@ class TestRun:
         )
 
     @pytest.mark.asyncio
-    @patch('itential_mcp.server.toolutils.itertools')
     @patch('itential_mcp.server.new')
     @patch('itential_mcp.server.config.get')
-    async def test_run_tool_registration_failure(self, mock_config_get, mock_new, mock_itertools):
-        """Test server exits when tool registration fails"""
+    async def test_run_tool_registration_failure(self, mock_config_get, mock_new):
+        """Test server exits when tool registration fails in new()"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()  # Properly mock the async method
-        mock_new.return_value = mock_mcp
-
-        # Make itertools raise an exception
-        mock_itertools.side_effect = Exception("Tool import failed")
+        # Make new() raise an exception (simulates tool registration failure)
+        mock_new.side_effect = Exception("Tool import failed")
 
         with patch('builtins.print') as mock_print, \
              patch('sys.exit') as mock_exit:
@@ -227,7 +206,7 @@ class TestRun:
             await server.run()
 
             mock_print.assert_called_with(
-                "ERROR: failed to import tool: Tool import failed",
+                "ERROR: server stopped unexpectedly: Tool import failed",
                 file=sys.stderr
             )
             mock_exit.assert_called_with(1)
@@ -307,11 +286,10 @@ class TestRun:
         mock_mcp.run_async.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch('itential_mcp.server.toolutils.itertools')
     @patch('itential_mcp.server.new')
     @patch('itential_mcp.server.config.get')
-    async def test_run_multiple_tools_registration(self, mock_config_get, mock_new, mock_itertools):
-        """Test multiple tools are registered correctly"""
+    async def test_run_multiple_tools_registration(self, mock_config_get, mock_new):
+        """Test server properly uses the configured MCP instance from new()"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config_get.return_value = mock_config
@@ -320,49 +298,23 @@ class TestRun:
         mock_mcp.run_async = AsyncMock()
         mock_new.return_value = mock_mcp
 
-        # Multiple tools with different tag configurations
-        mock_func1 = MagicMock()
-        mock_func2 = MagicMock()
-        mock_func3 = MagicMock()
-
-        mock_itertools.return_value = [
-            (mock_func1, ["system", "admin"]),
-            (mock_func2, ["user"]),
-            (mock_func3, [])  # No tags
-        ]
-
         await server.run()
 
-        # Verify all tools were registered with their respective tags
-        expected_calls = [
-            call(mock_func1, tags=["system", "admin"]),
-            call(mock_func2, tags=["user"]),
-            call(mock_func3, tags=[])
-        ]
-        mock_mcp.tool.assert_has_calls(expected_calls)
-        assert mock_mcp.tool.call_count == 3
+        # Verify new() was called with the config and the MCP instance was used
+        mock_new.assert_called_once_with(mock_config)
+        mock_mcp.run_async.assert_called_once_with(transport="stdio")
 
     @pytest.mark.asyncio
-    @patch('itential_mcp.server.toolutils.itertools')
     @patch('itential_mcp.server.new')
     @patch('itential_mcp.server.config.get')
-    async def test_run_partial_tool_failure(self, mock_config_get, mock_new, mock_itertools):
-        """Test that server fails if tool iteration fails partway through"""
+    async def test_run_partial_tool_failure(self, mock_config_get, mock_new):
+        """Test that server fails if new() fails due to tool registration issues"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()  # Properly mock the async method
-        mock_new.return_value = mock_mcp
-
-        # Iterator that yields some tools then fails
-        def failing_iterator():
-            yield (MagicMock(), ["tag1"])
-            yield (MagicMock(), ["tag2"])
-            raise ImportError("Failed to import third tool")
-
-        mock_itertools.return_value = failing_iterator()
+        # Make new() fail with an ImportError (simulating tool import failure)
+        mock_new.side_effect = ImportError("Failed to import third tool")
 
         with patch('builtins.print') as mock_print, \
              patch('sys.exit') as mock_exit:
@@ -370,7 +322,7 @@ class TestRun:
             await server.run()
 
             mock_print.assert_called_with(
-                "ERROR: failed to import tool: Failed to import third tool",
+                "ERROR: server stopped unexpectedly: Failed to import third tool",
                 file=sys.stderr
             )
             mock_exit.assert_called_with(1)


### PR DESCRIPTION
This adds a new command to the application that will call a tool directly.  To call a tool use `itential-mcp call <tool> [--params <params>]`  This command is useful for testing the tool calls agaisnt a server without having to have an entire end to end system configured.