### PR TITLE
ci: enforce 95% test coverage threshold

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run the permerge target
         run: make premerge
+
+      - name: Run coverage check with 95% threshold
+        run: uv run pytest --cov=itential_mcp --cov-report=term --cov-fail-under=95 tests/


### PR DESCRIPTION
Add coverage check step to GitHub premerge workflow that fails if test coverage drops below 95%. This ensures code quality standards are maintained in pull requests.