### PR TITLE
Fix workflow lookup to include project members

### DIFF
--- a/src/itential_mcp/functions.py
+++ b/src/itential_mcp/functions.py
@@ -37,6 +37,7 @@ async def workflow_id_to_name(ctx: Context, workflow_id: str) -> str:
         params={
             "equals[_id]": workflow_id,
             "include": "_id,name",
+            "exclude-project-members": False
         }
     )
 


### PR DESCRIPTION
Add exclude-project-members parameter to workflow_id_to_name function to ensure project-level workflows are included in the lookup results.