### PR TITLE
refactor: implement async context manager for Server class

### DIFF
--- a/src/itential_mcp/runner.py
+++ b/src/itential_mcp/runner.py
@@ -42,41 +42,42 @@ async def run(tool: str, params: Mapping[str, Any] | None=None) -> None:
 
         ValueError: If there are invalid parameters
     """
-    async with Client(await server.new(config.get())) as client:
-        # Basic server interaction
-        if await client.ping() is False:
-            raise ValueError("ERROR: cannot reach the server")
+    async with server.Server(config.get()) as srv:
+        async with Client(srv.mcp) as client:
+            # Basic server interaction
+            if await client.ping() is False:
+                raise ValueError("ERROR: cannot reach the server")
 
-        tools = {}
+            tools = {}
 
-        res = await client.list_tools_mcp()
+            res = await client.list_tools_mcp()
 
-        for t in res.tools:
-            tools[t.name] = t.inputSchema
+            for t in res.tools:
+                tools[t.name] = t.inputSchema
 
-        kwargs = {
-            "arguments": json.loads(params) if params else None
-        }
+            kwargs = {
+                "arguments": json.loads(params) if params else None
+            }
 
-        if tool not in tools:
-            raise ValueError(f"invalid tool: {tool}")
+            if tool not in tools:
+                raise ValueError(f"invalid tool: {tool}")
 
-        required = tools[tool].get("required") or list()
+            required = tools[tool].get("required") or list()
 
-        if required and set(required).difference((kwargs["arguments"] or {})):
-            for item in required:
-                if kwargs["arguments"] is None or item not in kwargs["arguments"]:
-                    raise ValueError(f"missing required property: {item}")
+            if required and set(required).difference((kwargs["arguments"] or {})):
+                for item in required:
+                    if kwargs["arguments"] is None or item not in kwargs["arguments"]:
+                        raise ValueError(f"missing required property: {item}")
 
-        if kwargs["arguments"]:
-            if set(kwargs["arguments"]).difference(tools[tool]["properties"]):
-                for item in kwargs["arguments"]:
-                    if item not in tools[tool]["properties"]:
-                        raise ValueError(f"invalid argument: {item}")
+            if kwargs["arguments"]:
+                if set(kwargs["arguments"]).difference(tools[tool]["properties"]):
+                    for item in kwargs["arguments"]:
+                        if item not in tools[tool]["properties"]:
+                            raise ValueError(f"invalid argument: {item}")
 
 
-        # Execute operations
-        result = await client.call_tool(tool, **kwargs)
+            # Execute operations
+            result = await client.call_tool(tool, **kwargs)
 
-        data = json.loads(result.content[0].text)
-        print(f"\n{json.dumps(data, indent=4)}")
+            data = json.loads(result.content[0].text)
+            print(f"\n{json.dumps(data, indent=4)}")

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -40,7 +40,6 @@ run_command or create_resource will indicate your operational scope.
 """
 
 
-
 @asynccontextmanager
 async def lifespan(mcp: FastMCP) -> AsyncGenerator[dict[str | Any], None]:
     """
@@ -67,97 +66,128 @@ async def lifespan(mcp: FastMCP) -> AsyncGenerator[dict[str | Any], None]:
         pass
 
 
-async def new(cfg: config.Config) -> FastMCP:
-    """Initialize a new FastMCP server instance with Itential Platform integration.
+class Server:
 
-    Creates and configures a FastMCP server with comprehensive Itential Platform
-    integration including tool discovery, middleware setup, and binding registration.
-    The server is configured with tool filtering, error handling, timing, logging,
-    and dynamic tool injection capabilities.
+    def __init__(self, cfg: config.Config):
+        self.config = cfg
+        self.mcp = None
 
-    The function performs the following setup:
-    - Configures FastMCP server with name, instructions, and lifespan management
-    - Adds middleware stack for error handling, timing, logging, and tool injection
-    - Registers all discovered tools from the tools directory with appropriate tags
-    - Registers dynamic tool bindings based on configuration
-    - Sets up JSON schema validation for tool outputs where available
+    async def __aenter__(self):
+        """Async context manager entry point.
 
-    Args:
-        cfg (config.Config): The application configuration containing server settings,
-            tool definitions, and platform connection details.
+        Initializes the server, tools, and bindings when entering the context.
 
-    Returns:
-        FastMCP: Fully configured server instance ready for execution with all
-            tools registered and middleware configured.
+        Returns:
+            Server: The initialized server instance
 
-    Raises:
-        Exception: If tool discovery, binding registration, or server configuration fails.
+        Raises:
+            Exception: If server initialization fails
+        """
+        await self.__init_server__()
+        await self.__init_tools__()
+        await self.__init_bindings__()
+        return self
 
-    Examples:
-        >>> config = config.get()
-        >>> server = await new(config)
-        >>> await server.run_async(transport="stdio")
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit point.
 
-    Note:
-        This function should only be called once during server initialization.
-        Multiple calls may result in duplicate tool registrations.
-    """
-    logging.info("Initializing the MCP server instance")
+        Performs cleanup when exiting the context.
 
-    auth_provider = auth.build_auth_provider(cfg)
+        Args:
+            exc_type: Exception type if an exception occurred
+            exc_val: Exception value if an exception occurred
+            exc_tb: Exception traceback if an exception occurred
 
-    # Initialize FastMCP server
-    srv = FastMCP(
-        name="Itential Platform MCP",
-        instructions=inspect.cleandoc(INSTRUCTIONS),
-        lifespan=lifespan,
-        auth=auth_provider,
-        include_tags=cfg.server.get("include_tags"),
-        exclude_tags=cfg.server.get("exclude_tags"),
-    )
+        Returns:
+            None
+        """
+        # Cleanup code if needed
+        pass
 
-    logger = logging.get_logger()
+    async def __init_server__(self) -> None:
+        """Initialize a new FastMCP server instance with Itential Platform integration."""
+        logging.info("Initializing the MCP server instance")
 
-    srv.add_middleware(ErrorHandlingMiddleware(logger=logger))
-    srv.add_middleware(DetailedTimingMiddleware(logger=logger))
-    srv.add_middleware(LoggingMiddleware(logger=logger, include_payloads=True, max_payload_length=1000))
-    srv.add_middleware(BindingsMiddleware(cfg))
+        auth_provider = auth.build_auth_provider(self.config)
 
-    logging.info("Adding tools to MCP server")
-
-    tool_paths = [pathlib.Path(__file__).parent / "tools"]
-
-    if cfg.server.get("tools_path") is not None:
-        tool_paths.append(
-            pathlib.Path(cfg.server.get("tools_path")).resolve()
+        # Initialize FastMCP server
+        self.mcp = FastMCP(
+            name="Itential Platform MCP",
+            instructions=inspect.cleandoc(INSTRUCTIONS),
+            lifespan=lifespan,
+            auth=auth_provider,
+            include_tags=self.config.server.get("include_tags"),
+            exclude_tags=self.config.server.get("exclude_tags"),
         )
 
-    for ele in tool_paths:
-        logger.info(f"Adding MCP Tools from {ele}")
-        for f, tags in toolutils.itertools(ele):
-            tags.add("default")
-            kwargs = {"tags": tags}
+        logger = logging.get_logger()
 
-            try:
-                schema = toolutils.get_json_schema(f)
-                if schema["type"] == "object":
-                    kwargs["output_schema"] = schema
+        self.mcp.add_middleware(ErrorHandlingMiddleware(logger=logger))
+        self.mcp.add_middleware(DetailedTimingMiddleware(logger=logger))
+        self.mcp.add_middleware(LoggingMiddleware(logger=logger, include_payloads=True, max_payload_length=1000))
+        self.mcp.add_middleware(BindingsMiddleware(self.config))
 
-            except ValueError:
-                # tool does not have an output_schema defined
-                logger.warning(f"tool {f.__name__} has a missing or invalid output_schema")
-                pass
+    async def __init_tools__(self) -> None:
+        """Initialize tools."""
+        logging.info("Adding tools to MCP server")
 
-            srv.tool(f, **kwargs)
-            logging.debug(f"Successfully added tool: {f.__name__}")
+        tool_paths = [pathlib.Path(__file__).parent / "tools"]
 
-    logging.info("Creating dynamic bindings for tools")
-    async for fn, kwargs in bindings.iterbindings(cfg):
-        srv.tool(fn, **kwargs)
-        logging.debug(f"Successfully added tool: {kwargs['name']}")
-    logging.info("Dynamic tool bindings is now complete")
+        if self.config.server.get("tools_path") is not None:
+            tool_paths.append(
+                pathlib.Path(self.config.server.get("tools_path")).resolve()
+            )
 
-    return srv
+        logger = logging.get_logger()
+
+        for ele in tool_paths:
+            logger.info(f"Adding MCP Tools from {ele}")
+            for f, tags in toolutils.itertools(ele):
+                tags.add("default")
+                kwargs = {"tags": tags}
+
+                try:
+                    schema = toolutils.get_json_schema(f)
+                    if schema["type"] == "object":
+                        kwargs["output_schema"] = schema
+
+                except ValueError:
+                    # tool does not have an output_schema defined
+                    logger.warning(f"tool {f.__name__} has a missing or invalid output_schema")
+                    pass
+
+                self.mcp.tool(f, **kwargs)
+                logging.debug(f"Successfully added tool: {f.__name__}")
+
+    async def __init_bindings__(self) -> None:
+        """Initialize bindings."""
+        logging.info("Creating dynamic bindings for tools")
+        async for fn, kwargs in bindings.iterbindings(self.config):
+            self.mcp.tool(fn, **kwargs)
+            logging.debug(f"Successfully added tool: {kwargs['name']}")
+        logging.info("Dynamic tool bindings is now complete")
+
+    async def run(self):
+        """Run the server."""
+        kwargs = {
+            "transport": self.config.server.get("transport"),
+            "show_banner": False
+        }
+
+        if kwargs["transport"] in ("sse", "http"):
+            kwargs.update(
+                {
+                    "host": self.config.server.get("host"),
+                    "port": self.config.server.get("port"),
+                }
+            )
+
+            if kwargs["transport"] == "http":
+                kwargs["path"] = self.config.server.get("path")
+
+        return await self.mcp.run_async(**kwargs)
+
+
 
 
 async def run() -> int:
@@ -199,25 +229,8 @@ async def run() -> int:
 
         logging.set_level(cfg.server_log_level)
 
-        mcp = await new(cfg)
-
-        kwargs = {
-            "transport": cfg.server.get("transport"),
-            "show_banner": False
-        }
-
-        if kwargs["transport"] in ("sse", "http"):
-            kwargs.update(
-                {
-                    "host": cfg.server.get("host"),
-                    "port": cfg.server.get("port"),
-                }
-            )
-
-            if kwargs["transport"] == "http":
-                kwargs["path"] = cfg.server.get("path")
-
-        await mcp.run_async(**kwargs)
+        async with Server(cfg) as srv:
+            await srv.run()
 
     except KeyboardInterrupt:
         print("Shutting down the server")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -26,16 +26,20 @@ class TestRun:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_basic_tool_no_params(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_basic_tool_no_params(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test running a tool without parameters"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -66,7 +70,7 @@ class TestRun:
         
         # Verify
         mock_config_get.assert_called_once()
-        mock_server_new.assert_called_once_with(mock_config)
+        mock_server_class.assert_called_once_with(mock_config)
         mock_client.ping.assert_called_once()
         mock_client.list_tools_mcp.assert_called_once()
         mock_client.call_tool.assert_called_once_with("test_tool", arguments=None)
@@ -78,16 +82,20 @@ class TestRun:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_tool_with_params(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_tool_with_params(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test running a tool with parameters"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -131,16 +139,20 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_server_ping_failure(self, mock_config_get, mock_server_new, mock_client_class):
+    async def test_run_server_ping_failure(self, mock_config_get, mock_server_class, mock_client_class):
         """Test failure when server ping fails"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = False
@@ -158,16 +170,20 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_invalid_tool(self, mock_config_get, mock_server_new, mock_client_class):
+    async def test_run_invalid_tool(self, mock_config_get, mock_server_class, mock_client_class):
         """Test running an invalid/non-existent tool"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -194,16 +210,20 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_missing_required_params(self, mock_config_get, mock_server_new, mock_client_class):
+    async def test_run_missing_required_params(self, mock_config_get, mock_server_class, mock_client_class):
         """Test running a tool with missing required parameters"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -240,16 +260,20 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_invalid_params(self, mock_config_get, mock_server_new, mock_client_class):
+    async def test_run_invalid_params(self, mock_config_get, mock_server_class, mock_client_class):
         """Test running a tool with invalid parameters"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -282,16 +306,20 @@ class TestRun:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_tool_no_required_params(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_tool_no_required_params(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test running a tool that has no required parameters in schema"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -330,16 +358,20 @@ class TestRun:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_multiple_tools_available(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_multiple_tools_available(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test running a specific tool when multiple tools are available"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -378,16 +410,20 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_invalid_json_params(self, mock_config_get, mock_server_new, mock_client_class):
+    async def test_run_invalid_json_params(self, mock_config_get, mock_server_class, mock_client_class):
         """Test running a tool with invalid JSON parameters"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -412,16 +448,20 @@ class TestRun:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_complex_result_formatting(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_complex_result_formatting(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test that complex results are properly formatted in JSON output"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -471,16 +511,20 @@ class TestRunEdgeCases:
 
     @pytest.mark.asyncio
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_empty_tool_list(self, mock_config_get, mock_server_new, mock_client_class):
+    async def test_run_empty_tool_list(self, mock_config_get, mock_server_class, mock_client_class):
         """Test behavior when no tools are available"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -500,16 +544,20 @@ class TestRunEdgeCases:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_empty_params_string(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_empty_params_string(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test running a tool with empty parameters string"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -545,16 +593,20 @@ class TestRunIntegration:
     @pytest.mark.asyncio
     @patch('sys.stdout', new_callable=StringIO)
     @patch('itential_mcp.runner.Client')
-    @patch('itential_mcp.runner.server.new')
+    @patch('itential_mcp.runner.server.Server')
     @patch('itential_mcp.runner.config.get')
-    async def test_run_full_workflow(self, mock_config_get, mock_server_new, mock_client_class, mock_stdout):
+    async def test_run_full_workflow(self, mock_config_get, mock_server_class, mock_client_class, mock_stdout):
         """Test the complete workflow from start to finish"""
         # Setup mocks
         mock_config = MagicMock()
         mock_config_get.return_value = mock_config
         
-        mock_server = MagicMock()
-        mock_server_new.return_value = mock_server
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
         
         mock_client = AsyncMock()
         mock_client.ping.return_value = True
@@ -601,7 +653,7 @@ class TestRunIntegration:
         
         # Verify complete flow
         mock_config_get.assert_called_once()
-        mock_server_new.assert_called_once_with(mock_config)
+        mock_server_class.assert_called_once_with(mock_config)
         mock_client.ping.assert_called_once()
         mock_client.list_tools_mcp.assert_called_once()
         

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,6 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from itential_mcp import server
-from itential_mcp.config import Config
 from itential_mcp.client import PlatformClient
 from itential_mcp.middleware.bindings import BindingsMiddleware
 
@@ -174,320 +173,15 @@ class TestBindingsMiddleware:
         assert "_tool_config" not in mock_context.message.arguments
 
 
-class TestNew:
-    """Test the new() function for creating FastMCP instances"""
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_creates_fastmcp_with_basic_config(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() creates FastMCP with basic configuration"""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {
-            "include_tags": ["tag1", "tag2"],
-            "exclude_tags": ["tag3"],
-            "tools_path": None,
-        }
-        mock_config.tools = []
-        mock_auth_builder.return_value = None
-
-        mock_itertools.return_value = []
-
-        async def empty_aiter():
-            return
-            yield  # unreachable but makes this an async generator
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-
-        result = await server.new(mock_config)
-
-        mock_fastmcp.assert_called_once_with(
-            name="Itential Platform MCP",
-            instructions=server.inspect.cleandoc(server.INSTRUCTIONS),
-            lifespan=server.lifespan,
-            include_tags=["tag1", "tag2"],
-            exclude_tags=["tag3"],
-            auth=None,
-        )
-        assert result == mock_mcp_instance
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_handles_none_tags(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() handles None values for tags"""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {"include_tags": None, "exclude_tags": None}
-        mock_config.tools = []
-        mock_auth_builder.return_value = None
-
-        mock_itertools.return_value = []
-
-        async def empty_aiter():
-            return
-            yield  # unreachable but makes this an async generator
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-
-        await server.new(mock_config)
-
-        mock_fastmcp.assert_called_once_with(
-            name="Itential Platform MCP",
-            instructions=server.inspect.cleandoc(server.INSTRUCTIONS),
-            lifespan=server.lifespan,
-            include_tags=None,
-            exclude_tags=None,
-            auth=None,
-        )
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_handles_empty_server_config(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() handles empty server configuration"""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {}
-        mock_config.tools = []
-        mock_auth_builder.return_value = None
-
-        mock_itertools.return_value = []
-
-        async def empty_aiter():
-            return
-            yield  # unreachable but makes this an async generator
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-
-        await server.new(mock_config)
-
-        mock_fastmcp.assert_called_once_with(
-            name="Itential Platform MCP",
-            instructions=server.inspect.cleandoc(server.INSTRUCTIONS),
-            lifespan=server.lifespan,
-            include_tags=None,
-            exclude_tags=None,
-            auth=None,
-        )
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_with_custom_tools_path(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() with custom tools_path configuration"""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {
-            "include_tags": None,
-            "exclude_tags": None,
-            "tools_path": "/custom/tools/path",
-        }
-        mock_config.tools = []
-        mock_auth_builder.return_value = None
-
-        mock_itertools.return_value = []
-
-        async def empty_aiter():
-            return
-            yield  # unreachable but makes this an async generator
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-
-        result = await server.new(mock_config)
-
-        # Should call itertools twice - once for default, once for custom path
-        assert mock_itertools.call_count == 2
-        mock_fastmcp.assert_called_once()
-        assert result == mock_mcp_instance
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_without_custom_tools_path(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() without custom tools_path (None)"""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {
-            "include_tags": None,
-            "exclude_tags": None,
-            "tools_path": None,
-        }
-        mock_config.tools = []
-        mock_auth_builder.return_value = None
-
-        mock_itertools.return_value = []
-
-        async def empty_aiter():
-            return
-            yield  # unreachable but makes this an async generator
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-
-        await server.new(mock_config)
-
-        # Should only call itertools once for default path
-        assert mock_itertools.call_count == 1
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.toolutils.get_json_schema")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_tool_with_missing_output_schema(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_get_json_schema,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() handles tools with missing or invalid output_schema"""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {
-            "include_tags": None,
-            "exclude_tags": None,
-            "tools_path": None,
-        }
-        mock_config.tools = []
-        mock_auth_builder.return_value = None
-        mock_auth_builder.return_value = None
-
-        # Mock a tool function
-        def mock_tool():
-            """Test tool function"""
-            pass
-
-        mock_tool.__name__ = "test_tool"
-        mock_itertools.return_value = [(mock_tool, {"test"})]
-
-        # Mock get_json_schema to raise ValueError (missing/invalid schema)
-        mock_get_json_schema.side_effect = ValueError("Missing schema")
-
-        async def empty_aiter():
-            return
-            yield  # unreachable but makes this an async generator
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-        mock_logger_instance = MagicMock()
-        mock_logger.return_value = mock_logger_instance
-
-        await server.new(mock_config)
-
-    @patch("itential_mcp.server.auth.build_auth_provider")
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.logging.get_logger")
-    @patch("itential_mcp.server.FastMCP")
-    @pytest.mark.asyncio
-    async def test_new_includes_auth_provider_when_configured(
-        self,
-        mock_fastmcp,
-        mock_logger,
-        mock_itertools,
-        mock_iterbindings,
-        mock_auth_builder,
-    ):
-        """Test new() passes configured auth provider into FastMCP."""
-        mock_config = MagicMock(spec=Config)
-        mock_config.server = {"include_tags": None, "exclude_tags": None, "tools_path": None}
-        mock_config.tools = []
-
-        mock_auth_provider = MagicMock()
-        mock_auth_builder.return_value = mock_auth_provider
-        mock_itertools.return_value = []
-
-        async def empty_aiter():
-            return
-            yield
-
-        mock_iterbindings.return_value = empty_aiter()
-
-        mock_mcp_instance = MagicMock()
-        mock_fastmcp.return_value = mock_mcp_instance
-
-        await server.new(mock_config)
-
-        mock_fastmcp.assert_called_once()
-        kwargs = mock_fastmcp.call_args.kwargs
-        assert kwargs["auth"] is mock_auth_provider
-
 
 class TestRun:
     """Test the run() function for server execution"""
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
-    async def test_run_stdio_transport_success(self, mock_set_level, mock_config_get, mock_new):
+    async def test_run_stdio_transport_success(self, mock_set_level, mock_config_get, mock_server_class):
         """Test successful server run with stdio transport"""
         # Setup mocks
         mock_config = MagicMock()
@@ -495,9 +189,12 @@ class TestRun:
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         # Execute
         await server.run()
@@ -505,18 +202,17 @@ class TestRun:
         # Verify
         mock_config_get.assert_called_once()
         mock_set_level.assert_called_once_with("INFO")
-        mock_new.assert_awaited_once_with(mock_config)
-
-        # Check server was run with correct parameters
-        mock_mcp.run_async.assert_called_once_with(transport="stdio", show_banner=False)
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.__aenter__.assert_called_once()
+        mock_server_instance.run.assert_called_once()
+        mock_server_instance.__aexit__.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
     async def test_run_sse_transport_success(
-        self, mock_set_level, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_server_class
     ):
         """Test successful server run with SSE transport"""
         mock_config = MagicMock()
@@ -529,26 +225,25 @@ class TestRun:
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
-
-        mock_itertools.return_value = []
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         await server.run()
 
         mock_set_level.assert_called_once_with("INFO")
-        mock_mcp.run_async.assert_called_once_with(
-            transport="sse", host="0.0.0.0", port=8000, show_banner=False
-        )
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
     async def test_run_http_transport_success(
-        self, mock_set_level, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_server_class
     ):
         """Test successful server run with HTTP transport"""
         mock_config = MagicMock()
@@ -562,36 +257,35 @@ class TestRun:
         mock_config.server_log_level = "DEBUG"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
-
-        mock_itertools.return_value = []
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         await server.run()
 
         mock_set_level.assert_called_once_with("DEBUG")
-        mock_mcp.run_async.assert_called_once_with(
-            transport="http",
-            host="localhost",
-            port=3000,
-            show_banner=False,
-            path="/mcp",
-        )
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
-    async def test_run_tool_registration_failure(self, mock_set_level, mock_config_get, mock_new):
-        """Test server exits when tool registration fails in new()"""
+    async def test_run_tool_registration_failure(self, mock_set_level, mock_config_get, mock_server_class):
+        """Test server exits when tool registration fails in Server context manager"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        # Make new() raise an exception (simulates tool registration failure)
-        mock_new.side_effect = Exception("Tool import failed")
+        # Make Server.__aenter__ raise an exception (simulates tool registration failure)
+        mock_server_instance = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(side_effect=Exception("Tool import failed"))
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         with patch("builtins.print") as mock_print, patch("sys.exit") as mock_exit:
             await server.run()
@@ -603,12 +297,11 @@ class TestRun:
             mock_exit.assert_called_with(1)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
     async def test_run_keyboard_interrupt(
-        self, mock_set_level, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_server_class
     ):
         """Test server handles KeyboardInterrupt gracefully"""
         mock_config = MagicMock()
@@ -616,11 +309,12 @@ class TestRun:
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock(side_effect=KeyboardInterrupt())
-        mock_new.return_value = mock_mcp
-
-        mock_itertools.return_value = []
+        # Setup server instance mock to raise KeyboardInterrupt
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock(side_effect=KeyboardInterrupt())
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         with patch("builtins.print") as mock_print, patch("sys.exit") as mock_exit:
             await server.run()
@@ -629,12 +323,11 @@ class TestRun:
             mock_exit.assert_called_with(0)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
     async def test_run_unexpected_exception(
-        self, mock_set_level, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_server_class
     ):
         """Test server handles unexpected exceptions"""
         mock_config = MagicMock()
@@ -642,11 +335,12 @@ class TestRun:
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock(side_effect=RuntimeError("Unexpected error"))
-        mock_new.return_value = mock_mcp
-
-        mock_itertools.return_value = []
+        # Setup server instance mock to raise RuntimeError
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock(side_effect=RuntimeError("Unexpected error"))
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         with patch("builtins.print") as mock_print, patch("sys.exit") as mock_exit:
             await server.run()
@@ -657,64 +351,68 @@ class TestRun:
             mock_exit.assert_called_with(1)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
-    async def test_run_no_tools_loaded(self, mock_set_level, mock_config_get, mock_new, mock_itertools):
+    async def test_run_no_tools_loaded(self, mock_set_level, mock_config_get, mock_server_class):
         """Test server runs successfully even with no tools"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
-
-        # No tools returned
-        mock_itertools.return_value = []
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         await server.run()
 
-        # Should not call mcp.tool since there are no tools
-        mock_mcp.tool.assert_not_called()
-        mock_mcp.run_async.assert_called_once()
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
-    async def test_run_multiple_tools_registration(self, mock_set_level, mock_config_get, mock_new):
-        """Test server properly uses the configured MCP instance from new()"""
+    async def test_run_multiple_tools_registration(self, mock_set_level, mock_config_get, mock_server_class):
+        """Test server properly uses the configured Server instance"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         await server.run()
 
-        # Verify new() was called with the config and the MCP instance was used
-        mock_new.assert_awaited_once_with(mock_config)
-        mock_mcp.run_async.assert_called_once_with(transport="stdio", show_banner=False)
+        # Verify Server was called with the config and the server instance was used
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
-    async def test_run_partial_tool_failure(self, mock_set_level, mock_config_get, mock_new):
-        """Test that server fails if new() fails due to tool registration issues"""
+    async def test_run_partial_tool_failure(self, mock_set_level, mock_config_get, mock_server_class):
+        """Test that server fails if Server context manager fails due to tool registration issues"""
         mock_config = MagicMock()
         mock_config.server = {"transport": "stdio"}
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        # Make new() fail with an ImportError (simulating tool import failure)
-        mock_new.side_effect = ImportError("Failed to import third tool")
+        # Make Server.__aenter__ fail with an ImportError (simulating tool import failure)
+        mock_server_instance = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(side_effect=ImportError("Failed to import third tool"))
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         with patch("builtins.print") as mock_print, patch("sys.exit") as mock_exit:
             await server.run()
@@ -726,12 +424,11 @@ class TestRun:
             mock_exit.assert_called_with(1)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
     async def test_run_config_variations(
-        self, mock_set_level, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_server_class
     ):
         """Test various configuration scenarios"""
         # Test with minimal config
@@ -740,23 +437,24 @@ class TestRun:
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
-
-        mock_itertools.return_value = []
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         await server.run()
 
-        mock_mcp.run_async.assert_called_with(transport="stdio", show_banner=False)
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.new", new_callable=AsyncMock)
+    @patch("itential_mcp.server.Server")
     @patch("itential_mcp.server.config.get")
     @patch("itential_mcp.server.logging.set_level")
     async def test_run_missing_server_config_keys(
-        self, mock_set_level, mock_config_get, mock_new, mock_itertools
+        self, mock_set_level, mock_config_get, mock_server_class
     ):
         """Test server handles missing configuration keys gracefully"""
         mock_config = MagicMock()
@@ -764,18 +462,17 @@ class TestRun:
         mock_config.server_log_level = "INFO"
         mock_config_get.return_value = mock_config
 
-        mock_mcp = MagicMock()
-        mock_mcp.run_async = AsyncMock()
-        mock_new.return_value = mock_mcp
-
-        mock_itertools.return_value = []
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.run = AsyncMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
 
         await server.run()
 
-        # Should call with None values for missing keys
-        mock_mcp.run_async.assert_called_with(
-            transport="sse", host=None, port=None, show_banner=False
-        )
+        mock_server_class.assert_called_once_with(mock_config)
+        mock_server_instance.run.assert_called_once()
 
 
 class TestIntegration:


### PR DESCRIPTION
• Add __aenter__ and __aexit__ methods to Server class for proper async context management 
• Move server initialization logic from new() function to Server class methods 
• Update run() function to use Server async context manager pattern 