### PR TITLE
Added logic to avoid tag overwrite

### DIFF
--- a/src/itential_mcp/toolutils.py
+++ b/src/itential_mcp/toolutils.py
@@ -104,15 +104,17 @@ def itertools(path: str) -> Iterator[Tuple[Callable, Sequence]]:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
 
-            # create a new tags set for the module and add any tags
-            # that have been configured using the `__tags__` variable
-            tags = set()
+            # Get module-level tags once (these apply to all functions in the module)
+            module_tags = set()
             if hasattr(module, "__tags__"):
-                tags = tags.union(module.__tags__)
+                module_tags = set(module.__tags__)
 
             # Inspect the module to retreive all of the functions.
             for name, f in inspect.getmembers(module, inspect.isfunction):
                 if not name.startswith("_") and f.__module__ == module_name:
+                    # Create a NEW tags set for THIS function (prevents tag pollution)
+                    tags = module_tags.copy()
+
                     # add the function name to the set of tags
                     tags.add(name)
 


### PR DESCRIPTION
__The Overlap:__ In `toolutils.py`, the `itertools()` function created a single `tags` set per module and reused it across all functions. Each function added its name and custom tags to the shared set, causing later functions to inherit tags from earlier functions in the same module.

__Impact Example:__

- `get_devices` → tags: `{'device_groups', 'get_devices'}`
- `restart_device` → tags: `{'device_groups', 'get_devices', 'start_device', 'stop_device', 'restart_device'}`

Result: `--exclude-tags get_devices` would incorrectly exclude `restart_device` too.

__The Fix:__ Changed from creating one tags set per module to creating a fresh set for each function:

- Renamed module-level variable to `module_tags`
- Create `tags = module_tags.copy()` for each function
- Each function now has isolated tags (own name + module tags + custom tags only)

__Affected:__ 16 of 17 tool modules with multiple functions (lifecycle_manager, workflow_engine, adapters, applications, operations_manager, etc.)
