### PR TITLE
fix: set the logging level on server start

### DIFF
--- a/src/itential_mcp/logging.py
+++ b/src/itential_mcp/logging.py
@@ -17,15 +17,7 @@ from typing import Literal
 
 from . import metadata
 
-# Configure global logging
 logging_message_format = "%(asctime)s: [%(name)s] %(levelname)s: %(message)s"
-
-# Create a console handler and set it to output to stderr (default for logging)
-# console_handler = logging.StreamHandler(sys.stderr)
-# console_handler.setFormatter(logging.Formatter(logging_message_format))
-
-# Configure the root logger
-# logging.basicConfig(handlers=[console_handler], format=logging_message_format)
 logging.getLogger(metadata.name).setLevel(100)
 
 # Add the FATAL logging level
@@ -144,8 +136,10 @@ def set_level(lvl: int, propagate: bool = False) -> None:
         None
     """
     logger = get_logger()
+
     logger.setLevel(lvl)
     logger.propagate = False
+
     logger.log(logging.INFO, f"{metadata.name} version {metadata.version}")
     logger.log(logging.INFO, f"Logging level set to {lvl}")
 
@@ -388,16 +382,15 @@ def initialize() -> None:
     Returns:
         None
     """
-    for name in logging.Logger.manager.loggerDict:
-        for logger in _get_loggers():
-            handlers = logger.handlers[:]
-            for handler in handlers:
-                logger.removeHandler(handler)
-                handler.close()
+    for logger in _get_loggers():
+        handlers = logger.handlers[:]
+        for handler in handlers:
+            logger.removeHandler(handler)
+            handler.close()
 
-            stream_handler = logging.StreamHandler(sys.stderr)
-            stream_handler.setFormatter(logging.Formatter(logging_message_format))
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setFormatter(logging.Formatter(logging_message_format))
 
-            logger.addHandler(stream_handler)
-            logger.setLevel(100)
-            logger.propagate = False
+        logger.addHandler(stream_handler)
+        logger.setLevel(100)
+        logger.propagate = False

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -253,6 +253,8 @@ async def run() -> int:
     try:
         cfg = config.get()
 
+        logging.set_level(cfg.server_log_level)
+
         mcp = await new(cfg)
 
         kwargs = {
@@ -265,7 +267,6 @@ async def run() -> int:
                 {
                     "host": cfg.server.get("host"),
                     "port": cfg.server.get("port"),
-                    #"log_level": cfg.server.get("log_level"),
                 }
             )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -410,11 +410,13 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
-    async def test_run_stdio_transport_success(self, mock_config_get, mock_new):
+    @patch("itential_mcp.server.logging.set_level")
+    async def test_run_stdio_transport_success(self, mock_set_level, mock_config_get, mock_new):
         """Test successful server run with stdio transport"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -426,6 +428,7 @@ class TestRun:
 
         # Verify
         mock_config_get.assert_called_once()
+        mock_set_level.assert_called_once_with("INFO")
         mock_new.assert_awaited_once_with(mock_config)
 
         # Check server was run with correct parameters
@@ -435,8 +438,9 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_run_sse_transport_success(
-        self, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_new, mock_itertools
     ):
         """Test successful server run with SSE transport"""
         mock_config = MagicMock()
@@ -446,6 +450,7 @@ class TestRun:
             "port": 8000,
             "log_level": "INFO",
         }
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -456,6 +461,7 @@ class TestRun:
 
         await server.run()
 
+        mock_set_level.assert_called_once_with("INFO")
         mock_mcp.run_async.assert_called_once_with(
             transport="sse", host="0.0.0.0", port=8000, show_banner=False
         )
@@ -464,8 +470,9 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_run_http_transport_success(
-        self, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_new, mock_itertools
     ):
         """Test successful server run with HTTP transport"""
         mock_config = MagicMock()
@@ -476,6 +483,7 @@ class TestRun:
             "log_level": "DEBUG",
             "path": "/mcp",
         }
+        mock_config.server_log_level = "DEBUG"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -486,6 +494,7 @@ class TestRun:
 
         await server.run()
 
+        mock_set_level.assert_called_once_with("DEBUG")
         mock_mcp.run_async.assert_called_once_with(
             transport="http",
             host="localhost",
@@ -497,10 +506,12 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
-    async def test_run_tool_registration_failure(self, mock_config_get, mock_new):
+    @patch("itential_mcp.server.logging.set_level")
+    async def test_run_tool_registration_failure(self, mock_set_level, mock_config_get, mock_new):
         """Test server exits when tool registration fails in new()"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         # Make new() raise an exception (simulates tool registration failure)
@@ -519,12 +530,14 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_run_keyboard_interrupt(
-        self, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_new, mock_itertools
     ):
         """Test server handles KeyboardInterrupt gracefully"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -543,12 +556,14 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_run_unexpected_exception(
-        self, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_new, mock_itertools
     ):
         """Test server handles unexpected exceptions"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -569,10 +584,12 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
-    async def test_run_no_tools_loaded(self, mock_config_get, mock_new, mock_itertools):
+    @patch("itential_mcp.server.logging.set_level")
+    async def test_run_no_tools_loaded(self, mock_set_level, mock_config_get, mock_new, mock_itertools):
         """Test server runs successfully even with no tools"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -591,10 +608,12 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
-    async def test_run_multiple_tools_registration(self, mock_config_get, mock_new):
+    @patch("itential_mcp.server.logging.set_level")
+    async def test_run_multiple_tools_registration(self, mock_set_level, mock_config_get, mock_new):
         """Test server properly uses the configured MCP instance from new()"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -610,10 +629,12 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
-    async def test_run_partial_tool_failure(self, mock_config_get, mock_new):
+    @patch("itential_mcp.server.logging.set_level")
+    async def test_run_partial_tool_failure(self, mock_set_level, mock_config_get, mock_new):
         """Test that server fails if new() fails due to tool registration issues"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         # Make new() fail with an ImportError (simulating tool import failure)
@@ -632,13 +653,15 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_run_config_variations(
-        self, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_new, mock_itertools
     ):
         """Test various configuration scenarios"""
         # Test with minimal config
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -655,12 +678,14 @@ class TestRun:
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.new", new_callable=AsyncMock)
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_run_missing_server_config_keys(
-        self, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_new, mock_itertools
     ):
         """Test server handles missing configuration keys gracefully"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "sse"}  # Missing host, port, log_level
+        mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
         mock_mcp = MagicMock()
@@ -684,8 +709,9 @@ class TestIntegration:
     @patch("itential_mcp.server.bindings.iterbindings")
     @patch("itential_mcp.server.toolutils.itertools")
     @patch("itential_mcp.server.config.get")
+    @patch("itential_mcp.server.logging.set_level")
     async def test_full_server_lifecycle(
-        self, mock_config_get, mock_itertools, mock_iterbindings
+        self, mock_set_level, mock_config_get, mock_itertools, mock_iterbindings
     ):
         """Test complete server lifecycle from config to shutdown"""
         # Setup configuration
@@ -695,6 +721,7 @@ class TestIntegration:
             "include_tags": ["system"],
             "exclude_tags": ["deprecated"],
         }
+        mock_config.server_log_level = "INFO"
         mock_config.tools = []
         mock_config_get.return_value = mock_config
 
@@ -722,6 +749,7 @@ class TestIntegration:
 
             # Verify complete flow
             mock_config_get.assert_called_once()
+            mock_set_level.assert_called_once_with("INFO")
 
             # Verify FastMCP was created with correct parameters
             mock_fastmcp_class.assert_called_once_with(


### PR DESCRIPTION
• Remove commented code and unused logic from logging.py • Fix logging initialization to properly iterate over loggers • Set server log level during startup in server.py • Clean up formatting and code organization