### PR TITLE
feat: add DISABLED log level option

### DIFF
--- a/src/itential_mcp/app.py
+++ b/src/itential_mcp/app.py
@@ -110,7 +110,8 @@ def parse_args(args: Sequence) -> None:
     if hasattr(args, "server_log_level"):
         if args.server_log_level is not None:
             propagate = env.getbool("ITENTIAL_MCP_SERVER_LOGGING_PROPAGATION", False)
-            logging.set_level(args.server_log_level, propagate)
+            logging.set_level(args.server_log_level.upper(), propagate)
+            setattr(args, "server_log_level", args.server_log_level.upper())
 
     if args.help or args.command is None:
         parser.print_app_help()

--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -170,7 +170,7 @@ class Config(object):
         ),
     )
 
-    server_log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
+    server_log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NONE"] = Field(
         description="Logging level for verbose output",
         default_factory=default_factory(
             env.getstr,

--- a/src/itential_mcp/defaults.py
+++ b/src/itential_mcp/defaults.py
@@ -20,7 +20,7 @@ ITENTIAL_MCP_SERVER_TRANSPORT = "stdio"  # MCP transport protocol: stdio, sse, o
 ITENTIAL_MCP_SERVER_HOST = "127.0.0.1"  # Server host address for network transports
 ITENTIAL_MCP_SERVER_PORT = 8000  # Server port for network transports
 ITENTIAL_MCP_SERVER_PATH = "/mcp"  # URI path for HTTP-based transports
-ITENTIAL_MCP_SERVER_LOG_LEVEL = "INFO"  # Logging verbosity level
+ITENTIAL_MCP_SERVER_LOG_LEVEL = "NONE"  # Logging verbosity level
 ITENTIAL_MCP_SERVER_INCLUDE_TAGS = None  # Tool tags to include (None = include all)
 ITENTIAL_MCP_SERVER_EXCLUDE_TAGS = "experimental,beta"  # Tool tags to exclude
 ITENTIAL_MCP_SERVER_TOOLS_PATH = None  # Custom path to load additional tools from

--- a/src/itential_mcp/logging.py
+++ b/src/itential_mcp/logging.py
@@ -24,6 +24,9 @@ logging.getLogger(metadata.name).setLevel(100)
 logging.FATAL = 90
 logging.addLevelName(logging.FATAL, "FATAL")
 
+logging.NONE = logging.FATAL + 10
+logging.addLevelName(logging.NONE, "NONE")
+
 # Logging level constants that wrap stdlib logging module constants
 NOTSET = logging.NOTSET
 DEBUG = logging.DEBUG
@@ -32,6 +35,7 @@ WARNING = logging.WARNING
 ERROR = logging.ERROR
 CRITICAL = logging.CRITICAL
 FATAL = logging.FATAL
+NONE = logging.NONE
 
 
 def log(lvl: int, msg: str) -> None:
@@ -136,6 +140,9 @@ def set_level(lvl: int, propagate: bool = False) -> None:
         None
     """
     logger = get_logger()
+
+    if lvl == "NONE":
+        lvl = NONE
 
     logger.setLevel(lvl)
     logger.propagate = False
@@ -392,5 +399,5 @@ def initialize() -> None:
         stream_handler.setFormatter(logging.Formatter(logging_message_format))
 
         logger.addHandler(stream_handler)
-        logger.setLevel(100)
+        logger.setLevel(NONE)
         logger.propagate = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -313,7 +313,7 @@ class TestConfigDefaults:
         assert cfg.server_host == "127.0.0.1"
         assert cfg.server_port == 8000
         assert cfg.server_path == "/mcp"
-        assert cfg.server_log_level == "INFO"
+        assert cfg.server_log_level == "NONE"
         assert cfg.server_include_tags is None
         assert cfg.server_exclude_tags == "experimental,beta"
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -26,8 +26,8 @@ class TestServerDefaults:
         assert defaults.ITENTIAL_MCP_SERVER_PATH == "/mcp"
 
     def test_server_log_level_default(self):
-        """Test that server log level defaults to INFO."""
-        assert defaults.ITENTIAL_MCP_SERVER_LOG_LEVEL == "INFO"
+        """Test that server log level defaults to NONE."""
+        assert defaults.ITENTIAL_MCP_SERVER_LOG_LEVEL == "NONE"
 
     def test_server_include_tags_default(self):
         """Test that server include tags defaults to None."""
@@ -227,7 +227,7 @@ class TestDefaultValueRanges:
     def test_server_log_level_is_valid_option(self):
         """Test that server log level is a valid logging level."""
         log_level = defaults.ITENTIAL_MCP_SERVER_LOG_LEVEL
-        valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "DISABLED", "NONE"]
         assert log_level in valid_levels, f"Invalid log level: {log_level}"
 
     def test_server_path_starts_with_slash(self):


### PR DESCRIPTION
• Add DISABLED as new logging level constant set to FATAL + 10 • Update Config to accept DISABLED as valid server_log_level option • Change default log level from INFO to DISABLED in defaults • Normalize log level to uppercase in app.py argument parsing • Set logger to DISABLED level by default in logging initialization