### PR TITLE
Fix automation lookup in bindings endpoint

### DIFF
--- a/src/itential_mcp/bindings/endpoint.py
+++ b/src/itential_mcp/bindings/endpoint.py
@@ -41,10 +41,12 @@ async def _get_trigger(platform_client: client.PlatformClient, t: config.Endpoin
 
     json_data = res.json()
 
-    if json_data["metadata"]["total"] != 1:
+    for ele in json_data["data"]:
+        if ele["name"] == t.automation:
+            automation_id = ele["_id"]
+            break
+    else:
         raise exceptions.NotFoundError(f"automation {t.automation} could not be found")
-
-    automation_id = json_data["data"][0]["_id"]
 
     res = await platform_client.client.get(
         "/operations-manager/triggers",

--- a/tests/test_bindings_endpoint.py
+++ b/tests/test_bindings_endpoint.py
@@ -149,8 +149,8 @@ class TestGetTrigger:
     async def test_get_trigger_multiple_automations_found(
         self, mock_platform_client, mock_endpoint_tool
     ):
-        """Test _get_trigger raises NotFoundError when multiple automations are found."""
-        # Setup - multiple automations found
+        """Test _get_trigger with multiple automations - uses first match, then fails on trigger lookup."""
+        # Setup - multiple automations found, but empty triggers response
         automation_response = {
             "metadata": {"total": 2},
             "data": [
@@ -158,14 +158,18 @@ class TestGetTrigger:
                 {"_id": "automation-456", "name": "test-automation"},
             ],
         }
-        mock_platform_client.client.get.return_value = MagicMock(
-            json=lambda: automation_response
-        )
+        triggers_response = {"data": []}
+        
+        # Mock responses in order: automation lookup succeeds, trigger lookup returns empty
+        mock_platform_client.client.get.side_effect = [
+            MagicMock(json=lambda: automation_response),
+            MagicMock(json=lambda: triggers_response),
+        ]
 
-        # Execute and verify
+        # Execute and verify - should fail when trigger is not found
         with pytest.raises(
             exceptions.NotFoundError,
-            match="automation test-automation could not be found",
+            match="trigger test-trigger could not be found",
         ):
             await _get_trigger(mock_platform_client, mock_endpoint_tool)
 


### PR DESCRIPTION
Improve automation lookup logic to properly handle multiple automations by searching for exact name match instead of assuming single result.