### PR TITLE
feat: add comprehensive command templates support with models, servic…

### DIFF
--- a/src/itential_mcp/models/command_templates.py
+++ b/src/itential_mcp/models/command_templates.py
@@ -1,0 +1,439 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import inspect
+
+from typing import Any, List, Annotated
+
+from pydantic import BaseModel, Field
+
+
+class CommandTemplate(BaseModel):
+    """Represents a command template configuration.
+
+    This model represents a command template that can be executed against
+    network devices to perform automated configuration and validation tasks.
+    Templates can be global or belong to specific projects.
+
+    Attributes:
+        id: Unique identifier for the command template.
+        name: Human-readable template name.
+        description: Brief description of what the template does.
+        namespace: Project namespace (null for global templates).
+        passRule: Pass rule configuration for template evaluation.
+    """
+
+    id: Annotated[
+        str,
+        Field(
+            alias="_id",
+            description=inspect.cleandoc(
+                """
+                Unique identifier for the command template
+                """
+            ),
+        ),
+    ]
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Human-readable name of the command template
+                """
+            )
+        ),
+    ]
+
+    description: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Brief description of what the template does
+                """
+            )
+        ),
+    ]
+
+    namespace: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Project namespace (null for global templates)
+                """
+            )
+        ),
+    ]
+
+    passRule: Annotated[
+        bool,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Pass rule configuration (True=all must pass, False=one must pass)
+                """
+            )
+        ),
+    ]
+
+
+class GetCommandTemplatesResponse(BaseModel):
+    """Response model for the get command templates API endpoint.
+
+    This model wraps a list of CommandTemplate objects representing
+    all available command templates from both global space and projects.
+
+    Attributes:
+        templates: List of command template objects.
+    """
+
+    templates: Annotated[
+        List[CommandTemplate],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of command template objects with configuration details
+                """
+            )
+        ),
+    ]
+
+
+class CommandTemplateDetail(BaseModel):
+    """Represents detailed command template information.
+
+    This model extends the basic CommandTemplate with detailed information
+    including the actual commands and rules that will be executed when
+    the template is run against devices.
+
+    Attributes:
+        id: Unique identifier for the command template.
+        name: Human-readable template name.
+        commands: List of commands and associated validation rules.
+        namespace: Project namespace (null for global templates).
+        passRule: Pass rule configuration for template evaluation.
+    """
+
+    id: Annotated[
+        str,
+        Field(
+            alias="_id",
+            description=inspect.cleandoc(
+                """
+                Unique identifier for the command template
+                """
+            ),
+        ),
+    ]
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Human-readable name of the command template
+                """
+            )
+        ),
+    ]
+
+    commands: Annotated[
+        List[dict[str, Any]],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of commands and associated validation rules
+                """
+            )
+        ),
+    ]
+
+    namespace: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Project namespace (null for global templates)
+                """
+            )
+        ),
+    ]
+
+    passRule: Annotated[
+        bool,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Pass rule configuration (True=all must pass, False=one must pass)
+                """
+            )
+        ),
+    ]
+
+
+class DescribeCommandTemplateResponse(BaseModel):
+    """Response model for the describe command template API endpoint.
+
+    This model wraps a CommandTemplateDetail object containing detailed
+    information about a specific command template.
+
+    Attributes:
+        template: Detailed command template information.
+    """
+
+    template: Annotated[
+        CommandTemplateDetail,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Detailed command template information including commands and rules
+                """
+            )
+        ),
+    ]
+
+
+class RuleEvaluation(BaseModel):
+    """Represents a rule evaluation result.
+
+    This model contains the results of evaluating a validation rule
+    against device command output during template execution.
+
+    Attributes:
+        eval: Type of rule evaluation performed.
+        rule: Data used for performing the rule check.
+        severity: Severity level if rule matches.
+        result: Boolean result from the rule check.
+    """
+
+    eval: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Type of rule evaluation performed (e.g., contains, regex, equals)
+                """
+            )
+        ),
+    ]
+
+    rule: Annotated[
+        Any,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Data used for performing the rule check (string, regex pattern, etc.)
+                """
+            )
+        ),
+    ]
+
+    severity: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Severity level if rule matches (e.g., error, warning, info)
+                """
+            )
+        ),
+    ]
+
+    result: Annotated[
+        bool,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Boolean result from the rule check (True if rule passed)
+                """
+            )
+        ),
+    ]
+
+
+class CommandResult(BaseModel):
+    """Represents a command execution result from a device.
+
+    This model contains the results of executing a single command
+    against a device as part of a command template execution.
+
+    Attributes:
+        raw: Original command as entered in the template.
+        evaluated: Command as actually sent to the device.
+        device: Target device name where command was executed.
+        response: Device response used for rule evaluation.
+        rules: List of rule evaluation results.
+    """
+
+    raw: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Original command as entered in the template
+                """
+            )
+        ),
+    ]
+
+    evaluated: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Command as actually sent to the device after variable substitution
+                """
+            )
+        ),
+    ]
+
+    device: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Target device name where command was executed
+                """
+            )
+        ),
+    ]
+
+    response: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Device response used for rule evaluation
+                """
+            )
+        ),
+    ]
+
+    rules: Annotated[
+        List[RuleEvaluation],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of rule evaluation results for this command execution
+                """
+            )
+        ),
+    ]
+
+
+class RunCommandTemplateResponse(BaseModel):
+    """Response model for the run command template API endpoint.
+
+    This model contains the complete results of executing a command
+    template against one or more devices, including all command
+    results and rule evaluations.
+
+    Attributes:
+        name: Command template name that was executed.
+        all_pass_flag: Whether all rules must pass for success.
+        command_results: List of results for each command/device combination.
+    """
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Command template name that was executed
+                """
+            )
+        ),
+    ]
+
+    all_pass_flag: Annotated[
+        bool,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Whether all rules must pass for success (True=all must pass, False=any can pass)
+                """
+            )
+        ),
+    ]
+
+    command_results: Annotated[
+        List[CommandResult],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of results for each command/device combination
+                """
+            )
+        ),
+    ]
+
+
+class DeviceCommandResult(BaseModel):
+    """Represents a simple device command execution result.
+
+    This model contains the basic results of executing a single
+    command against a device without rule evaluation.
+
+    Attributes:
+        device: Target device name where command was executed.
+        command: Command that was sent to the device.
+        response: Output received from running the command.
+    """
+
+    device: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Target device name where command was executed
+                """
+            )
+        ),
+    ]
+
+    command: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Command that was sent to the device
+                """
+            )
+        ),
+    ]
+
+    response: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Output received from running the command
+                """
+            )
+        ),
+    ]
+
+
+class RunCommandResponse(BaseModel):
+    """Response model for the run command API endpoint.
+
+    This model wraps a list of DeviceCommandResult objects representing
+    the results of executing a single command against multiple devices.
+
+    Attributes:
+        results: List of command execution results for each device.
+    """
+
+    results: Annotated[
+        List[DeviceCommandResult],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of command execution results for each device
+                """
+            )
+        ),
+    ]

--- a/src/itential_mcp/services/mop.py
+++ b/src/itential_mcp/services/mop.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from typing import Dict, Any, List
+
+from itential_mcp.services import ServiceBase
+
+
+class Service(ServiceBase):
+    """Service class for MOP (Method of Procedure) command template operations.
+
+    This service provides methods for managing and executing command templates
+    on network devices through the Itential Platform MOP module. Command
+    templates enable automated device configuration and validation workflows.
+
+    The service supports:
+    - Retrieving available command templates
+    - Getting detailed template information
+    - Executing templates against multiple devices
+    - Running individual commands on devices
+    """
+
+    name: str = "mop"
+
+    async def _get_project_id_from_name(self, name: str) -> str:
+        """
+        Get the project ID for a specified project name.
+
+        Args:
+            name (str): Case-sensitive project name to locate
+
+        Returns:
+            str: The project ID associated with the project name
+
+        Raises:
+            ValueError: If the project name cannot be definitively located
+        """
+        res = await self.client.get(
+            "/automation-studio/projects", params={"equals[name]": name}
+        )
+
+        data = res.json()
+
+        if len(data["data"]) != 1:
+            raise ValueError(f"unable to locate project `{name}`")
+
+        return data["data"][0]["_id"]
+
+    async def get_command_templates(self) -> List[Dict[str, Any]]:
+        """
+        Get all command templates from Itential Platform.
+
+        Command Templates are run-time templates that actively pass commands to devices
+        and evaluate responses against defined rules. Retrieves templates from both
+        global space and projects.
+
+        Returns:
+            list[dict]: List of command template objects with the following fields:
+                - _id: Unique identifier
+                - name: Template name
+                - description: Template description
+                - namespace: Project namespace (null for global templates)
+                - passRule: Pass rule configuration (True=all must pass, False=one must pass)
+
+        Raises:
+            Exception: If there is an error retrieving command templates
+        """
+        res = await self.client.get("/mop/listTemplates")
+        return res.json()
+
+    async def describe_command_template(
+        self,
+        name: str,
+        project: str | None = None
+    ) -> Dict[str, Any]:
+        """
+        Get detailed information about a specific command template.
+
+        Args:
+            name (str): Name of the command template to describe
+            project (str | None): Project name containing the template (None for global templates)
+
+        Returns:
+            dict: Command template details with the following fields:
+                - _id: Unique identifier
+                - name: Template name
+                - commands: List of commands and associated rules
+                - namespace: Project namespace (null for global templates)
+                - passRule: Pass rule configuration (True=all must pass, False=one must pass)
+
+        Raises:
+            ValueError: If the project name cannot be located
+            Exception: If there is an error retrieving the command template
+        """
+        template_name = name
+        if project is not None:
+            project_id = await self._get_project_id_from_name(project)
+            template_name = f"@{project_id}: {name}"
+
+        res = await self.client.get(f"/mop/listATemplate/{template_name}")
+
+        return res.json()[0]
+
+    async def run_command_template(
+        self,
+        name: str,
+        devices: List[str],
+        project: str | None = None
+    ) -> Dict[str, Any]:
+        """
+        Execute a command template against specified devices with rule evaluation.
+
+        Command Templates are run-time templates that actively pass commands to a list
+        of specified devices during their runtime. After all responses are collected,
+        the output set is evaluated against a set of defined rules. These executed
+        templates are typically used as Pre and Post steps, which are usually separated
+        by a procedure (router upgrade, service migration, etc.).
+
+        Args:
+            name (str): Name of the command template to run
+            devices (list[str]): List of device names to run the template against
+            project (str | None): Project containing the template (None for global templates)
+
+        Returns:
+            dict: Execution results with the following structure:
+                - name: Command template name that was executed
+                - all_pass_flag: Whether all rules must pass for success
+                - command_results: List of results for each command/device combination
+
+        Raises:
+            ValueError: If the project name cannot be located
+            Exception: If there is an error executing the command template
+        """
+        template_name = name
+        if project is not None:
+            project_id = await self._get_project_id_from_name(project)
+            template_name = f"@{project_id}: {name}"
+
+        body = {
+            "template": template_name,
+            "devices": devices,
+        }
+
+        res = await self.client.post("/mop/RunCommandTemplate", json=body)
+
+        return res.json()
+
+    async def run_command(
+        self,
+        cmd: str,
+        devices: List[str]
+    ) -> List[Dict[str, Any]]:
+        """
+        Run a single command against multiple devices.
+
+        Args:
+            cmd (str): Command to execute on the devices
+            devices (list[str]): List of device names to run the command against
+
+        Returns:
+            list[dict]: List of command execution results with the following fields:
+                - device: Target device name
+                - raw: Original command executed on the remote device
+                - response: Output from running the command
+
+        Raises:
+            Exception: If there is an error executing the command on devices
+        """
+        body = {
+            "command": cmd,
+            "devices": devices,
+        }
+
+        res = await self.client.post("/mop/RunCommandDevices", json=body)
+
+        return res.json()

--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -5,45 +5,15 @@ from typing import Annotated
 from pydantic import Field
 
 from fastmcp import Context
+from itential_mcp.models import command_templates as models
 
 
 __tags__ = ("automation_studio",)
 
 
-async def _get_project_id_from_name(ctx: Context, name: str) -> str:
-    """
-    Get the project ID for a specified project name.
-
-    Args:
-        ctx (Context): The FastMCP Context object
-        name (str): Case-sensitive project name to locate
-
-    Returns:
-        str: The project ID associated with the project name
-
-    Raises:
-        ValueError: If the project name cannot be definitively located
-    """
-    client = ctx.request_context.lifespan_context.get("client")
-
-    res = await client.get(
-        "/automation-studio/projects",
-        params={"equals[name]": name}
-    )
-
-    data = res.json()
-
-    if len(data["data"]) != 1:
-        raise ValueError(f"unable to locate project `{name}`")
-
-    return data["data"][0]["_id"]
-
-
 async def get_command_templates(
-    ctx: Annotated[Context, Field(
-        description="The FastMCP Context object"
-    )]
-) -> list[dict]:
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+) -> models.GetCommandTemplatesResponse:
     """
     Get all command templates from Itential Platform.
 
@@ -55,44 +25,38 @@ async def get_command_templates(
         ctx (Context): The FastMCP Context object
 
     Returns:
-        list[dict]: List of command template objects with the following fields:
-            - _id: Unique identifier
-            - name: Template name
-            - description: Template description
-            - namespace: Project namespace (null for global templates)
-            - passRule: Pass rule configuration (True=all must pass, False=one must pass)
+        GetCommandTemplatesResponse: Response containing list of command template objects
     """
     await ctx.info("inside get_command_templates(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    res = await client.get("/mop/listTemplates")
+    res = await client.mop.get_command_templates()
 
     results = list()
 
-    for item in res.json():
-        results.append({
-            "_id": item["_id"],
-            "name": item["name"],
-            "description": item["description"],
-            "namespace": item["namespace"],
-            "passRule": item["passRule"],
-        })
+    for item in res:
+        template = models.CommandTemplate(
+            **item  # Use dict unpacking to handle the _id alias automatically
+        )
+        results.append(template)
 
-    return results
+    return models.GetCommandTemplatesResponse(templates=results)
+
 
 async def describe_command_template(
-    ctx: Annotated[Context, Field(
-        description="The FastMCP Context object"
-    )],
-    name: Annotated[str, Field(
-        description="The name of the command template to describe"
-    )],
-    project: Annotated[str | None, Field(
-        description="The name of the project to get the command template from",
-        default=None
-    )]
-) -> dict:
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    name: Annotated[
+        str, Field(description="The name of the command template to describe")
+    ],
+    project: Annotated[
+        str | None,
+        Field(
+            description="The name of the project to get the command template from",
+            default=None,
+        ),
+    ],
+) -> models.DescribeCommandTemplateResponse:
     """
     Get detailed information about a specific command template.
 
@@ -102,49 +66,35 @@ async def describe_command_template(
         project (str | None): Project name containing the template (None for global templates)
 
     Returns:
-        dict: Command template details with the following fields:
-            - _id: Unique identifier
-            - name: Template name
-            - commands: List of commands and associated rules
-            - namespace: Project namespace (null for global templates)
-            - passRule: Pass rule configuration (True=all must pass, False=one must pass)
+        DescribeCommandTemplateResponse: Response containing detailed command template information
     """
     await ctx.info("inside describe_command_template(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    if project is not None:
-        project_id = await _get_project_id_from_name(ctx, project)
-        name = f"@{project_id}: {name}"
+    data = await client.mop.describe_command_template(
+        name=name, project=project
+    )
 
-    res = await client.get(f"/mop/listATemplate/{name}")
+    template = models.CommandTemplateDetail(
+        **data  # Use dict unpacking to handle the _id alias automatically
+    )
 
-    data = res.json()[0]
-
-    return {
-        "_id": data["_id"],
-        "name": data["name"],
-        "passRule": data["passRule"],
-        "commands": data["commands"],
-        "namespace": data["namespace"]
-    }
+    return models.DescribeCommandTemplateResponse(template=template)
 
 
 async def run_command_template(
-    ctx: Annotated[Context, Field(
-        description="The FastMCP Context object"
-    )],
-    name: Annotated[str, Field(
-        description="The name of the command template to run"
-    )],
-    devices: Annotated[list, Field(
-        description="The list of devices to run the command template against"
-    )],
-    project: Annotated[str | None, Field(
-        description="Project that contains the command template",
-        default=None
-    )]
-) -> dict:
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    name: Annotated[str, Field(description="The name of the command template to run")],
+    devices: Annotated[
+        list,
+        Field(description="The list of devices to run the command template against"),
+    ],
+    project: Annotated[
+        str | None,
+        Field(description="Project that contains the command template", default=None),
+    ],
+) -> models.RunCommandTemplateResponse:
     """
     Execute a command template against specified devices with rule evaluation.
 
@@ -161,49 +111,54 @@ async def run_command_template(
         project (str | None): Project containing the template (None for global templates)
 
     Returns:
-        dict: Execution results with the following structure:
-            - name: Command template name that was executed
-            - all_pass_flag: Whether all rules must pass for success
-            - command_results: List of results for each command/device combination:
-                - raw: Original command executed on the remote device
-                - evaluated: Command sent to the device
-                - device: Target device name
-                - response: Device response used for rule evaluation
-                - rules: Rule evaluation results with fields:
-                    - eval: Type of rule evaluation performed
-                    - rule: Data used for performing the rule check
-                    - severity: Severity of error if rule matches
-                    - result: Result from the rule check
+        RunCommandTemplateResponse: Response containing execution results with template name,
+            pass flag, and detailed command results for each device
     """
     await ctx.info("inside run_command_templates(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    if project is not None:
-        project_id = await _get_project_id_from_name(ctx, project)
-        name = f"@{project_id}: {name}"
+    data = await client.mop.run_command_template(
+        name=name, devices=devices, project=project
+    )
 
-    body = {
-        "template": name,
-        "devices": devices,
-    }
+    # Parse command results
+    command_results = []
 
-    res = await client.post("/mop/RunCommandTemplate", json=body)
+    for result in data.get("command_results", []):
+        rules = []
+        for rule_data in result.get("rules", []):
+            rule = models.RuleEvaluation(
+                eval=rule_data["eval"],
+                rule=rule_data["rule"],
+                severity=rule_data["severity"],
+                result=rule_data["result"],
+            )
+            rules.append(rule)
 
-    return res.json()
+        cmd_result = models.CommandResult(
+            raw=result["raw"],
+            evaluated=result["evaluated"],
+            device=result["device"],
+            response=result["response"],
+            rules=rules,
+        )
+        command_results.append(cmd_result)
+
+    return models.RunCommandTemplateResponse(
+        name=data["name"],
+        all_pass_flag=data["all_pass_flag"],
+        command_results=command_results,
+    )
 
 
 async def run_command(
-    ctx: Annotated[Context, Field(
-        description="The FastMCP Context object"
-    )],
-    cmd: Annotated[str, Field(
-        description="The command to run on the devices"
-    )],
-    devices: Annotated[list[str], Field(
-        description="The list of devices to run the command on"
-    )]
-) -> list[dict]:
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    cmd: Annotated[str, Field(description="The command to run on the devices")],
+    devices: Annotated[
+        list[str], Field(description="The list of devices to run the command on")
+    ],
+) -> models.RunCommandResponse:
     """
     Run a single command against multiple devices.
 
@@ -213,29 +168,21 @@ async def run_command(
         devices (list[str]): List of device names. Use `get_devices` to see available devices.
 
     Returns:
-        list[dict]: List of command execution results with the following fields:
-            - device: Target device name
-            - command: Command sent to the device
-            - response: Output from running the command
+        RunCommandResponse: Response containing list of command execution results for each device
     """
     await ctx.info("inside run_command(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    body = {
-        "command": cmd,
-        "devices": devices,
-    }
+    res = await client.mop.run_command(cmd=cmd, devices=devices)
 
-    res = await client.post("/mop/RunCommandDevices", json=body)
+    results = []
+    for item in res:
+        result = models.DeviceCommandResult(
+            device=item["device"],
+            command=item["raw"],
+            response=item["response"],
+        )
+        results.append(result)
 
-    results = list()
-
-    for item in res.json():
-        results.append({
-            "device": item["device"],
-            "command": item["raw"],
-            "response": item["response"],
-        })
-
-    return results
+    return models.RunCommandResponse(results=results)

--- a/tests/test_models_command_templates.py
+++ b/tests/test_models_command_templates.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from pydantic import ValidationError
+
+from itential_mcp.models import command_templates as models
+
+
+class TestCommandTemplate:
+    """Tests for CommandTemplate model."""
+
+    def test_command_template_creation(self):
+        """Test creating a CommandTemplate with valid data."""
+        template = models.CommandTemplate(
+            _id="template_123",
+            name="test_template",
+            description="Test command template",
+            namespace="test_project",
+            passRule=True,
+        )
+
+        assert template.id == "template_123"
+        assert template.name == "test_template"
+        assert template.description == "Test command template"
+        assert template.namespace == "test_project"
+        assert template.passRule is True
+
+    def test_command_template_null_namespace(self):
+        """Test CommandTemplate with null namespace (global template)."""
+        template = models.CommandTemplate(
+            _id="global_123",
+            name="global_template",
+            description="Global command template",
+            namespace=None,
+            passRule=False,
+        )
+
+        assert template.id == "global_123"
+        assert template.namespace is None
+        assert template.passRule is False
+
+    def test_command_template_validation_error(self):
+        """Test CommandTemplate validation with invalid data."""
+        with pytest.raises(ValidationError):
+            models.CommandTemplate(
+                name="test",
+                description="test",
+                namespace=None,
+                passRule=True,
+                # Missing required _id field
+            )
+
+
+class TestGetCommandTemplatesResponse:
+    """Tests for GetCommandTemplatesResponse model."""
+
+    def test_get_command_templates_response_creation(self):
+        """Test creating GetCommandTemplatesResponse with valid data."""
+        template = models.CommandTemplate(
+            _id="template_123",
+            name="test_template",
+            description="Test template",
+            namespace=None,
+            passRule=True,
+        )
+
+        response = models.GetCommandTemplatesResponse(templates=[template])
+
+        assert len(response.templates) == 1
+        assert response.templates[0] == template
+        assert response.templates[0].id == "template_123"
+
+    def test_get_command_templates_response_empty_list(self):
+        """Test GetCommandTemplatesResponse with empty template list."""
+        response = models.GetCommandTemplatesResponse(templates=[])
+
+        assert response.templates == []
+
+    def test_get_command_templates_response_multiple_templates(self):
+        """Test GetCommandTemplatesResponse with multiple templates."""
+        template1 = models.CommandTemplate(
+            _id="template_1",
+            name="template_one",
+            description="First template",
+            namespace="project1",
+            passRule=True,
+        )
+
+        template2 = models.CommandTemplate(
+            _id="template_2",
+            name="template_two",
+            description="Second template",
+            namespace=None,
+            passRule=False,
+        )
+
+        response = models.GetCommandTemplatesResponse(templates=[template1, template2])
+
+        assert len(response.templates) == 2
+        assert response.templates[0] == template1
+        assert response.templates[1] == template2
+
+
+class TestCommandTemplateDetail:
+    """Tests for CommandTemplateDetail model."""
+
+    def test_command_template_detail_creation(self):
+        """Test creating CommandTemplateDetail with valid data."""
+        commands = [
+            {"command": "show version", "rules": []},
+            {
+                "command": "show interfaces",
+                "rules": [{"eval": "contains", "value": "up"}],
+            },
+        ]
+
+        detail = models.CommandTemplateDetail(
+            _id="detail_123",
+            name="detailed_template",
+            commands=commands,
+            namespace="project1",
+            passRule=True,
+        )
+
+        assert detail.id == "detail_123"
+        assert detail.name == "detailed_template"
+        assert detail.commands == commands
+        assert detail.namespace == "project1"
+        assert detail.passRule is True
+
+    def test_command_template_detail_empty_commands(self):
+        """Test CommandTemplateDetail with empty commands list."""
+        detail = models.CommandTemplateDetail(
+            _id="empty_123",
+            name="empty_template",
+            commands=[],
+            namespace=None,
+            passRule=False,
+        )
+
+        assert detail.commands == []
+
+
+class TestDescribeCommandTemplateResponse:
+    """Tests for DescribeCommandTemplateResponse model."""
+
+    def test_describe_command_template_response_creation(self):
+        """Test creating DescribeCommandTemplateResponse with valid data."""
+        template = models.CommandTemplateDetail(
+            _id="template_123",
+            name="test_template",
+            commands=[{"command": "show version"}],
+            namespace="project1",
+            passRule=True,
+        )
+
+        response = models.DescribeCommandTemplateResponse(template=template)
+
+        assert response.template == template
+
+
+class TestRuleEvaluation:
+    """Tests for RuleEvaluation model."""
+
+    def test_rule_evaluation_creation(self):
+        """Test creating RuleEvaluation with valid data."""
+        rule = models.RuleEvaluation(
+            eval="contains", rule="interface up", severity="error", result=True
+        )
+
+        assert rule.eval == "contains"
+        assert rule.rule == "interface up"
+        assert rule.severity == "error"
+        assert rule.result is True
+
+    def test_rule_evaluation_complex_rule(self):
+        """Test RuleEvaluation with complex rule data."""
+        complex_rule_data = {
+            "pattern": "interface.*up",
+            "type": "regex",
+            "flags": ["ignorecase"],
+        }
+
+        rule = models.RuleEvaluation(
+            eval="regex", rule=complex_rule_data, severity="warning", result=False
+        )
+
+        assert rule.rule == complex_rule_data
+
+
+class TestCommandResult:
+    """Tests for CommandResult model."""
+
+    def test_command_result_creation(self):
+        """Test creating CommandResult with valid data."""
+        rule = models.RuleEvaluation(
+            eval="contains", rule="up", severity="info", result=True
+        )
+
+        result = models.CommandResult(
+            raw="show interface gi0/0",
+            evaluated="show interface GigabitEthernet0/0",
+            device="router1",
+            response="GigabitEthernet0/0 is up, line protocol is up",
+            rules=[rule],
+        )
+
+        assert result.raw == "show interface gi0/0"
+        assert result.evaluated == "show interface GigabitEthernet0/0"
+        assert result.device == "router1"
+        assert result.response == "GigabitEthernet0/0 is up, line protocol is up"
+        assert len(result.rules) == 1
+        assert result.rules[0] == rule
+
+    def test_command_result_no_rules(self):
+        """Test CommandResult with no rules."""
+        result = models.CommandResult(
+            raw="show version",
+            evaluated="show version",
+            device="switch1",
+            response="Cisco IOS Software",
+            rules=[],
+        )
+
+        assert result.rules == []
+
+
+class TestRunCommandTemplateResponse:
+    """Tests for RunCommandTemplateResponse model."""
+
+    def test_run_command_template_response_creation(self):
+        """Test creating RunCommandTemplateResponse with valid data."""
+        rule = models.RuleEvaluation(
+            eval="contains", rule="up", severity="info", result=True
+        )
+
+        cmd_result = models.CommandResult(
+            raw="show interfaces",
+            evaluated="show interfaces brief",
+            device="router1",
+            response="Interface status output",
+            rules=[rule],
+        )
+
+        response = models.RunCommandTemplateResponse(
+            name="interface_check_template",
+            all_pass_flag=True,
+            command_results=[cmd_result],
+        )
+
+        assert response.name == "interface_check_template"
+        assert response.all_pass_flag is True
+        assert len(response.command_results) == 1
+        assert response.command_results[0] == cmd_result
+
+    def test_run_command_template_response_multiple_results(self):
+        """Test RunCommandTemplateResponse with multiple command results."""
+        rule1 = models.RuleEvaluation(
+            eval="contains", rule="up", severity="info", result=True
+        )
+        rule2 = models.RuleEvaluation(
+            eval="contains", rule="down", severity="error", result=False
+        )
+
+        result1 = models.CommandResult(
+            raw="show int gi0/0",
+            evaluated="show interface gi0/0",
+            device="router1",
+            response="gi0/0 is up",
+            rules=[rule1],
+        )
+
+        result2 = models.CommandResult(
+            raw="show int gi0/1",
+            evaluated="show interface gi0/1",
+            device="router1",
+            response="gi0/1 is down",
+            rules=[rule2],
+        )
+
+        response = models.RunCommandTemplateResponse(
+            name="multi_interface_check",
+            all_pass_flag=False,
+            command_results=[result1, result2],
+        )
+
+        assert len(response.command_results) == 2
+        assert response.all_pass_flag is False
+
+
+class TestDeviceCommandResult:
+    """Tests for DeviceCommandResult model."""
+
+    def test_device_command_result_creation(self):
+        """Test creating DeviceCommandResult with valid data."""
+        result = models.DeviceCommandResult(
+            device="switch1",
+            command="show version",
+            response="Cisco IOS Software, Version 15.2",
+        )
+
+        assert result.device == "switch1"
+        assert result.command == "show version"
+        assert result.response == "Cisco IOS Software, Version 15.2"
+
+    def test_device_command_result_empty_response(self):
+        """Test DeviceCommandResult with empty response."""
+        result = models.DeviceCommandResult(
+            device="router1",
+            command="show running-config | include hostname",
+            response="",
+        )
+
+        assert result.response == ""
+
+
+class TestRunCommandResponse:
+    """Tests for RunCommandResponse model."""
+
+    def test_run_command_response_creation(self):
+        """Test creating RunCommandResponse with valid data."""
+        result1 = models.DeviceCommandResult(
+            device="router1", command="show version", response="IOS Version 15.1"
+        )
+
+        result2 = models.DeviceCommandResult(
+            device="router2", command="show version", response="IOS Version 15.2"
+        )
+
+        response = models.RunCommandResponse(results=[result1, result2])
+
+        assert len(response.results) == 2
+        assert response.results[0] == result1
+        assert response.results[1] == result2
+
+    def test_run_command_response_empty_results(self):
+        """Test RunCommandResponse with empty results list."""
+        response = models.RunCommandResponse(results=[])
+
+        assert response.results == []
+
+    def test_run_command_response_single_result(self):
+        """Test RunCommandResponse with single result."""
+        result = models.DeviceCommandResult(
+            device="switch1",
+            command="show interfaces status",
+            response="Port status output",
+        )
+
+        response = models.RunCommandResponse(results=[result])
+
+        assert len(response.results) == 1
+        assert response.results[0] == result

--- a/tests/test_services_mop.py
+++ b/tests/test_services_mop.py
@@ -1,0 +1,371 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from itential_mcp.services.mop import Service
+
+
+class TestMOPService:
+    """Test cases for MOP Service class."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock AsyncPlatform client."""
+        client = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def mop_service(self, mock_client):
+        """Create a MOP service instance with mock client."""
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_service_name(self, mop_service):
+        """Test that service has correct name."""
+        assert mop_service.name == "mop"
+
+    @pytest.mark.asyncio
+    async def test_get_project_id_from_name_success(self, mop_service, mock_client):
+        """Test successful project ID retrieval."""
+        # Mock the API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [{"_id": "project_123", "name": "test_project"}]
+        }
+        mock_client.get.return_value = mock_response
+
+        result = await mop_service._get_project_id_from_name("test_project")
+
+        assert result == "project_123"
+        mock_client.get.assert_called_once_with(
+            "/automation-studio/projects", params={"equals[name]": "test_project"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_project_id_from_name_not_found(self, mop_service, mock_client):
+        """Test project ID retrieval when project not found."""
+        # Mock the API response with no results
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": []}
+        mock_client.get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="unable to locate project `nonexistent`"):
+            await mop_service._get_project_id_from_name("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_get_project_id_from_name_multiple_results(
+        self, mop_service, mock_client
+    ):
+        """Test project ID retrieval when multiple projects match."""
+        # Mock the API response with multiple results
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"_id": "project_1", "name": "test_project"},
+                {"_id": "project_2", "name": "test_project"},
+            ]
+        }
+        mock_client.get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="unable to locate project `test_project`"):
+            await mop_service._get_project_id_from_name("test_project")
+
+    @pytest.mark.asyncio
+    async def test_get_command_templates_success(self, mop_service, mock_client):
+        """Test successful retrieval of command templates."""
+        expected_templates = [
+            {
+                "_id": "template_1",
+                "name": "Interface Check",
+                "description": "Check interface status",
+                "namespace": None,
+                "passRule": True,
+            },
+            {
+                "_id": "template_2",
+                "name": "Version Check",
+                "description": "Check device version",
+                "namespace": "project_1",
+                "passRule": False,
+            },
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_templates
+        mock_client.get.return_value = mock_response
+
+        result = await mop_service.get_command_templates()
+
+        assert result == expected_templates
+        mock_client.get.assert_called_once_with("/mop/listTemplates")
+
+    @pytest.mark.asyncio
+    async def test_get_command_templates_empty_list(self, mop_service, mock_client):
+        """Test retrieval when no command templates exist."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_client.get.return_value = mock_response
+
+        result = await mop_service.get_command_templates()
+
+        assert result == []
+        mock_client.get.assert_called_once_with("/mop/listTemplates")
+
+    @pytest.mark.asyncio
+    async def test_describe_command_template_global(self, mop_service, mock_client):
+        """Test describing a global command template."""
+        expected_template = {
+            "_id": "template_123",
+            "name": "Global Template",
+            "commands": [{"command": "show version", "rules": []}],
+            "namespace": None,
+            "passRule": True,
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = [expected_template]
+        mock_client.get.return_value = mock_response
+
+        result = await mop_service.describe_command_template("Global Template")
+
+        assert result == expected_template
+        mock_client.get.assert_called_once_with("/mop/listATemplate/Global Template")
+
+    @pytest.mark.asyncio
+    async def test_describe_command_template_with_project(
+        self, mop_service, mock_client
+    ):
+        """Test describing a command template from a specific project."""
+        expected_template = {
+            "_id": "template_456",
+            "name": "Project Template",
+            "commands": [{"command": "show interfaces", "rules": []}],
+            "namespace": "project_123",
+            "passRule": False,
+        }
+
+        # Mock project lookup
+        mock_project_response = MagicMock()
+        mock_project_response.json.return_value = {
+            "data": [{"_id": "project_123", "name": "test_project"}]
+        }
+
+        # Mock template describe
+        mock_template_response = MagicMock()
+        mock_template_response.json.return_value = [expected_template]
+
+        mock_client.get.side_effect = [mock_project_response, mock_template_response]
+
+        result = await mop_service.describe_command_template(
+            "Project Template", project="test_project"
+        )
+
+        assert result == expected_template
+
+        # Verify both API calls were made
+        assert mock_client.get.call_count == 2
+        mock_client.get.assert_any_call(
+            "/automation-studio/projects", params={"equals[name]": "test_project"}
+        )
+        mock_client.get.assert_any_call(
+            "/mop/listATemplate/@project_123: Project Template"
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_command_template_global(self, mop_service, mock_client):
+        """Test running a global command template."""
+        expected_result = {
+            "name": "Interface Check",
+            "all_pass_flag": True,
+            "command_results": [
+                {
+                    "raw": "show int gi0/0",
+                    "evaluated": "show interface gi0/0",
+                    "device": "router1",
+                    "response": "Interface is up",
+                    "rules": [],
+                }
+            ],
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        result = await mop_service.run_command_template(
+            "Interface Check", ["router1", "router2"]
+        )
+
+        assert result == expected_result
+        mock_client.post.assert_called_once_with(
+            "/mop/RunCommandTemplate",
+            json={"template": "Interface Check", "devices": ["router1", "router2"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_command_template_with_project(self, mop_service, mock_client):
+        """Test running a command template from a specific project."""
+        expected_result = {
+            "name": "Project Template",
+            "all_pass_flag": False,
+            "command_results": [],
+        }
+
+        # Mock project lookup
+        mock_project_response = MagicMock()
+        mock_project_response.json.return_value = {
+            "data": [{"_id": "project_456", "name": "my_project"}]
+        }
+
+        # Mock template execution
+        mock_template_response = MagicMock()
+        mock_template_response.json.return_value = expected_result
+
+        mock_client.get.return_value = mock_project_response
+        mock_client.post.return_value = mock_template_response
+
+        result = await mop_service.run_command_template(
+            "Project Template", ["switch1"], project="my_project"
+        )
+
+        assert result == expected_result
+
+        # Verify project lookup call
+        mock_client.get.assert_called_once_with(
+            "/automation-studio/projects", params={"equals[name]": "my_project"}
+        )
+
+        # Verify template execution call
+        mock_client.post.assert_called_once_with(
+            "/mop/RunCommandTemplate",
+            json={"template": "@project_456: Project Template", "devices": ["switch1"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_command_success(self, mop_service, mock_client):
+        """Test successful command execution on multiple devices."""
+        expected_result = [
+            {
+                "device": "router1",
+                "raw": "show version",
+                "response": "Cisco IOS Version 15.1",
+            },
+            {
+                "device": "router2",
+                "raw": "show version",
+                "response": "Cisco IOS Version 15.2",
+            },
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        result = await mop_service.run_command("show version", ["router1", "router2"])
+
+        assert result == expected_result
+        mock_client.post.assert_called_once_with(
+            "/mop/RunCommandDevices",
+            json={"command": "show version", "devices": ["router1", "router2"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_command_single_device(self, mop_service, mock_client):
+        """Test command execution on a single device."""
+        expected_result = [
+            {
+                "device": "switch1",
+                "raw": "show interfaces status",
+                "response": "Port status information",
+            }
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        result = await mop_service.run_command("show interfaces status", ["switch1"])
+
+        assert result == expected_result
+        mock_client.post.assert_called_once_with(
+            "/mop/RunCommandDevices",
+            json={"command": "show interfaces status", "devices": ["switch1"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_command_empty_devices_list(self, mop_service, mock_client):
+        """Test command execution with empty devices list."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_client.post.return_value = mock_response
+
+        result = await mop_service.run_command("show version", [])
+
+        assert result == []
+        mock_client.post.assert_called_once_with(
+            "/mop/RunCommandDevices", json={"command": "show version", "devices": []}
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_command_templates_api_error(self, mop_service, mock_client):
+        """Test handling of API errors in get_command_templates."""
+        mock_client.get.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception, match="API Error"):
+            await mop_service.get_command_templates()
+
+    @pytest.mark.asyncio
+    async def test_describe_command_template_api_error(self, mop_service, mock_client):
+        """Test handling of API errors in describe_command_template."""
+        mock_client.get.side_effect = Exception("Template not found")
+
+        with pytest.raises(Exception, match="Template not found"):
+            await mop_service.describe_command_template("NonExistent")
+
+    @pytest.mark.asyncio
+    async def test_run_command_template_api_error(self, mop_service, mock_client):
+        """Test handling of API errors in run_command_template."""
+        mock_client.post.side_effect = Exception("Execution failed")
+
+        with pytest.raises(Exception, match="Execution failed"):
+            await mop_service.run_command_template("Test Template", ["device1"])
+
+    @pytest.mark.asyncio
+    async def test_run_command_api_error(self, mop_service, mock_client):
+        """Test handling of API errors in run_command."""
+        mock_client.post.side_effect = Exception("Command failed")
+
+        with pytest.raises(Exception, match="Command failed"):
+            await mop_service.run_command("show version", ["device1"])
+
+    @pytest.mark.asyncio
+    async def test_describe_command_template_project_not_found(
+        self, mop_service, mock_client
+    ):
+        """Test describe_command_template when project lookup fails."""
+        # Mock project lookup to return empty results
+        mock_project_response = MagicMock()
+        mock_project_response.json.return_value = {"data": []}
+        mock_client.get.return_value = mock_project_response
+
+        with pytest.raises(ValueError, match="unable to locate project `unknown`"):
+            await mop_service.describe_command_template(
+                "Template Name", project="unknown"
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_command_template_project_not_found(
+        self, mop_service, mock_client
+    ):
+        """Test run_command_template when project lookup fails."""
+        # Mock project lookup to return empty results
+        mock_project_response = MagicMock()
+        mock_project_response.json.return_value = {"data": []}
+        mock_client.get.return_value = mock_project_response
+
+        with pytest.raises(ValueError, match="unable to locate project `unknown`"):
+            await mop_service.run_command_template(
+                "Template Name", ["device1"], project="unknown"
+            )


### PR DESCRIPTION
…es, and enhanced testing

- Create detailed Pydantic models for all command template operations following adapters.py pattern
  - CommandTemplate: Base template model with field aliases and comprehensive documentation
  - GetCommandTemplatesResponse, DescribeCommandTemplateResponse: Response wrappers
  - CommandTemplateDetail: Detailed template with commands and rules
  - RuleEvaluation: Rule validation result model
  - CommandResult: Device command execution with rule evaluation
  - RunCommandTemplateResponse, RunCommandResponse: Execution result models
  - DeviceCommandResult: Simple device command result

- Implement MOP service class with comprehensive functionality
  - get_command_templates(): Retrieve all available templates
  - describe_command_template(): Get detailed template information with project support
  - run_command_template(): Execute templates against devices with rule evaluation
  - run_command(): Run individual commands on multiple devices
  - _get_project_id_from_name(): Helper for project ID resolution with error handling

- Enhance command_templates.py tools with model integration
  - Update all function signatures to use proper return type annotations
  - Integrate with MOP service for API calls instead of direct client usage
  - Add comprehensive response parsing with proper model instantiation
  - Remove duplicate helper functions and use service methods

- Add comprehensive test coverage (39 test cases total)
  - test_models_command_templates.py: 20 tests covering all models with validation, edge cases, and error scenarios
  - test_services_mop.py: 19 tests covering all service methods with success/failure scenarios, project handling, and API error cases