### PR TITLE
fix: correct CLI default values

### DIFF
--- a/src/itential_mcp/cli.py
+++ b/src/itential_mcp/cli.py
@@ -197,8 +197,19 @@ def _get_arguments_from_config() -> Sequence[Tuple[str, Sequence, Mapping]]:
         attrs = ele.default.json_schema_extra
         if attrs and attrs.get("x-itential-mcp-cli-enabled"):
             helpstr = ele.default.description
+
+            if hasattr(config.Config, ele.name):
+                attr = getattr(config.Config, ele.name)
+                if hasattr(attr, "default_factory"):
+                    default_value = getattr(config.Config, ele.name).default_factory()
+                elif hasattr(attr, "default"):
+                    default_value = getattr(config.Config, ele.name).default
+            else:
+                default_value = "UNKNOWN"
+
             if helpstr is not None:
-                helpstr += f" (default={ele.default.default})"
+                helpstr += f" (default={default_value})"
+
             else:
                 helpstr = "NO HELP AVAILABLE!!"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,7 +264,7 @@ class TestGetArgumentsFromConfig:
         assert result[0][0] == "server_host"
         assert result[0][1] == ["--host"]
         assert result[0][2]["dest"] == "server_host"
-        assert result[0][2]["help"] == "Server host address (default=localhost)"
+        assert result[0][2]["help"] == "Server host address (default=127.0.0.1)"
         assert result[0][2]["type"] is str
 
     @patch('itential_mcp.cli.fields')


### PR DESCRIPTION
• Fix default value calculation for CLI arguments to use actual Config class defaults 
• Handle both default_factory and direct default attribute access