### PR TITLE
Change Device.deviceType and Device.status to optional.

### DIFF
--- a/src/itential_mcp/models/devices.py
+++ b/src/itential_mcp/models/devices.py
@@ -46,8 +46,9 @@ class Device(BaseModel):
     ]
 
     deviceType: Annotated[
-        str,
+        str | None,
         Field(
+            default=None,
             description=inspect.cleandoc(
                 """
                 The type of device (e.g., 'cisco_ios', 'juniper')
@@ -57,8 +58,9 @@ class Device(BaseModel):
     ]
 
     status: Annotated[
-        str,
+        str | None,
         Field(
+            default=None,
             description=inspect.cleandoc(
                 """
                 Current operational status of the device

--- a/tests/test_models_devices.py
+++ b/tests/test_models_devices.py
@@ -49,16 +49,20 @@ class TestDevice:
         assert device.location == "datacenter-a"
         assert device.vendor == "cisco"
 
-    def test_device_missing_required_fields(self):
-        """Test that Device validation fails with missing required fields."""
+    def test_device_missing_optional_fields(self):
+        """Test that Device allows missing optional fields with default values."""
         device_data = {
             "name": "router-1",
             "host": "192.168.1.1",
-            # Missing deviceType and status
+            # Missing deviceType and status - should default to None
         }
 
-        with pytest.raises(ValidationError):
-            Device(**device_data)
+        device = Device(**device_data)
+        
+        assert device.name == "router-1"
+        assert device.host == "192.168.1.1"
+        assert device.deviceType is None
+        assert device.status is None
 
 
 class TestGetDevicesResponse:


### PR DESCRIPTION
Updated tests file accordingly. In some weird circumstances you'll get this from devices. 

{
        "name": "XRV9K-ATL-1",
        "host": "selab-iag-4.4",
        "deviceType": null,
        "status": null,
        "hostKeyChecking": "0",
        "user": "admin",
        "port": 22,
        "password": "admin",
        "ostype": "cisco-iosxr",
        "ipaddress": "172.20.100.63",
        "device-type": "network_cli",
        "actions": [
            "deleteDevice",
            "getConfig",
            "getDevice",
            "getDevicesFiltered",
            "getOperationalData",
            "isAlive",
            "loadConfig",
            "restoreConfig",
            "runCommand",
            "setConfig"
        ],
        "origins": [
            "selab-iag-4.4"
        ]
    }