### PR TITLE
Fix release container build

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           context: .
           push: true
+          file: Containerfile
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This fixes an error buiding the release container.  The action didn't specify the name of the container build file `Containerfile` and the default is `Dockerfile`.  This fixes the problem.