### PR TITLE
fix: update CLA workflow permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
• Change contents permission from read to write
• Allows workflow to properly update PR status