### PR TITLE
Expand CI testing to cover Python 3.10-3.13 matrix

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -10,15 +10,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'  # You can specify an exact version like '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ A Model Context Protocol _(MCP)_ server that provides tools for connecting LLMs 
 - Access to an [Itential Platform Instance](https://www.itential.com/)
 - For _development_ - `uv` and `make`
 
+### Tested Python Versions
+This project is automatically tested against the following Python versions:
+- Python 3.10
+- Python 3.11  
+- Python 3.12
+- Python 3.13
+
 ## 🔧 Installation
 The `itential-mcp` application can be installed using either PyPI or it can be
 run directly from source.


### PR DESCRIPTION
- Update GitHub Actions premerge workflow to test against Python versions 3.10, 3.11, 3.12, and 3.13
- Add matrix strategy to run tests in parallel across all supported Python versions
- Update README to document tested Python versions for better transparency