### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 # Dependabot configuration for Itential MCP
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+---
 version: 2
+
 updates:
   # Python dependencies
   - package-ecosystem: "pip"
@@ -27,8 +28,7 @@ updates:
     assignees:
       - "maintainers"
     labels:
-      - "dependencies"
-      - "automated"
+      - "dependabot"
     reviewers:
       - "itential/maintainers"
 
@@ -45,8 +45,7 @@ updates:
       prefix: "ci"
       include: "scope"
     labels:
-      - "github-actions"
-      - "automated"
+      - "dependabot"
     reviewers:
       - "itential/maintainers"
 
@@ -63,7 +62,6 @@ updates:
       prefix: "docker"
       include: "scope"
     labels:
-      - "docker"
-      - "automated"
+      - "dependabot"
     reviewers:
       - "itential/maintainers"


### PR DESCRIPTION
This updates the dependabot configuration to apply the correct labels
when new pull requests are applied.   All dependabot pull requests will
now set the `dependabot` label only.