### PR TITLE
Added capability to parse out string inputs to handle Claude behavior

### DIFF
--- a/src/itential_mcp/bindings/endpoint.py
+++ b/src/itential_mcp/bindings/endpoint.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from itential_mcp import config
 from itential_mcp import client
 from itential_mcp import exceptions
+from itential_mcp import jsonutils
 
 from itential_mcp.tools import operations_manager
 
@@ -70,7 +71,7 @@ async def _get_trigger(platform_client: client.PlatformClient, t: config.Endpoin
 async def start_workflow(
     ctx: Context,
     _tool_config: config.EndpointTool | None = None,
-    data: dict | None = None,
+    data: dict | str | None = None,
 ) -> BaseModel:
     """Start a workflow using the configured endpoint trigger.
 
@@ -94,6 +95,10 @@ async def start_workflow(
     platform_client = ctx.request_context.lifespan_context.get("client")
 
     trigger = await _get_trigger(platform_client, _tool_config)
+
+    # Parse data if it's a JSON string
+    if isinstance(data, str):
+        data = jsonutils.loads(data)
 
     return await operations_manager.start_workflow(
         ctx, route_name=trigger["routeName"], data=data

--- a/src/itential_mcp/bindings/service.py
+++ b/src/itential_mcp/bindings/service.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from itential_mcp import config
 from itential_mcp import client
 from itential_mcp import exceptions
+from itential_mcp import jsonutils
 
 from itential_mcp.tools import gateway_manager
 
@@ -44,7 +45,7 @@ async def _get_service(platform_client: client.PlatformClient, t: config.Endpoin
 async def run_service(
     ctx: Context,
     _tool_config: config.Tool | None = None,
-    input_params: dict| None = None
+    input_params: dict | str | None = None
 ) -> BaseModel:
     """Execute a service on the Itential Platform using the configured tool settings.
 
@@ -67,6 +68,10 @@ async def run_service(
 
     service_name = service["service_metadata"]["name"]
     cluster = service["service_metadata"]["location"]
+
+    # Parse input_params if it's a JSON string
+    if isinstance(input_params, str):
+        input_params = jsonutils.loads(input_params)
 
     return await gateway_manager.run_service(
         ctx, name=service_name, cluster=cluster, input_params=input_params

--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from pydantic import Field
 
 from fastmcp import Context
+from itential_mcp import jsonutils
 from itential_mcp.models import command_templates as models
 
 
@@ -213,7 +214,7 @@ async def create_command_template(
     name: Annotated[str, Field(
         description="Name for the command template"
     )],
-    commands: Annotated[list[dict], Field(
+    commands: Annotated[list[dict] | str, Field(
         description="List of commands with their validation rules"
     )],
     project: Annotated[str | None, Field(
@@ -321,6 +322,10 @@ async def create_command_template(
 
     client = ctx.request_context.lifespan_context.get("client")
 
+    # Parse commands if it's a JSON string
+    if isinstance(commands, str):
+        commands = jsonutils.loads(commands)
+
     data = await client.mop.create_command_template(
         name=name,
         commands=commands,
@@ -341,7 +346,7 @@ async def update_command_template(
     name: Annotated[str, Field(
         description="Name of the command template to update"
     )],
-    commands: Annotated[list[dict], Field(
+    commands: Annotated[list[dict] | str, Field(
         description="List of commands with their validation rules"
     )],
     project: Annotated[str | None, Field(
@@ -448,6 +453,10 @@ async def update_command_template(
     await ctx.info("inside update_command_template(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
+
+    # Parse commands if it's a JSON string
+    if isinstance(commands, str):
+        commands = jsonutils.loads(commands)
 
     data = await client.mop.update_command_template(
         name=name,

--- a/src/itential_mcp/tools/configuration_manager.py
+++ b/src/itential_mcp/tools/configuration_manager.py
@@ -7,6 +7,7 @@ from pydantic import Field
 
 from fastmcp import Context
 
+from itential_mcp import jsonutils
 from itential_mcp.models import configuration_manager as models
 
 
@@ -20,7 +21,7 @@ async def render_template(
     template: Annotated[str, Field(
         description="The Jinja2 template string"
     )],
-    variables: Annotated[dict, Field(
+    variables: Annotated[dict | str | None, Field(
         description="Zero or more variables to associate with this template",
         default=None,
     )],
@@ -45,6 +46,11 @@ async def render_template(
     """
     await ctx.info("inside render_template()")
     client = ctx.request_context.lifespan_context.get("client")
+    
+    # Parse variables if it's a JSON string
+    if isinstance(variables, str):
+        variables = jsonutils.loads(variables)
+    
     data = client.configuration_manager.render_template(
         template=template, variables=variables
     )

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -8,6 +8,7 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp import jsonutils
+from itential_mcp import exceptions
 
 from itential_mcp.models import gateway_manager as models
 
@@ -149,10 +150,12 @@ async def run_service(
     if "error" in res:
         raise ValueError(res["error"]["data"])
 
+    # Attempt to parse stdout as JSON, but keep raw string if parsing fails
     try:
         stdout_json = jsonutils.loads(res["result"]["stdout"])
         res["result"]["stdout"] = stdout_json
-    except Exception:
+    except (exceptions.ValidationException, ValueError, TypeError):
+        # Not valid JSON, keep as raw string
         pass
 
     return models.RunServiceResponse(**res["result"])

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -8,7 +8,6 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp import jsonutils
-from itential_mcp.exceptions import ValidationException
 
 from itential_mcp.models import gateway_manager as models
 
@@ -110,7 +109,7 @@ async def run_service(
     cluster: Annotated[str, Field(
         description="The name of the cluster where the service lives"
     )],
-    input_params: Annotated[dict, Field(
+    input_params: Annotated[dict | str | None, Field(
         description="Optional input parameters to pass to the service",
         default=None
     )]
@@ -141,6 +140,10 @@ async def run_service(
 
     client = ctx.request_context.lifespan_context.get("client")
 
+    # Parse input_params if it's a JSON string
+    if isinstance(input_params, str):
+        input_params = jsonutils.loads(input_params)
+
     res = await client.gateway_manager.run_service(name, cluster, input_params)
 
     if "error" in res:
@@ -149,7 +152,7 @@ async def run_service(
     try:
         stdout_json = jsonutils.loads(res["result"]["stdout"])
         res["result"]["stdout"] = stdout_json
-    except ValidationException:
+    except Exception:
         pass
 
     return models.RunServiceResponse(**res["result"])

--- a/src/itential_mcp/tools/golden_config.py
+++ b/src/itential_mcp/tools/golden_config.py
@@ -9,6 +9,7 @@ from fastmcp import Context
 
 from itential_mcp import exceptions
 from itential_mcp import errors
+from itential_mcp import jsonutils
 
 from itential_mcp.models import configuration_manager as models
 
@@ -72,7 +73,7 @@ async def create_golden_config_tree(
         description="The configuration template associated with the base node",
         default=None,
     )],
-    variables: Annotated[dict | None, Field(
+    variables: Annotated[dict | str | None, Field(
         description="The variables associated with this Golden Config tree",
         default=None,
     )]
@@ -103,6 +104,10 @@ async def create_golden_config_tree(
     await ctx.info("inside create_golden_config_tree(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
+
+    # Parse variables if it's a JSON string
+    if isinstance(variables, str):
+        variables = jsonutils.loads(variables)
 
     try:
         res = await client.configuration_manager.create_golden_config_tree(

--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -11,6 +11,7 @@ from fastmcp import Context
 
 from itential_mcp import exceptions
 from itential_mcp import errors
+from itential_mcp import jsonutils
 from itential_mcp.models import lifecycle_manager as models
 
 
@@ -314,7 +315,7 @@ async def run_action(
         description="The instance description",
         default=None
     )],
-    input_params: Annotated[dict, Field(
+    input_params: Annotated[dict | str | None, Field(
         description="The input parameters for the action",
         default=None
     )],
@@ -353,6 +354,10 @@ async def run_action(
     await ctx.info("inside run_action(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
+
+    # Parse input_params if it's a JSON string
+    if isinstance(input_params, str):
+        input_params = jsonutils.loads(input_params)
 
     try:
         json_data = await client.lifecycle_manager.run_action(

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -9,6 +9,7 @@ from fastmcp import Context
 
 from itential_mcp import timeutils
 from itential_mcp import exceptions
+from itential_mcp import jsonutils
 
 from itential_mcp.models import operations_manager as models
 
@@ -132,7 +133,7 @@ async def start_workflow(
         Field(description="The name of the API endpoint used to start the workflow"),
     ],
     data: Annotated[
-        dict | None,
+        dict | str | None,
         Field(
             description="Data to include in the request body when calling the route",
             default=None,
@@ -174,6 +175,10 @@ async def start_workflow(
     await ctx.info("inside start_workflow(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
+
+    # Parse data if it's a JSON string
+    if isinstance(data, str):
+        data = jsonutils.loads(data)
 
     res = await client.operations_manager.start_workflow(route_name, data)
 


### PR DESCRIPTION
Claude Desktop tends to randomly use strings for the payloads. Added code to handle this situation. 

+    input_params: Annotated[dict | str | None, Field(

+    # Parse input_params if it's a JSON string
+    if isinstance(input_params, str):
+        input_params = jsonutils.loads(input_params)

Tool descriptions still call for object inputs to discourage this behavior from other LLMs/Assistants.
