### PR TITLE
Adds new workflow to release container

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,43 @@
+# .github/workflows/release.yml
+# This workflow will push a new container into the Github Container Registry
+# whenever a new tag is merged into the repository.
+---
+nname: Build and Push Container
+
+on:
+  push:
+    tags:
+      - "v*"   # runs only when a tag starting with "v" is pushed (e.g., v1.0.0)
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: vars
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.VERSION }}
+            ghcr.io/${{ github.repository }}:latest
+


### PR DESCRIPTION
This adds a new Github workflow that will push a released container into the Github Container Registry. This workflow is triggered by adding a new version tag to the repository.  The container will be built and pushed into the package registry