### PR TITLE
Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ htmlcov/
 # dotenv 
 .env
 
+# local development 
+.devel
 


### PR DESCRIPTION
This updates the .gitignore file to ignore .devel/ in the project.  The .devel/ folder can be used to store local development assets that should not be committed to the project