### PR TITLE
Globalize server instructions as a variable

### DIFF
--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -16,6 +16,20 @@ from . import cache
 from . import toolutils
 
 
+INSTRUCTIONS = """
+Tools for Itential - a network and infrastructure automation and orchestration
+platform. First, examine your available tools to understand your assigned
+persona: Platform SRE (platform administration, adapter/integration management,
+health monitoring), Platform Builder (asset development and promotion with
+full resource creation), Automation Developer (focused code asset development),
+Platform Operator (execute jobs, run compliance, consume data) or a Custom set
+of tools. Based on your tool access, adapt your approach - whether monitoring
+platform health, building automation assets, developing code resources, or
+operating established workflows. Key tools like get_health, get_workflows,
+run_command or create_resource will indicate your operational scope.
+"""
+
+
 @asynccontextmanager
 async def lifespan(mcp: FastMCP) -> AsyncGenerator[dict[str | Any], None]:
     """
@@ -60,7 +74,7 @@ def new(cfg: config.Config) -> FastMCP:
     # Initialize FastMCP server
     srv = FastMCP(
         name="Itential Platform MCP",
-        instructions="Tools for Itential - a network and infrastructure automation and orchestration platform. First, examine your available tools to understand your assigned persona: Platform SRE (platform administration, adapter/integration management, health monitoring), Platform Builder (asset development and promotion with full resource creation), Automation Developer (focused code asset development), Platform Operator (execute jobs, run compliance, consume data) or a Custom set of tools. Based on your tool access, adapt your approach - whether monitoring platform health, building automation assets, developing code resources, or operating established workflows. Key tools like get_health, get_workflows, run_command or create_resource will indicate your operational scope.",
+        instructions=INSTRUCTIONS.strip(),
         lifespan=lifespan,
         include_tags=cfg.server.get("include_tags"),
         exclude_tags=cfg.server.get("exclude_tags")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,6 @@ from itential_mcp.config import Config
 from itential_mcp.client import PlatformClient
 from itential_mcp.cache import Cache
 
-instructions = "Tools for Itential - a network and infrastructure automation and orchestration platform. First, examine your available tools to understand your assigned persona: Platform SRE (platform administration, adapter/integration management, health monitoring), Platform Builder (asset development and promotion with full resource creation), Automation Developer (focused code asset development), Platform Operator (execute jobs, run compliance, consume data) or a Custom set of tools. Based on your tool access, adapt your approach - whether monitoring platform health, building automation assets, developing code resources, or operating established workflows. Key tools like get_health, get_workflows, run_command or create_resource will indicate your operational scope."
 
 class TestLifespan:
     """Test the lifespan context manager functionality"""
@@ -56,7 +55,7 @@ class TestNew:
 
         mock_fastmcp.assert_called_once_with(
             name="Itential Platform MCP",
-            instructions=instructions,
+            instructions=server.INSTRUCTIONS.strip(),
             lifespan=server.lifespan,
             include_tags=["tag1", "tag2"],
             exclude_tags=["tag3"]
@@ -76,7 +75,7 @@ class TestNew:
 
         mock_fastmcp.assert_called_once_with(
             name="Itential Platform MCP",
-            instructions=instructions,
+            instructions=server.INSTRUCTIONS.strip(),
             lifespan=server.lifespan,
             include_tags=None,
             exclude_tags=None
@@ -92,7 +91,7 @@ class TestNew:
 
         mock_fastmcp.assert_called_once_with(
             name="Itential Platform MCP",
-            instructions=instructions,
+            instructions=server.INSTRUCTIONS.strip(),
             lifespan=server.lifespan,
             include_tags=None,
             exclude_tags=None
@@ -411,7 +410,7 @@ class TestIntegration:
             # Verify FastMCP was created with correct parameters
             mock_fastmcp_class.assert_called_once_with(
                 name="Itential Platform MCP",
-                instructions=instructions,
+                instructions=server.INSTRUCTIONS.strip(),
                 lifespan=server.lifespan,
                 include_tags=["system"],
                 exclude_tags=["deprecated"]


### PR DESCRIPTION
This change moves the server instructions to a globalized variable instead of passing the string directly as a keywork parameter.  This will aid in updating the instructions later if needed.  All test cases have been updated to ensure passing.