### PR TITLE
feat: add device type validation for golden config trees

### DIFF
--- a/src/itential_mcp/services/configuration_manager.py
+++ b/src/itential_mcp/services/configuration_manager.py
@@ -65,6 +65,25 @@ class Service(ServiceBase):
 
     name: str = "configuration_manager"
 
+    async def get_configuration_parser_names(self) -> list[str]:
+        """
+        Retrieve list of valid device type names from configuration parsers.
+
+        This method fetches the available configuration parser names which represent
+        the valid device types that can be used when creating Golden Configuration trees.
+
+        Returns:
+            list[str]: List of parser names (device types) such as 'cisco-ios',
+                'arista-eos', 'juniper-junos', etc.
+
+        Raises:
+            Exception: If there are API communication failures or server errors
+                during the retrieval process.
+        """
+        res = await self.client.get("/configuration_manager/configurations/parser")
+        data = res.json()
+        return [parser["name"] for parser in data["list"]]
+
     async def get_golden_config_trees(self) -> list[dict]:
         """
         Retrieve all Golden Configuration trees from the Configuration Manager.
@@ -115,9 +134,18 @@ class Service(ServiceBase):
             dict: Created tree object containing tree metadata including ID and name
 
         Raises:
+            ValueError: If the specified device_type is not a valid configuration parser
             ServerException: If there is an error creating the Golden Configuration tree
                 or setting the template/variables
         """
+        # Validate device_type against available parsers
+        valid_device_types = await self.get_configuration_parser_names()
+        if device_type not in valid_device_types:
+            raise ValueError(
+                f"Invalid device_type '{device_type}'. "
+                f"Valid types are: {', '.join(valid_device_types)}"
+            )
+
         try:
             res = await self.client.post(
                 "/configuration_manager/configs",

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -127,6 +127,40 @@ class TestConfigurationManagerService:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_get_configuration_parser_names_success(self, service, mock_client):
+        """Test successful retrieval of configuration parser names."""
+        expected_parsers = [
+            {"name": "cisco_ios"},
+            {"name": "juniper"},
+            {"name": "arista_eos"},
+        ]
+
+        mock_response = Mock()
+        mock_response.json.return_value = {"list": expected_parsers}
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_configuration_parser_names()
+
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/configurations/parser"
+        )
+        assert result == ["cisco_ios", "juniper", "arista_eos"]
+
+    @pytest.mark.asyncio
+    async def test_get_configuration_parser_names_empty(self, service, mock_client):
+        """Test get_configuration_parser_names with empty list."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"list": []}
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_configuration_parser_names()
+
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/configurations/parser"
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_create_golden_config_tree_minimal(self, service, mock_client):
         """Test creating a golden config tree with minimal parameters."""
         expected_response = {
@@ -134,6 +168,13 @@ class TestConfigurationManagerService:
             "name": "test-tree",
             "deviceType": "cisco_ios",
         }
+
+        # Mock the parser endpoint for device type validation
+        parser_mock_response = Mock()
+        parser_mock_response.json.return_value = {
+            "list": [{"name": "cisco_ios"}, {"name": "juniper"}]
+        }
+        mock_client.get.return_value = parser_mock_response
 
         mock_response = Mock()
         mock_response.json.return_value = expected_response
@@ -143,6 +184,9 @@ class TestConfigurationManagerService:
             name="test-tree", device_type="cisco_ios"
         )
 
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/configurations/parser"
+        )
         mock_client.post.assert_called_once_with(
             "/configuration_manager/configs",
             json={"name": "test-tree", "deviceType": "cisco_ios"},
@@ -159,6 +203,13 @@ class TestConfigurationManagerService:
         }
         variables = {"var1": "value1", "var2": "value2"}
 
+        # Mock the parser endpoint for device type validation
+        parser_mock_response = Mock()
+        parser_mock_response.json.return_value = {
+            "list": [{"name": "cisco_ios"}, {"name": "juniper"}]
+        }
+        mock_client.get.return_value = parser_mock_response
+
         mock_response = Mock()
         mock_response.json.return_value = expected_response
         mock_client.post.return_value = mock_response
@@ -167,6 +218,9 @@ class TestConfigurationManagerService:
             name="test-tree", device_type="cisco_ios", variables=variables
         )
 
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/configurations/parser"
+        )
         mock_client.post.assert_called_once_with(
             "/configuration_manager/configs",
             json={"name": "test-tree", "deviceType": "cisco_ios"},
@@ -189,6 +243,13 @@ class TestConfigurationManagerService:
         }
         template = "interface {{ interface_name }}\n description {{ description }}"
 
+        # Mock the parser endpoint for device type validation
+        parser_mock_response = Mock()
+        parser_mock_response.json.return_value = {
+            "list": [{"name": "cisco_ios"}, {"name": "juniper"}]
+        }
+        mock_client.get.return_value = parser_mock_response
+
         mock_response = Mock()
         mock_response.json.return_value = expected_response
         mock_client.post.return_value = mock_response
@@ -200,6 +261,9 @@ class TestConfigurationManagerService:
             name="test-tree", device_type="cisco_ios", template=template
         )
 
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/configurations/parser"
+        )
         mock_client.post.assert_called_once_with(
             "/configuration_manager/configs",
             json={"name": "test-tree", "deviceType": "cisco_ios"},
@@ -224,6 +288,13 @@ class TestConfigurationManagerService:
         template = "interface {{ interface_name }}"
         variables = {"interface_name": "GigabitEthernet0/1"}
 
+        # Mock the parser endpoint for device type validation
+        parser_mock_response = Mock()
+        parser_mock_response.json.return_value = {
+            "list": [{"name": "cisco_ios"}, {"name": "juniper"}]
+        }
+        mock_client.get.return_value = parser_mock_response
+
         mock_response = Mock()
         mock_response.json.return_value = expected_response
         mock_client.post.return_value = mock_response
@@ -237,6 +308,9 @@ class TestConfigurationManagerService:
             variables=variables,
         )
 
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/configurations/parser"
+        )
         mock_client.post.assert_called_once_with(
             "/configuration_manager/configs",
             json={"name": "test-tree", "deviceType": "cisco_ios"},
@@ -256,6 +330,13 @@ class TestConfigurationManagerService:
     @pytest.mark.asyncio
     async def test_create_golden_config_tree_server_error(self, service, mock_client):
         """Test create_golden_config_tree with server error."""
+        # Mock the parser endpoint for device type validation
+        parser_mock_response = Mock()
+        parser_mock_response.json.return_value = {
+            "list": [{"name": "cisco_ios"}, {"name": "juniper"}]
+        }
+        mock_client.get.return_value = parser_mock_response
+
         error_response = {"error": "Tree name already exists"}
         server_error = ipsdk.exceptions.ServerError(
             "Server Error", details={"response_body": json.dumps(error_response)}
@@ -269,6 +350,28 @@ class TestConfigurationManagerService:
 
         # Just verify that the ServerException was raised correctly
         assert isinstance(exc_info.value, exceptions.ServerException)
+
+    @pytest.mark.asyncio
+    async def test_create_golden_config_tree_invalid_device_type(
+        self, service, mock_client
+    ):
+        """Test create_golden_config_tree with invalid device type."""
+        # Mock the parser endpoint with valid device types
+        parser_mock_response = Mock()
+        parser_mock_response.json.return_value = {
+            "list": [{"name": "cisco_ios"}, {"name": "juniper"}]
+        }
+        mock_client.get.return_value = parser_mock_response
+
+        with pytest.raises(ValueError) as exc_info:
+            await service.create_golden_config_tree(
+                name="test-tree", device_type="invalid_device"
+            )
+
+        # Verify the error message contains the invalid type and valid types
+        assert "invalid_device" in str(exc_info.value)
+        assert "cisco_ios" in str(exc_info.value)
+        assert "juniper" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_describe_golden_config_tree_version(self, service, mock_client):


### PR DESCRIPTION
## Summary

Adds validation for device types when creating Golden Configuration trees by:
- Adding `get_configuration_parser_names()` method to retrieve valid device types from configuration parsers
- Validating device_type parameter against available parsers before tree creation
- Raising ValueError with helpful message if invalid device type is provided

## Test plan

- [ ] Verify `get_configuration_parser_names()` returns list of valid parser names
- [ ] Test creating golden config tree with valid device type succeeds
- [ ] Test creating golden config tree with invalid device type raises ValueError
- [ ] Verify error message includes list of valid device types