### PR TITLE
fix: remove invalid darwin/arm64 platform from container workflow

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -41,7 +41,7 @@ jobs:
           context: .
           push: true
           file: Containerfile
-          platforms: linux/amd64,linux/arm64,darwin/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
• Remove darwin/arm64 platform from multi-arch build • Container platforms should only include Linux architectures • Fixes build failure with python:3.10-slim base image