### PR TITLE
Refactor Action.schema field to input_schema in lifecycle manager models

### DIFF
--- a/src/itential_mcp/models/lifecycle_manager.py
+++ b/src/itential_mcp/models/lifecycle_manager.py
@@ -92,7 +92,7 @@ class Action(BaseModel):
     Attributes:
         name: The configured name identifier for this action.
         type: The type of operation this action performs (create, update, delete).
-        schema: A JSON Schema object defining the required input structure
+        input_schema: A JSON Schema object defining the required input structure
             for successfully executing this action.
     """
 
@@ -118,7 +118,7 @@ class Action(BaseModel):
         )
     ]
 
-    schema: Annotated[
+    input_schema: Annotated[
         Mapping[str, Any],
         Field(
             description = inspect.cleandoc(

--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -149,7 +149,7 @@ async def describe_resource(
         - For each action the following fields will be returned:
             - name: The name of the action
             - type: The type of action (CREATE, UPDATE, DELETE)
-            - schema: The input schema required to execute the action
+            - input_schema: The input schema required to execute the action
     """
     await ctx.info("inside describe_resource(...)")
 
@@ -190,7 +190,7 @@ async def describe_resource(
         actions.append(Action(
             name=ele["name"],
             type=ele["type"],
-            schema=action_schema
+            input_schema=action_schema
         ))
 
     return DescribeResourceResponse(

--- a/tests/test_models_lifecycle_manager.py
+++ b/tests/test_models_lifecycle_manager.py
@@ -167,12 +167,12 @@ class TestAction:
         action = Action(
             name="create_vlan",
             type="create",
-            schema={"type": "object", "properties": {"vlan_id": {"type": "integer"}}}
+            input_schema={"type": "object", "properties": {"vlan_id": {"type": "integer"}}}
         )
         
         assert action.name == "create_vlan"
         assert action.type == "create"
-        assert action.schema == {"type": "object", "properties": {"vlan_id": {"type": "integer"}}}
+        assert action.input_schema == {"type": "object", "properties": {"vlan_id": {"type": "integer"}}}
 
     def test_action_all_types(self):
         """Test Action with all valid types"""
@@ -180,7 +180,7 @@ class TestAction:
             action = Action(
                 name=f"{action_type}_action",
                 type=action_type,
-                schema={"type": "object"}
+                input_schema={"type": "object"}
             )
             assert action.type == action_type
 
@@ -190,7 +190,7 @@ class TestAction:
             Action(
                 name="invalid_action",
                 type="invalid_type",
-                schema={"type": "object"}
+                input_schema={"type": "object"}
             )
         
         assert "invalid_type" in str(exc_info.value)
@@ -215,29 +215,33 @@ class TestAction:
         action = Action(
             name="complex_action",
             type="create",
-            schema=complex_schema
+            input_schema=complex_schema
         )
         
-        assert action.schema == complex_schema
+        assert action.input_schema == complex_schema
 
     def test_action_required_fields(self):
         """Test Action with missing required fields"""
         # Test missing name
         try:
-            Action(type="create", schema={"type": "object"})  # Missing name
+            Action(type="create", input_schema={"type": "object"})  # Missing name
             assert False, "Should have raised ValidationError"
         except ValidationError as e:
             assert "name" in str(e)
         
         # Test missing type  
         try:
-            Action(name="test", schema={"type": "object"})  # Missing type
+            Action(name="test", input_schema={"type": "object"})  # Missing type
             assert False, "Should have raised ValidationError"
         except ValidationError as e:
             assert "type" in str(e)
         
-        # Note: schema field shadows BaseModel.schema method and gets a default,
-        # so we can't test missing schema validation easily
+        # Test missing input_schema
+        try:
+            Action(name="test", type="create")  # Missing input_schema
+            assert False, "Should have raised ValidationError"
+        except ValidationError as e:
+            assert "input_schema" in str(e)
 
 
 class TestDescribeResourceResponse:
@@ -246,8 +250,8 @@ class TestDescribeResourceResponse:
     def test_describe_resource_response_basic(self):
         """Test basic DescribeResourceResponse creation"""
         actions = [
-            Action(name="create", type="create", schema={"type": "object"}),
-            Action(name="delete", type="delete", schema={"type": "object"}),
+            Action(name="create", type="create", input_schema={"type": "object"}),
+            Action(name="delete", type="delete", input_schema={"type": "object"}),
         ]
         
         response = DescribeResourceResponse(
@@ -560,7 +564,7 @@ class TestModelIntegration:
         create_action = Action(
             name="provision",
             type="create",
-            schema={"type": "object", "properties": {"vlan_id": {"type": "integer"}}}
+            input_schema={"type": "object", "properties": {"vlan_id": {"type": "integer"}}}
         )
         
         # Create a describe resource response

--- a/tests/test_tools_lifecycle_manager.py
+++ b/tests/test_tools_lifecycle_manager.py
@@ -286,7 +286,7 @@ class TestDescribeResource:
         assert len(result.actions) == 1
         assert result.actions[0].name == "create"
         assert result.actions[0].type == "create"
-        assert result.actions[0].schema == {"type": "object"}
+        assert result.actions[0].input_schema == {"type": "object"}
 
     @pytest.mark.asyncio
     async def test_describe_resource_not_found(self, mock_context):
@@ -332,7 +332,7 @@ class TestDescribeResource:
         result = await lifecycle_manager.describe_resource(mock_context, "test-resource")
 
         assert isinstance(result, DescribeResourceResponse)
-        assert result.actions[0].schema == mock_transformation_data["incoming"]
+        assert result.actions[0].input_schema == mock_transformation_data["incoming"]
         mock_client.transformations.describe_transformation.assert_called_once_with("transformation123")
 
     @pytest.mark.asyncio
@@ -365,7 +365,7 @@ class TestDescribeResource:
         result = await lifecycle_manager.describe_resource(mock_context, "test-resource")
 
         assert isinstance(result, DescribeResourceResponse)
-        assert result.actions[0].schema == mock_workflow_data["inputSchema"]
+        assert result.actions[0].input_schema == mock_workflow_data["inputSchema"]
         mock_client.automation_studio.describe_workflow.assert_called_once_with("workflow123")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
- Rename schema field to input_schema in Action class for better clarity
- Update Action class docstring to reflect the field name change
- Update lifecycle_manager tool documentation and implementation
- Update all unit tests to use input_schema instead of schema
- Maintain backward compatibility in functionality
- All tests pass and code follows style guidelines