### PR TITLE
fix: avoid redundant JSON schema generation in output_schema assignment

### DIFF
--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -197,7 +197,7 @@ async def new(cfg: config.Config) -> FastMCP:
             try:
                 schema = toolutils.get_json_schema(f)
                 if schema["type"] == "object":
-                    kwargs["output_schema"] = toolutils.get_json_schema(f)
+                    kwargs["output_schema"] = schema
 
             except ValueError:
                 # tool does not have an output_schema defined


### PR DESCRIPTION
• Use already generated schema variable instead of calling get_json_schema twice • Improves performance by eliminating duplicate schema computation