### PR TITLE
feat: add multi-architecture container build support

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -38,6 +41,7 @@ jobs:
           context: .
           push: true
           file: Containerfile
+          platforms: linux/amd64,linux/arm64,darwin/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}
             ghcr.io/${{ github.repository }}:latest

--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ premerge: clean lint security test
 # Build a container image that include the MCP server.  The server will start
 # when the container is run and can be configured using environment variables
 container:
-	${CONTAINER_RUNTIME} build ${PWD} --file Containerfile --tag ${CONTAINER_TAG}
+	${CONTAINER_RUNTIME} buildx build ${PWD} --file Containerfile --tag ${CONTAINER_TAG} --platform linux/amd64,linux/arm64


### PR DESCRIPTION
• Add Docker Buildx setup to GitHub Actions workflow • Enable builds for linux/amd64, linux/arm64, and darwin/arm64 platforms • Update Makefile container target for multi-platform builds • Support macOS ARM64 architecture for Apple Silicon compatibility

Fixes #211