### PR TITLE
Fix typo in workflow name

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -2,7 +2,7 @@
 # This workflow will push a new container into the Github Container Registry
 # whenever a new tag is merged into the repository.
 ---
-nname: Build and Push Container
+name: Build and Push Container
 
 on:
   push:


### PR DESCRIPTION
This small change fixes a typo in the container release workflow.  The name key was mistyped and therefore the workflow name didn't appear in the UI