### PR TITLE
Fix model to accept dict or list

### DIFF
--- a/src/itential_mcp/models/lifecycle_manager.py
+++ b/src/itential_mcp/models/lifecycle_manager.py
@@ -119,12 +119,13 @@ class Action(BaseModel):
     ]
 
     input_schema: Annotated[
-        Mapping[str, Any],
+        Mapping[str, Any] | List[Any],
         Field(
             description = inspect.cleandoc(
                 """
                 A JSON Schema object that defines the input schema required
-                to successfully run the action.
+                to successfully run the action. Can be either a dictionary
+                or a list depending on the schema structure.
                 """
             )
         )


### PR DESCRIPTION
## Description

The describe_resource tool was failing with a Pydantic validation error because the Action model's input_schema field was typed as Mapping[str, Any] (dictionary only), but the Itential Platform API was returning a list in some cases.

Pre commit pipeline verified
Coding guidelines reviewed

---

See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.
