### PR TITLE
feat: add support for Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,101 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+      - 'deps'
+      - 'refactor'
+  - title: '📚 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '⚠️ Breaking Changes'
+    labels:
+      - 'breaking'
+      - 'breaking-change'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'chore'
+      - 'dependencies'
+      - 'deps'
+      - 'documentation'
+      - 'docs'
+      - 'security'
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+exclude-labels:
+  - 'skip-changelog'
+  - 'duplicate'
+  - 'question'
+  - 'invalid'
+  - 'wontfix'
+
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**/*'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'feature'
+    branch:
+      - '/feature\/.+/'
+      - '/feat\/.+/'
+    title:
+      - '/feat/i'
+      - '/feature/i'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/chore/i'
+  - label: 'dependencies'
+    files:
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'Pipfile'
+      - 'Pipfile.lock'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,28 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - devel
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release Notes as Pull Requests are merged into "devel"
+      - uses: release-drafter/release-drafter@v6
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 # .github/workflows/release.yml
-# This workflow will create a new release and upload it to PyPI.  It will run
-# whenever a new tag is merged into the repository.  It builds the application
-# and pushes it to PyPI.
+# This workflow will create a new release, publish it to GitHub releases, and upload it to PyPI.
+# It will run whenever a new tag is merged into the repository. It builds the application
+# and pushes it to both GitHub releases and PyPI.
 ---
-name: Deploy package to PyPI
+name: Release and Deploy package
 
 on:
   push:
@@ -36,7 +36,22 @@ jobs:
       - name: Build package
         run: uv run python -m build
 
-      - name: Publish to PyPI or TestPyPI
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ steps.version.outputs.version }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+
+      - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,34 @@ conneting Itential Plaform to AI agents.
 - Coverage reports generated in `htmlcov/`
 - All tests must pass before merging (`make premerge`)
 
+## Pull Request Labels
+
+This project uses Release Drafter to automatically generate release notes. To ensure proper categorization of changes, please use the following labels on your pull requests:
+
+### Change Type Labels
+- `feature`, `enhancement` - New features and enhancements
+- `fix`, `bug`, `bugfix` - Bug fixes and corrections
+- `chore`, `dependencies`, `refactor` - Maintenance, dependency updates, and refactoring
+- `documentation`, `docs` - Documentation changes
+- `security` - Security fixes and improvements
+- `breaking`, `breaking-change` - Breaking changes that require major version bump
+
+### Version Impact
+- `major` - Breaking changes (increments major version)
+- `minor` - New features (increments minor version)  
+- `patch` - Bug fixes and maintenance (increments patch version)
+
+### Auto-Labeling
+The Release Drafter will automatically apply labels based on:
+- **Branch names**: `feature/`, `fix/`, `chore/` prefixes
+- **File changes**: Documentation files, dependency files
+- **PR titles**: Keywords like "feat", "fix", "chore"
+
+### Excluded Labels
+These labels will be excluded from release notes:
+- `skip-changelog` - Explicitly exclude from changelog
+- `duplicate`, `question`, `invalid`, `wontfix` - Issues that don't represent changes
+
 ## Dependencies
 
 - **FastMCP**: Model Context Protocol framework


### PR DESCRIPTION
• Add Release Drafter configuration with categorized change types • Add GitHub workflow for automated release note generation • Update release workflow to create GitHub releases alongside PyPI publishing • Document PR labeling guidelines in AGENTS.md for proper categorization