### PR TITLE
refactor: create middleware package

### DIFF
--- a/src/itential_mcp/middleware/bindings.py
+++ b/src/itential_mcp/middleware/bindings.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from .. import config
+
+
+class BindingsMiddleware(Middleware):
+    """Middleware for injecting dynamic tool configurations into MCP calls.
+
+    This middleware automatically injects tool configuration objects into
+    the arguments of MCP tool calls when the tool name matches a configured
+    dynamic tool. It adds the configuration as a special `_tool_config` parameter
+    that can be used by the tool implementation, then removes it after execution.
+
+    The middleware enables dynamic tool behavior based on configuration without
+    requiring manual parameter passing from the client.
+
+    Attributes:
+        config (config.Config): The application configuration containing tool definitions.
+    """
+
+    def __init__(self, cfg: config.Config):
+        """Initialize the middleware with configuration.
+
+        Args:
+            cfg (config.Config): The application configuration containing tool definitions.
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        self.config = cfg
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next):
+        """Inject tool configuration into MCP tool calls.
+
+        Automatically adds the `_tool_config` parameter to tool arguments when
+        the tool name matches a configured dynamic tool. The configuration is
+        removed after the tool execution completes.
+
+        Args:
+            context (MiddlewareContext): The middleware context containing the
+                message and other request information.
+            call_next: The next middleware or handler in the chain.
+
+        Returns:
+            Any: The result from the next handler in the middleware chain.
+
+        Raises:
+            Any exceptions from the next handler in the chain.
+        """
+        for t in self.config.tools:
+            if t.tool_name == context.message.name:
+                context.message.arguments["_tool_config"] = t
+
+        res = await call_next(context)
+
+        for t in self.config.tools:
+            if t.tool_name == context.message.name:
+                context.message.arguments.pop("_tool_config", None)
+                break
+
+        return res

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from fastmcp import FastMCP
 
-from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.logging import LoggingMiddleware
 from fastmcp.server.middleware.timing import DetailedTimingMiddleware
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
@@ -23,6 +22,8 @@ from . import config
 from . import toolutils
 from . import bindings
 from . import logging
+
+from .middleware.bindings import BindingsMiddleware
 
 
 INSTRUCTIONS = """
@@ -64,67 +65,6 @@ async def lifespan(mcp: FastMCP) -> AsyncGenerator[dict[str | Any], None]:
     finally:
         # No cleanup needed for client
         pass
-
-
-class DynamicToolInjectionMiddleware(Middleware):
-    """Middleware for injecting dynamic tool configurations into MCP calls.
-
-    This middleware automatically injects tool configuration objects into
-    the arguments of MCP tool calls when the tool name matches a configured
-    dynamic tool. It adds the configuration as a special `_tool_config` parameter
-    that can be used by the tool implementation, then removes it after execution.
-
-    The middleware enables dynamic tool behavior based on configuration without
-    requiring manual parameter passing from the client.
-
-    Attributes:
-        config (config.Config): The application configuration containing tool definitions.
-    """
-
-    def __init__(self, cfg: config.Config):
-        """Initialize the middleware with configuration.
-
-        Args:
-            cfg (config.Config): The application configuration containing tool definitions.
-
-        Returns:
-            None
-
-        Raises:
-            None
-        """
-        self.config = cfg
-
-    async def on_call_tool(self, context: MiddlewareContext, call_next):
-        """Inject tool configuration into MCP tool calls.
-
-        Automatically adds the `_tool_config` parameter to tool arguments when
-        the tool name matches a configured dynamic tool. The configuration is
-        removed after the tool execution completes.
-
-        Args:
-            context (MiddlewareContext): The middleware context containing the
-                message and other request information.
-            call_next: The next middleware or handler in the chain.
-
-        Returns:
-            Any: The result from the next handler in the middleware chain.
-
-        Raises:
-            Any exceptions from the next handler in the chain.
-        """
-        for t in self.config.tools:
-            if t.tool_name == context.message.name:
-                context.message.arguments["_tool_config"] = t
-
-        res = await call_next(context)
-
-        for t in self.config.tools:
-            if t.tool_name == context.message.name:
-                context.message.arguments.pop("_tool_config", None)
-                break
-
-        return res
 
 
 async def new(cfg: config.Config) -> FastMCP:
@@ -181,7 +121,7 @@ async def new(cfg: config.Config) -> FastMCP:
     srv.add_middleware(ErrorHandlingMiddleware(logger=logger))
     srv.add_middleware(DetailedTimingMiddleware(logger=logger))
     srv.add_middleware(LoggingMiddleware(logger=logger, include_payloads=True, max_payload_length=1000))
-    srv.add_middleware(DynamicToolInjectionMiddleware(cfg))
+    srv.add_middleware(BindingsMiddleware(cfg))
 
     logging.info("Adding tools to MCP server")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from itential_mcp import server
 from itential_mcp.config import Config
 from itential_mcp.client import PlatformClient
+from itential_mcp.middleware.bindings import BindingsMiddleware
 
 instructions = """
 Tools for Itential - a network and infrastructure automation and orchestration
@@ -49,15 +50,15 @@ class TestLifespan:
         # Context should be properly cleaned up after exiting
 
 
-class TestDynamicToolInjectionMiddleware:
-    """Test the DynamicToolInjectionMiddleware class"""
+class TestBindingsMiddleware:
+    """Test the BindingsMiddleware class"""
 
     def test_middleware_initialization(self):
-        """Test DynamicToolInjectionMiddleware initializes with config"""
+        """Test BindingsMiddleware initializes with config"""
         mock_config = MagicMock()
         mock_config.tools = [MagicMock()]
 
-        middleware = server.DynamicToolInjectionMiddleware(mock_config)
+        middleware = BindingsMiddleware(mock_config)
 
         assert middleware.config == mock_config
 
@@ -73,7 +74,7 @@ class TestDynamicToolInjectionMiddleware:
         mock_config = MagicMock()
         mock_config.tools = [mock_tool1, mock_tool2]
 
-        middleware = server.DynamicToolInjectionMiddleware(mock_config)
+        middleware = BindingsMiddleware(mock_config)
 
         # Setup context
         mock_context = MagicMock()
@@ -104,7 +105,7 @@ class TestDynamicToolInjectionMiddleware:
         mock_config = MagicMock()
         mock_config.tools = [mock_tool]
 
-        middleware = server.DynamicToolInjectionMiddleware(mock_config)
+        middleware = BindingsMiddleware(mock_config)
 
         # Setup context with non-matching tool name
         mock_context = MagicMock()
@@ -131,7 +132,7 @@ class TestDynamicToolInjectionMiddleware:
         mock_config = MagicMock()
         mock_config.tools = [mock_tool1, mock_tool2]
 
-        middleware = server.DynamicToolInjectionMiddleware(mock_config)
+        middleware = BindingsMiddleware(mock_config)
 
         mock_context = MagicMock()
         mock_context.message.name = "test_tool"
@@ -156,7 +157,7 @@ class TestDynamicToolInjectionMiddleware:
         mock_config = MagicMock()
         mock_config.tools = [mock_tool]
 
-        middleware = server.DynamicToolInjectionMiddleware(mock_config)
+        middleware = BindingsMiddleware(mock_config)
 
         # Setup context with existing arguments
         mock_context = MagicMock()


### PR DESCRIPTION
• Relocated middleware class from server.py to middleware/bindings.py 
• Renamed DynamicToolInjectionMiddleware to BindingsMiddleware 
• Updated server.py to import from new location
• Fixed test imports and class references
• Removed unused middleware imports from server.py