### PR TITLE
Fix TextFSM Template Validation Issues

### DIFF
--- a/src/itential_mcp/models/automation_studio.py
+++ b/src/itential_mcp/models/automation_studio.py
@@ -73,8 +73,8 @@ class TextFSMTemplate(BaseModel):
     type: str = Field(default="textfsm", description="Template type (textfsm)")
     created: str = Field(description="Creation timestamp")
     lastUpdated: str = Field(description="Last update timestamp")
-    createdBy: dict[str, Any] = Field(description="Creator information")
-    lastUpdatedBy: dict[str, Any] = Field(description="Last updater information")
+    createdBy: str = Field(description="Creator user ID")
+    lastUpdatedBy: str = Field(description="Last updater user ID")
     tags: list[str] = Field(default_factory=list, description="Template tags")
 
 

--- a/src/itential_mcp/models/automation_studio.py
+++ b/src/itential_mcp/models/automation_studio.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from typing import List, Optional, Any
+from typing import List, Optional
 from pydantic import BaseModel, Field
 
 

--- a/src/itential_mcp/tools/textfsm_templates.py
+++ b/src/itential_mcp/tools/textfsm_templates.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from typing import Annotated, Sequence
+from typing import Annotated
 
 from pydantic import Field
 

--- a/src/itential_mcp/tools/textfsm_templates.py
+++ b/src/itential_mcp/tools/textfsm_templates.py
@@ -15,10 +15,10 @@ __tags__ = ("automation_studio", "textfsm")
 async def get_textfsm_templates(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     include: Annotated[
-        Sequence[str] | None,
+        str | None,
         Field(
-            description="Fields to include in the response (_id,name,group)",
-            default=("_id", "name", "group"),
+            description="Comma-separated fields to include in the response (e.g., '_id,name,group,command')",
+            default="_id,name,group",
         ),
     ],
     exclude_project_members: Annotated[
@@ -41,8 +41,13 @@ async def get_textfsm_templates(
 
     client = ctx.request_context.lifespan_context.get("client")
 
+    # Convert comma-separated string to list if needed
+    include_list = None
+    if include:
+        include_list = [field.strip() for field in include.split(",")]
+
     return await client.automation_studio.get_templates(
-        include=include,
+        include=include_list,
         exclude_project_members=exclude_project_members,
         limit=limit,
         sort=sort,

--- a/tests/test_models_textfsm.py
+++ b/tests/test_models_textfsm.py
@@ -20,22 +20,8 @@ class TestTextFSMTemplate:
             "type": "textfsm",
             "created": "2025-09-11T19:15:17.397Z",
             "lastUpdated": "2025-09-11T19:15:17.397Z",
-            "createdBy": {
-                "_id": "67eaf8b49b093bfbf0e62a9f",
-                "provenance": "Okta SAML",
-                "username": "ankit.bhansali@itential.com",
-                "firstname": "Ankit",
-                "inactive": False,
-                "email": "ankit.bhansali@itential.com"
-            },
-            "lastUpdatedBy": {
-                "_id": "67eaf8b49b093bfbf0e62a9f",
-                "provenance": "Okta SAML",
-                "username": "ankit.bhansali@itential.com",
-                "firstname": "Ankit",
-                "inactive": False,
-                "email": "ankit.bhansali@itential.com"
-            },
+            "createdBy": "67eaf8b49b093bfbf0e62a9f",
+            "lastUpdatedBy": "67eaf8b49b093bfbf0e62a9f",
             "tags": []
         }
 
@@ -110,22 +96,8 @@ EOF""",
             "type": "textfsm",
             "created": "2025-09-11T19:15:17.397Z",
             "lastUpdated": "2025-09-11T19:18:00.060Z",
-            "createdBy": {
-                "_id": "67eaf8b49b093bfbf0e62a9f",
-                "provenance": "Okta SAML",
-                "username": "ankit.bhansali@itential.com",
-                "firstname": "Ankit",
-                "inactive": False,
-                "email": "ankit.bhansali@itential.com"
-            },
-            "lastUpdatedBy": {
-                "_id": "67eaf8b49b093bfbf0e62a9f",
-                "provenance": "Okta SAML",
-                "username": "ankit.bhansali@itential.com",
-                "firstname": "Ankit",
-                "inactive": False,
-                "email": "ankit.bhansali@itential.com"
-            },
+            "createdBy": "67eaf8b49b093bfbf0e62a9f",
+            "lastUpdatedBy": "67eaf8b49b093bfbf0e62a9f",
             "tags": []
         }
 
@@ -196,22 +168,8 @@ class TestCreateTextFSMTemplateResponse:
                 "type": "textfsm",
                 "created": "2025-09-11T19:15:17.397Z",
                 "lastUpdated": "2025-09-11T19:15:17.397Z",
-                "createdBy": {
-                    "_id": "67eaf8b49b093bfbf0e62a9f",
-                    "provenance": "Okta SAML",
-                    "username": "ankit.bhansali@itential.com",
-                    "firstname": "Ankit",
-                    "inactive": False,
-                    "email": "ankit.bhansali@itential.com"
-                },
-                "lastUpdatedBy": {
-                    "_id": "67eaf8b49b093bfbf0e62a9f",
-                    "provenance": "Okta SAML",
-                    "username": "ankit.bhansali@itential.com",
-                    "firstname": "Ankit",
-                    "inactive": False,
-                    "email": "ankit.bhansali@itential.com"
-                },
+                "createdBy": "67eaf8b49b093bfbf0e62a9f",
+                "lastUpdatedBy": "67eaf8b49b093bfbf0e62a9f",
                 "tags": []
             },
             "edit": "/automation-studio/#/edit?tab=0&template=68c31fc5f7a1e4d40186b6d5"
@@ -264,22 +222,8 @@ class TestUpdateTextFSMTemplateResponse:
                 "type": "textfsm",
                 "created": "2025-09-11T19:15:17.397Z",
                 "lastUpdated": "2025-09-11T19:18:00.060Z",
-                "createdBy": {
-                    "_id": "67eaf8b49b093bfbf0e62a9f",
-                    "provenance": "Okta SAML",
-                    "username": "ankit.bhansali@itential.com",
-                    "firstname": "Ankit",
-                    "inactive": False,
-                    "email": "ankit.bhansali@itential.com"
-                },
-                "lastUpdatedBy": {
-                    "_id": "67eaf8b49b093bfbf0e62a9f",
-                    "provenance": "Okta SAML",
-                    "username": "ankit.bhansali@itential.com",
-                    "firstname": "Ankit",
-                    "inactive": False,
-                    "email": "ankit.bhansali@itential.com"
-                },
+                "createdBy": "67eaf8b49b093bfbf0e62a9f",
+                "lastUpdatedBy": "67eaf8b49b093bfbf0e62a9f",
                 "tags": []
             },
             "edit": "/automation-studio/#/edit?tab=0&template=68c31fc5f7a1e4d40186b6d5"

--- a/tests/test_tools_textfsm_templates.py
+++ b/tests/test_tools_textfsm_templates.py
@@ -100,19 +100,9 @@ class TestTextFSMTemplatesTools:
                 "data": "ip access-list extended sample\n permit tcp host 10.1.1.1 any\n deny ip any any",
                 "command": "show access-list",
                 "created": "2025-01-11T10:00:00.000Z",
-                "createdBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                },
+                "createdBy": "user123",
                 "lastUpdated": "2025-01-11T10:00:00.000Z",
-                "lastUpdatedBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                }
+                "lastUpdatedBy": "user123"
             },
             "edit": "/automation-studio/#/edit?tab=0&template=template123"
         }
@@ -203,19 +193,9 @@ class TestTextFSMTemplatesTools:
                 "data": "ip access-list extended updated\n permit tcp host 10.1.1.1 any\n deny ip any any",
                 "command": "show access-list",
                 "created": "2025-01-11T10:00:00.000Z",
-                "createdBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                },
+                "createdBy": "user123",
                 "lastUpdated": "2025-01-11T11:00:00.000Z",
-                "lastUpdatedBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                }
+                "lastUpdatedBy": "user123"
             },
             "edit": "/automation-studio/#/edit?tab=0&template=template123"
         }

--- a/tests/test_tools_textfsm_templates.py
+++ b/tests/test_tools_textfsm_templates.py
@@ -45,7 +45,7 @@ class TestTextFSMTemplatesTools:
         
         result = await textfsm_templates.get_textfsm_templates(
             ctx=mock_context,
-            include=("_id", "name", "group"),
+            include="_id,name,group",
             exclude_project_members=True,
             limit=50,
             sort="group",
@@ -54,7 +54,7 @@ class TestTextFSMTemplatesTools:
         
         assert result == expected_response
         mock_client.automation_studio.get_templates.assert_called_once_with(
-            include=("_id", "name", "group"),
+            include=["_id", "name", "group"],
             exclude_project_members=True,
             limit=50,
             sort="group",
@@ -70,7 +70,7 @@ class TestTextFSMTemplatesTools:
         
         result = await textfsm_templates.get_textfsm_templates(
             ctx=mock_context,
-            include=("_id", "name"),
+            include="_id,name",
             exclude_project_members=False,
             limit=25,
             sort="name",
@@ -79,7 +79,7 @@ class TestTextFSMTemplatesTools:
         
         assert result == expected_response
         mock_client.automation_studio.get_templates.assert_called_once_with(
-            include=("_id", "name"),
+            include=["_id", "name"],
             exclude_project_members=False,
             limit=25,
             sort="name",
@@ -157,18 +157,8 @@ class TestTextFSMTemplatesTools:
                 "command": "",
                 "created": "2025-01-11T10:00:00.000Z",
                 "lastUpdated": "2025-01-11T10:00:00.000Z",
-                "createdBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                },
-                "lastUpdatedBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                },
+                "createdBy": "user123",
+                "lastUpdatedBy": "user123",
                 "tags": []
             },
             "edit": "/automation-studio/#/edit?tab=0&template=template456"
@@ -273,18 +263,8 @@ class TestTextFSMTemplatesTools:
                 "command": "",
                 "created": "2025-01-11T10:00:00.000Z",
                 "lastUpdated": "2025-01-11T11:00:00.000Z",
-                "createdBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                },
-                "lastUpdatedBy": {
-                    "_id": "user123",
-                    "username": "test@example.com",
-                    "firstname": "Test",
-                    "email": "test@example.com"
-                },
+                "createdBy": "user123",
+                "lastUpdatedBy": "user123",
                 "tags": []
             },
             "edit": "/automation-studio/#/edit?tab=0&template=template456"


### PR DESCRIPTION
## 🔧 TextFSM Template Validation Fixes

This PR resolves critical validation issues discovered during testing of the TextFSM template functionality.

### 🐛 Issues Fixed

#### 1. Pydantic Validation Error - User ID Fields
**Problem**: The API returns user IDs as strings (e.g., `"6827b8aecb8ecf6e828e848e"`), but our Pydantic models expected dictionaries.

**Error**:
```
2 validation errors for CreateTextFSMTemplateResponse
created.createdBy
  Input should be a valid dictionary [type=dict_type, input_value='6827b8aecb8ecf6e828e848e', input_type=str]
created.lastUpdatedBy
  Input should be a valid dictionary [type=dict_type, input_value='6827b8aecb8ecf6e828e848e', input_type=str]
```

**Solution**: Updated `TextFSMTemplate` model to expect `createdBy` and `lastUpdatedBy` as strings instead of dictionaries.

#### 2. Input Validation Error - Include Parameter
**Problem**: The `include` parameter was being passed as a string `'["_id", "name", "group", "command"]'` but validation expected a list.

**Error**:
```
Input validation error: '["_id", "name", "group", "command"]' is not valid under any of the given schemas
```

**Solution**: Modified `get_textfsm_templates` tool to accept comma-separated strings and convert them to lists internally.

### 🔄 Changes Made

#### Model Updates (`src/itential_mcp/models/automation_studio.py`)
- Changed `createdBy` field from `dict[str, Any]` to `str`
- Changed `lastUpdatedBy` field from `dict[str, Any]` to `str`
- Updated field descriptions to reflect correct data types

#### Tool Updates (`src/itential_mcp/tools/textfsm_templates.py`)
- Modified `get_textfsm_templates` to accept `include` as comma-separated string
- Added string-to-list conversion logic: `[field.strip() for field in include.split(",")]`
- Updated parameter description to show correct format

#### Test Updates
- Updated all test data in `tests/test_models_textfsm.py` to use string user IDs
- Updated all test data in `tests/test_tools_textfsm_templates.py` to use string user IDs
- Fixed test assertions to expect converted list format

### ✅ Testing

All tests now pass:
- ✅ `tests/test_models_textfsm.py` - 7/7 tests passing
- ✅ `tests/test_tools_textfsm_templates.py` - 6/6 tests passing

### 🎯 Impact

These fixes resolve the validation errors that were preventing:
- ✅ Creating TextFSM templates via `create_textfsm_template`
- ✅ Listing TextFSM templates via `get_textfsm_templates`
- ✅ Updating TextFSM templates via `update_textfsm_template`

The TextFSM template functionality is now fully operational and compatible with the actual Itential Platform API responses.

### 📋 Files Changed
- `src/itential_mcp/models/automation_studio.py`
- `src/itential_mcp/tools/textfsm_templates.py`
- `tests/test_models_textfsm.py`
- `tests/test_tools_textfsm_templates.py`