### PR TITLE
fix: resolve data structure mismatch in get_services tool

### DIFF
--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -46,7 +46,7 @@ async def get_services(
 
     results = []
 
-    for ele in data["result"]:
+    for ele in data:
         results.append(models.ServiceElement(
             name=ele["service_metadata"]["name"],
             cluster=ele["service_metadata"]["location"],

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -52,58 +52,57 @@ class TestGetServices(TestGatewayManagerTools):
 
     def create_mock_services_data(self):
         """Create mock services data for testing."""
-        return {
-            "result": [
-                {
-                    "service_metadata": {
-                        "name": "backup-service",
-                        "location": "cluster-east",
-                        "type": "ansible-playbook",
-                        "description": "Automated backup service",
-                        "decorator": {
-                            "type": "object",
-                            "properties": {
-                                "backup_path": {"type": "string"},
-                                "retention_days": {"type": "integer", "default": 7}
-                            },
-                            "required": ["backup_path"]
-                        }
+        # Return just the services array, as the service layer strips the "result" wrapper
+        return [
+            {
+                "service_metadata": {
+                    "name": "backup-service",
+                    "location": "cluster-east",
+                    "type": "ansible-playbook",
+                    "description": "Automated backup service",
+                    "decorator": {
+                        "type": "object",
+                        "properties": {
+                            "backup_path": {"type": "string"},
+                            "retention_days": {"type": "integer", "default": 7}
+                        },
+                        "required": ["backup_path"]
                     }
-                },
-                {
-                    "service_metadata": {
-                        "name": "deploy-service",
-                        "location": "cluster-west",
-                        "type": "python-script",
-                        "description": "Application deployment service",
-                        "decorator": {
-                            "type": "object",
-                            "properties": {
-                                "app_name": {"type": "string"},
-                                "version": {"type": "string"},
-                                "environment": {"type": "string", "enum": ["dev", "staging", "prod"]}
-                            },
-                            "required": ["app_name", "version", "environment"]
-                        }
+                }
+            },
+            {
+                "service_metadata": {
+                    "name": "deploy-service",
+                    "location": "cluster-west",
+                    "type": "python-script",
+                    "description": "Application deployment service",
+                    "decorator": {
+                        "type": "object",
+                        "properties": {
+                            "app_name": {"type": "string"},
+                            "version": {"type": "string"},
+                            "environment": {"type": "string", "enum": ["dev", "staging", "prod"]}
+                        },
+                        "required": ["app_name", "version", "environment"]
                     }
-                },
-                {
-                    "service_metadata": {
-                        "name": "infrastructure-service",
-                        "location": "cluster-central",
-                        "type": "opentofu-plan",
-                        "description": "Infrastructure provisioning service",
-                        "decorator": {
-                            "type": "object",
-                            "properties": {
-                                "terraform_config": {"type": "string"},
-                                "apply": {"type": "boolean", "default": False}
-                            }
+                }
+            },
+            {
+                "service_metadata": {
+                    "name": "infrastructure-service",
+                    "location": "cluster-central",
+                    "type": "opentofu-plan",
+                    "description": "Infrastructure provisioning service",
+                    "decorator": {
+                        "type": "object",
+                        "properties": {
+                            "terraform_config": {"type": "string"},
+                            "apply": {"type": "boolean", "default": False}
                         }
                     }
                 }
-            ]
-        }
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_get_services_success(self):
@@ -146,7 +145,7 @@ class TestGetServices(TestGatewayManagerTools):
     @pytest.mark.asyncio
     async def test_get_services_empty_result(self):
         """Test get_services with empty result."""
-        mock_data = {"result": []}
+        mock_data = []  # Return empty array directly
         self.mock_client.gateway_manager.get_services.return_value = mock_data
 
         result = await get_services(self.mock_context)
@@ -157,19 +156,17 @@ class TestGetServices(TestGatewayManagerTools):
     @pytest.mark.asyncio
     async def test_get_services_single_service(self):
         """Test get_services with single service."""
-        mock_data = {
-            "result": [
-                {
-                    "service_metadata": {
-                        "name": "single-service",
-                        "location": "single-cluster",
-                        "type": "custom-script",
-                        "description": "Single service test",
-                        "decorator": {}
-                    }
+        mock_data = [
+            {
+                "service_metadata": {
+                    "name": "single-service",
+                    "location": "single-cluster",
+                    "type": "custom-script",
+                    "description": "Single service test",
+                    "decorator": {}
                 }
-            ]
-        }
+            }
+        ]
         self.mock_client.gateway_manager.get_services.return_value = mock_data
 
         result = await get_services(self.mock_context)
@@ -181,40 +178,38 @@ class TestGetServices(TestGatewayManagerTools):
     @pytest.mark.asyncio
     async def test_get_services_with_complex_decorators(self):
         """Test get_services with complex decorator schemas."""
-        mock_data = {
-            "result": [
-                {
-                    "service_metadata": {
-                        "name": "complex-service",
-                        "location": "complex-cluster",
-                        "type": "ansible-playbook",
-                        "description": "Service with complex decorator",
-                        "decorator": {
-                            "type": "object",
-                            "properties": {
-                                "config": {
-                                    "type": "object",
-                                    "properties": {
-                                        "timeout": {"type": "integer", "minimum": 1, "maximum": 3600},
-                                        "retries": {"type": "integer", "default": 3}
-                                    }
-                                },
-                                "hosts": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "minItems": 1
-                                },
-                                "variables": {
-                                    "type": "object",
-                                    "additionalProperties": True
+        mock_data = [
+            {
+                "service_metadata": {
+                    "name": "complex-service",
+                    "location": "complex-cluster",
+                    "type": "ansible-playbook",
+                    "description": "Service with complex decorator",
+                    "decorator": {
+                        "type": "object",
+                        "properties": {
+                            "config": {
+                                "type": "object",
+                                "properties": {
+                                    "timeout": {"type": "integer", "minimum": 1, "maximum": 3600},
+                                    "retries": {"type": "integer", "default": 3}
                                 }
                             },
-                            "required": ["hosts"]
-                        }
+                            "hosts": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 1
+                            },
+                            "variables": {
+                                "type": "object",
+                                "additionalProperties": True
+                            }
+                        },
+                        "required": ["hosts"]
                     }
                 }
-            ]
-        }
+            }
+        ]
         self.mock_client.gateway_manager.get_services.return_value = mock_data
 
         result = await get_services(self.mock_context)
@@ -840,16 +835,14 @@ class TestGatewayManagerErrorHandling:
     @pytest.mark.asyncio
     async def test_get_services_missing_service_metadata(self):
         """Test get_services handling malformed service data."""
-        mock_data = {
-            "result": [
-                {
-                    # Missing service_metadata key
-                    "metadata": {
-                        "name": "broken-service"
-                    }
+        mock_data = [
+            {
+                # Missing service_metadata key
+                "metadata": {
+                    "name": "broken-service"
                 }
-            ]
-        }
+            }
+        ]
 
         self.mock_client.gateway_manager = MagicMock()
         self.mock_client.gateway_manager.get_services = AsyncMock(return_value=mock_data)


### PR DESCRIPTION
The get_services tool was incorrectly accessing data['result'] when the service layer already returns the services array directly. This caused a 'list indices must be integers or slices, not str' error.

Changes:
- Fixed tool layer to iterate directly over services array
- Updated test mocks to match actual service layer behavior
- All 31 gateway manager tests now pass

Fixes the reported issue with get_services tool failing on data access.