### PR TITLE
refactor: Default bindings tag is now `bindings`

### DIFF
--- a/docs/endpoint-tools.md
+++ b/docs/endpoint-tools.md
@@ -281,7 +281,7 @@ For endpoint tools to work properly, the Itential Platform automation must have:
 
 Tags control tool visibility and can be used for filtering. Endpoint tools automatically get these tags:
 
-- `dynamic` - Added to all dynamically created tools
+- `bindings` - Added to all dynamically created tools
 - The tool's `name` value from configuration
 - Any additional tags specified in the `tags` field
 
@@ -382,7 +382,7 @@ Endpoint tools work alongside the standard MCP tools. You can mix and match:
 ```ini
 [server]
 # Include both standard operations tools and custom endpoint tools
-include_tags = operations,dynamic,custom-workflows
+include_tags = operations,bindings,custom-workflows
 exclude_tags = experimental
 
 [tool:custom-provisioning]
@@ -394,7 +394,7 @@ tags = custom-workflows
 
 This configuration would provide access to:
 - Standard operations manager tools (tagged with `operations`)
-- Your custom endpoint tool (tagged with `dynamic` and `custom-workflows`)
+- Your custom endpoint tool (tagged with `bindings` and `custom-workflows`)
 - All other default tools
 
 ## Troubleshooting

--- a/src/itential_mcp/bindings/__init__.py
+++ b/src/itential_mcp/bindings/__init__.py
@@ -16,7 +16,6 @@ from .. import client
 logger = get_logger(__name__)
 
 
-
 def _import_binding(module_name: str) -> ModuleType:
     """Dynamically import a binding module by name.
 
@@ -82,7 +81,7 @@ async def bind_to_tool(
 
     kwargs["description"] = description
 
-    tags = f"dynamic,{tool.name}"
+    tags = f"bindings,{tool.name}"
 
     if tool.tags is not None:
         tags = f"{tags},{tool.tags}"

--- a/tests/test_bindings_init.py
+++ b/tests/test_bindings_init.py
@@ -109,7 +109,7 @@ class TestBindToTool:
         assert callable(fn)
         assert kwargs["name"] == "test_tool_name"
         assert kwargs["exclude_args"] == ("_tool_config",)
-        assert kwargs["tags"] == ["dynamic", "test-tool", "tag1", "tag2"]
+        assert kwargs["tags"] == ["bindings", "test-tool", "tag1", "tag2"]
 
     @patch("itential_mcp.bindings._import_binding")
     @pytest.mark.asyncio
@@ -135,7 +135,7 @@ class TestBindToTool:
         assert callable(fn)
         assert kwargs["name"] == "test_tool_name"
         assert kwargs["exclude_args"] == ("_tool_config",)
-        assert kwargs["tags"] == ["dynamic", "test-tool"]
+        assert kwargs["tags"] == ["bindings", "test-tool"]
 
     @patch("itential_mcp.bindings._import_binding")
     @pytest.mark.asyncio
@@ -335,7 +335,7 @@ class TestBindingsIntegration:
         assert callable(bound_fn)
         assert bound_kwargs["name"] == "test_workflow"
         assert bound_kwargs["exclude_args"] == ("_tool_config",)
-        assert bound_kwargs["tags"] == ["dynamic", "test-workflow", "workflow", "automation"]
+        assert bound_kwargs["tags"] == ["bindings", "test-workflow", "workflow", "automation"]
 
         # Verify the endpoint module was called correctly
         mock_endpoint_module.new.assert_called_once_with(


### PR DESCRIPTION
All dynamically added tools are now tagged with `bindings` instead of `dynamic`.  The `bindings` tag can be used to either include or exclude all dynamic bindings.