### PR TITLE
ci: add GitHub release creation to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,3 +43,12 @@ jobs:
         run: |
             echo "Publishing to PyPI..."
             twine upload dist/*
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          files: dist/*
+          draft: false
+          prerelease: false


### PR DESCRIPTION
• Add GitHub release step using softprops/action-gh-release@v2 
• Configure release with tag name and distribution files 
• Set release as non-draft and non-prerelease
