### PR TITLE
feat: add OAuth 2.0 auth support for HTTP transports

### DIFF
--- a/src/itential_mcp/auth.py
+++ b/src/itential_mcp/auth.py
@@ -1,13 +1,14 @@
 """Authentication provider factory for the Itential MCP server.
 
 This module converts application configuration into FastMCP authentication
-providers.  Support currently includes JWT token verification with optional
-JWKS lookups and is designed to be extended with additional providers in
-the future.
+providers. Support includes JWT token verification with optional JWKS lookups,
+OAuth 2.0 flows via RemoteAuthProvider and OAuthProxy, and is designed to be
+extended with additional providers in the future.
 """
 
-from fastmcp.server.auth.auth import AuthProvider
-from fastmcp.server.auth.providers.jwt import JWTVerifier
+from typing import Dict, Any
+
+from fastmcp.server.auth import AuthProvider, JWTVerifier, RemoteAuthProvider, OAuthProxy, OAuthProvider
 
 from .core import logging
 from .config import Config
@@ -36,11 +37,30 @@ def build_auth_provider(cfg: Config) -> AuthProvider | None:
         logging.debug("Server authentication disabled; no provider constructed")
         return None
 
-    if auth_type != "jwt":
+    if auth_type == "jwt":
+        return _build_jwt_provider(auth_config)
+    elif auth_type == "oauth":
+        return _build_oauth_provider(auth_config)
+    elif auth_type == "oauth_proxy":
+        return _build_oauth_proxy_provider(auth_config)
+    else:
         raise ConfigurationException(
             f"Unsupported authentication type configured: {auth_type}"
         )
 
+
+def _build_jwt_provider(auth_config: Dict[str, Any]) -> AuthProvider:
+    """Build a JWT authentication provider.
+
+    Args:
+        auth_config (Dict[str, Any]): Authentication configuration dictionary.
+
+    Returns:
+        AuthProvider: Configured JWT authentication provider.
+
+    Raises:
+        ConfigurationException: If JWT provider initialization fails.
+    """
     jwt_kwargs = {key: value for key, value in auth_config.items() if key != "type"}
 
     try:
@@ -54,3 +74,175 @@ def build_auth_provider(cfg: Config) -> AuthProvider | None:
 
     logging.info("Server authentication enabled using JWT provider")
     return provider
+
+
+def _build_oauth_provider(auth_config: Dict[str, Any]) -> AuthProvider:
+    """Build a full OAuth 2.0 authorization server.
+
+    Args:
+        auth_config (Dict[str, Any]): Authentication configuration dictionary.
+
+    Returns:
+        AuthProvider: Configured OAuth authorization server provider.
+
+    Raises:
+        ConfigurationException: If OAuth provider initialization fails.
+    """
+    required_fields = ["redirect_uri"]
+    missing_fields = [field for field in required_fields if not auth_config.get(field)]
+    
+    if missing_fields:
+        raise ConfigurationException(
+            f"OAuth server requires the following fields: {', '.join(missing_fields)}"
+        )
+
+    oauth_kwargs = {
+        "base_url": auth_config["redirect_uri"].rstrip("/auth/callback"),
+    }
+
+    # Add optional parameters
+    if auth_config.get("scopes"):
+        oauth_kwargs["required_scopes"] = auth_config["scopes"]
+
+    try:
+        provider = OAuthProvider(**oauth_kwargs)
+    except ValueError as exc:
+        raise ConfigurationException(str(exc)) from exc
+    except Exception as exc:
+        raise ConfigurationException(
+            f"Failed to initialize OAuth authorization server: {exc}"
+        ) from exc
+
+    logging.info("Server authentication enabled using OAuth authorization server")
+    return provider
+
+
+def _build_oauth_proxy_provider(auth_config: Dict[str, Any]) -> AuthProvider:
+    """Build an OAuthProxy for upstream OAuth providers.
+
+    Args:
+        auth_config (Dict[str, Any]): Authentication configuration dictionary.
+
+    Returns:
+        AuthProvider: Configured OAuth proxy authentication provider.
+
+    Raises:
+        ConfigurationException: If OAuth proxy provider initialization fails.
+    """
+    required_fields = ["client_id", "client_secret", "authorization_url", "token_url", "redirect_uri"]
+    missing_fields = [field for field in required_fields if not auth_config.get(field)]
+    
+    if missing_fields:
+        raise ConfigurationException(
+            f"OAuth proxy authentication requires the following fields: {', '.join(missing_fields)}"
+        )
+
+    # Create a token verifier (can use JWTVerifier or StaticTokenVerifier)
+    try:
+        from fastmcp.server.auth import StaticTokenVerifier
+        token_verifier = StaticTokenVerifier()  # Basic token verifier
+    except ImportError:
+        # Fallback to JWT verifier if StaticTokenVerifier not available
+        token_verifier = JWTVerifier()
+
+    base_url = auth_config["redirect_uri"].rstrip("/auth/callback")
+    
+    oauth_kwargs = {
+        "upstream_authorization_endpoint": auth_config["authorization_url"],
+        "upstream_token_endpoint": auth_config["token_url"],
+        "upstream_client_id": auth_config["client_id"],
+        "upstream_client_secret": auth_config["client_secret"],
+        "token_verifier": token_verifier,
+        "base_url": base_url,
+    }
+
+    # Add optional parameters
+    if auth_config.get("userinfo_url"):
+        oauth_kwargs["upstream_revocation_endpoint"] = auth_config["userinfo_url"]
+    if auth_config.get("scopes"):
+        oauth_kwargs["valid_scopes"] = auth_config["scopes"]
+
+    try:
+        provider = OAuthProxy(**oauth_kwargs)
+    except ValueError as exc:
+        raise ConfigurationException(str(exc)) from exc
+    except Exception as exc:
+        raise ConfigurationException(
+            f"Failed to initialize OAuth proxy authentication provider: {exc}"
+        ) from exc
+
+    logging.info("Server authentication enabled using OAuth proxy provider")
+    return provider
+
+
+def _get_provider_config(provider_type: str, auth_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Get provider-specific OAuth configuration.
+
+    Args:
+        provider_type (str): The OAuth provider type (google, azure, etc.)
+        auth_config (Dict[str, Any]): Full authentication configuration.
+
+    Returns:
+        Dict[str, Any]: Provider-specific configuration parameters.
+
+    Raises:
+        ConfigurationException: If provider type is not supported.
+    """
+    config = {}
+    
+    # Add custom scopes if specified
+    if auth_config.get("scopes"):
+        config["scopes"] = auth_config["scopes"]
+    
+    # Add custom redirect URI if specified
+    if auth_config.get("redirect_uri"):
+        config["redirect_uri"] = auth_config["redirect_uri"]
+        
+    # Provider-specific defaults and overrides
+    if provider_type == "google":
+        if not auth_config.get("scopes"):
+            config["scopes"] = ["openid", "email", "profile"]
+    elif provider_type == "azure":
+        if not auth_config.get("scopes"):
+            config["scopes"] = ["openid", "email", "profile"]
+    elif provider_type == "auth0":
+        if not auth_config.get("scopes"):
+            config["scopes"] = ["openid", "email", "profile"]
+    elif provider_type == "github":
+        if not auth_config.get("scopes"):
+            config["scopes"] = ["user:email"]
+    elif provider_type == "okta":
+        if not auth_config.get("scopes"):
+            config["scopes"] = ["openid", "email", "profile"]
+    elif provider_type == "generic":
+        # Generic provider requires explicit configuration
+        pass
+    else:
+        raise ConfigurationException(
+            f"Unsupported OAuth provider type: {provider_type}. "
+            f"Supported types: google, azure, auth0, github, okta, generic"
+        )
+    
+    return config
+
+
+def supports_transport(auth_provider: AuthProvider, transport: str) -> bool:
+    """Check if an auth provider supports a given transport.
+
+    Args:
+        auth_provider (AuthProvider): The authentication provider to check.
+        transport (str): The transport type (stdio, sse, http).
+
+    Returns:
+        bool: True if the provider supports the transport, False otherwise.
+    """
+    # OAuth providers only work with HTTP-based transports
+    if isinstance(auth_provider, (RemoteAuthProvider, OAuthProxy, OAuthProvider)):
+        return transport in ("sse", "http")
+    
+    # JWT can work with any transport
+    if isinstance(auth_provider, JWTVerifier):
+        return True
+    
+    # Default: assume compatibility
+    return True

--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -186,7 +186,7 @@ class Config(object):
         ),
     )
 
-    server_auth_type: Literal["none", "jwt"] = Field(
+    server_auth_type: Literal["none", "jwt", "oauth", "oauth_proxy"] = Field(
         description="Authentication provider type used to secure the MCP server",
         default_factory=default_factory(
             env.getstr,
@@ -194,7 +194,7 @@ class Config(object):
         ),
         json_schema_extra=options(
             "--auth-type",
-            choices=("none", "jwt"),
+            choices=("none", "jwt", "oauth", "oauth_proxy"),
             metavar="<type>",
         ),
     )
@@ -268,6 +268,105 @@ class Config(object):
         json_schema_extra=options(
             "--auth-required-scopes",
             metavar="<scopes>",
+        ),
+    )
+
+    server_auth_oauth_client_id: str | None = Field(
+        description="OAuth client ID for authentication",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_ID",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-client-id",
+            metavar="<client_id>",
+        ),
+    )
+
+    server_auth_oauth_client_secret: str | None = Field(
+        description="OAuth client secret for authentication",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_SECRET",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-client-secret",
+            metavar="<client_secret>",
+        ),
+    )
+
+    server_auth_oauth_authorization_url: str | None = Field(
+        description="OAuth authorization endpoint URL",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-authorization-url",
+            metavar="<url>",
+        ),
+    )
+
+    server_auth_oauth_token_url: str | None = Field(
+        description="OAuth token endpoint URL",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-token-url",
+            metavar="<url>",
+        ),
+    )
+
+    server_auth_oauth_userinfo_url: str | None = Field(
+        description="OAuth userinfo endpoint URL",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_USERINFO_URL",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-userinfo-url",
+            metavar="<url>",
+        ),
+    )
+
+    server_auth_oauth_scopes: str | None = Field(
+        description="OAuth scopes to request (space or comma separated)",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_SCOPES",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-scopes",
+            metavar="<scopes>",
+        ),
+    )
+
+    server_auth_oauth_redirect_uri: str | None = Field(
+        description="OAuth redirect URI for callback",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-redirect-uri",
+            metavar="<uri>",
+        ),
+    )
+
+    server_auth_oauth_provider_type: Literal[
+        "generic", "google", "azure", "auth0", "github", "okta"
+    ] | None = Field(
+        description="OAuth provider type for predefined configurations",
+        default_factory=default_factory(
+            env.getstr,
+            "ITENTIAL_MCP_SERVER_AUTH_OAUTH_PROVIDER_TYPE",
+        ),
+        json_schema_extra=options(
+            "--auth-oauth-provider-type",
+            choices=("generic", "google", "azure", "auth0", "github", "okta"),
+            metavar="<type>",
         ),
     )
 
@@ -404,14 +503,31 @@ class Config(object):
             else None
         )
 
+        # Handle OAuth scopes parsing
+        oauth_scopes = None
+        if self.server_auth_oauth_scopes:
+            # Support both space and comma separated scopes
+            scopes_str = self.server_auth_oauth_scopes.replace(",", " ")
+            oauth_scopes = [s.strip() for s in scopes_str.split() if s.strip()]
+
         data: dict[str, Any] = {
             "type": auth_type,
+            # JWT-specific fields
             "jwks_uri": self.server_auth_jwks_uri or None,
             "public_key": self.server_auth_public_key or None,
             "issuer": self.server_auth_issuer or None,
             "audience": audience,
             "algorithm": self.server_auth_algorithm or None,
             "required_scopes": required_scopes,
+            # OAuth-specific fields
+            "client_id": self.server_auth_oauth_client_id or None,
+            "client_secret": self.server_auth_oauth_client_secret or None,
+            "authorization_url": self.server_auth_oauth_authorization_url or None,
+            "token_url": self.server_auth_oauth_token_url or None,
+            "userinfo_url": self.server_auth_oauth_userinfo_url or None,
+            "scopes": oauth_scopes,
+            "redirect_uri": self.server_auth_oauth_redirect_uri or None,
+            "provider_type": self.server_auth_oauth_provider_type or None,
         }
 
         return {k: v for k, v in data.items() if v not in (None, "", [])}

--- a/src/itential_mcp/defaults.py
+++ b/src/itential_mcp/defaults.py
@@ -36,6 +36,16 @@ ITENTIAL_MCP_SERVER_AUTH_REQUIRED_SCOPES = (
     None  # Comma separated list of required scopes
 )
 
+# OAuth Configuration Defaults
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_ID = None  # OAuth client ID for authentication
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_SECRET = None  # OAuth client secret for authentication
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL = None  # OAuth authorization endpoint URL
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL = None  # OAuth token endpoint URL
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_USERINFO_URL = None  # OAuth userinfo endpoint URL
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_SCOPES = None  # OAuth scopes to request
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI = None  # OAuth redirect URI for callback
+ITENTIAL_MCP_SERVER_AUTH_OAUTH_PROVIDER_TYPE = None  # OAuth provider type for predefined configurations
+
 # Platform Configuration Defaults
 ITENTIAL_MCP_PLATFORM_HOST = "localhost"  # Itential Platform server hostname
 ITENTIAL_MCP_PLATFORM_PORT = 0  # Platform server port (0 = use default for protocol)

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -108,6 +108,16 @@ class Server:
         logging.info("Initializing the MCP server instance")
 
         auth_provider = auth.build_auth_provider(self.config)
+        
+        # Validate auth provider compatibility with transport
+        transport = self.config.server.get("transport")
+        if auth_provider and not auth.supports_transport(auth_provider, transport):
+            from .core.exceptions import ConfigurationException
+            raise ConfigurationException(
+                f"Authentication provider {type(auth_provider).__name__} "
+                f"is not supported for transport '{transport}'. "
+                f"OAuth providers require HTTP-based transports (sse or http)."
+            )
 
         # Initialize FastMCP server
         self.mcp = FastMCP(

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from itential_mcp.auth import (
+    build_auth_provider,
+    _build_oauth_provider,
+    _build_oauth_proxy_provider,
+    _get_provider_config,
+    supports_transport
+)
+from itential_mcp.config import Config
+from itential_mcp.core.exceptions import ConfigurationException
+
+from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider, OAuthProxy, OAuthProvider
+
+
+class TestOAuthConfiguration:
+    """Test OAuth configuration parsing and validation."""
+    
+    def test_oauth_scopes_parsing_comma_separated(self):
+        """Test OAuth scopes parsing with comma-separated values."""
+        config_data = {
+            "server_auth_oauth_scopes": "openid,email,profile"
+        }
+        config = Config(**config_data)
+        auth_config = config.auth
+        
+        assert auth_config["scopes"] == ["openid", "email", "profile"]
+    
+    def test_oauth_scopes_parsing_space_separated(self):
+        """Test OAuth scopes parsing with space-separated values."""
+        config_data = {
+            "server_auth_oauth_scopes": "openid email profile"
+        }
+        config = Config(**config_data)
+        auth_config = config.auth
+        
+        assert auth_config["scopes"] == ["openid", "email", "profile"]
+    
+    def test_oauth_scopes_parsing_mixed_separators(self):
+        """Test OAuth scopes parsing with mixed separators."""
+        config_data = {
+            "server_auth_oauth_scopes": "openid, email profile,user:read"
+        }
+        config = Config(**config_data)
+        auth_config = config.auth
+        
+        assert auth_config["scopes"] == ["openid", "email", "profile", "user:read"]
+    
+    def test_oauth_config_includes_all_fields(self):
+        """Test that OAuth configuration includes all relevant fields."""
+        config_data = {
+            "server_auth_type": "oauth",
+            "server_auth_oauth_client_id": "test_client",
+            "server_auth_oauth_client_secret": "test_secret",
+            "server_auth_oauth_authorization_url": "https://auth.example.com/oauth/authorize",
+            "server_auth_oauth_token_url": "https://auth.example.com/oauth/token",
+            "server_auth_oauth_userinfo_url": "https://auth.example.com/oauth/userinfo",
+            "server_auth_oauth_scopes": "openid email profile",
+            "server_auth_oauth_redirect_uri": "http://localhost:8000/callback",
+            "server_auth_oauth_provider_type": "generic"
+        }
+        config = Config(**config_data)
+        auth_config = config.auth
+        
+        assert auth_config["type"] == "oauth"
+        assert auth_config["client_id"] == "test_client"
+        assert auth_config["client_secret"] == "test_secret"
+        assert auth_config["authorization_url"] == "https://auth.example.com/oauth/authorize"
+        assert auth_config["token_url"] == "https://auth.example.com/oauth/token"
+        assert auth_config["userinfo_url"] == "https://auth.example.com/oauth/userinfo"
+        assert auth_config["scopes"] == ["openid", "email", "profile"]
+        assert auth_config["redirect_uri"] == "http://localhost:8000/callback"
+        assert auth_config["provider_type"] == "generic"
+    
+    def test_oauth_config_excludes_none_values(self):
+        """Test that OAuth configuration excludes None values."""
+        config_data = {
+            "server_auth_type": "oauth",
+            "server_auth_oauth_client_id": "test_client"
+        }
+        config = Config(**config_data)
+        auth_config = config.auth
+        
+        assert "client_secret" not in auth_config
+        assert "authorization_url" not in auth_config
+        assert "token_url" not in auth_config
+
+
+class TestOAuthProviderBuilding:
+    """Test OAuth provider building logic."""
+    
+    @patch("itential_mcp.auth.OAuthProvider")
+    def test_build_oauth_provider_success(self, mock_oauth_provider):
+        """Test successful OAuth provider building."""
+        auth_config = {
+            "type": "oauth",
+            "redirect_uri": "http://localhost:8000/auth/callback"
+        }
+        
+        mock_provider = MagicMock()
+        mock_oauth_provider.return_value = mock_provider
+        
+        result = _build_oauth_provider(auth_config)
+        
+        assert result == mock_provider
+        mock_oauth_provider.assert_called_once_with(
+            base_url="http://localhost:8000"
+        )
+    
+    def test_build_oauth_provider_missing_required_fields(self):
+        """Test OAuth provider building with missing required fields."""
+        auth_config = {
+            "type": "oauth"
+            # Missing redirect_uri
+        }
+        
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_provider(auth_config)
+        
+        assert "requires the following fields" in str(exc_info.value)
+        assert "redirect_uri" in str(exc_info.value)
+    
+    @patch("itential_mcp.auth.OAuthProvider")
+    def test_build_oauth_provider_with_optional_fields(self, mock_oauth_provider):
+        """Test OAuth provider building with optional fields."""
+        auth_config = {
+            "type": "oauth",
+            "redirect_uri": "http://localhost:8000/auth/callback",
+            "scopes": ["openid", "email"]
+        }
+        
+        mock_provider = MagicMock()
+        mock_oauth_provider.return_value = mock_provider
+        
+        _build_oauth_provider(auth_config)
+        
+        mock_oauth_provider.assert_called_once_with(
+            base_url="http://localhost:8000",
+            required_scopes=["openid", "email"]
+        )
+    
+    @patch("itential_mcp.auth.OAuthProxy")
+    @patch("fastmcp.server.auth.StaticTokenVerifier")
+    def test_build_oauth_proxy_provider_success(self, mock_token_verifier, mock_oauth_proxy):
+        """Test successful OAuth proxy provider building."""
+        auth_config = {
+            "type": "oauth_proxy",
+            "client_id": "test_client",
+            "client_secret": "test_secret",
+            "authorization_url": "https://accounts.google.com/oauth/authorize",
+            "token_url": "https://oauth2.googleapis.com/token",
+            "redirect_uri": "http://localhost:8000/auth/callback"
+        }
+        
+        mock_verifier_instance = MagicMock()
+        mock_token_verifier.return_value = mock_verifier_instance
+        
+        mock_provider = MagicMock()
+        mock_oauth_proxy.return_value = mock_provider
+        
+        result = _build_oauth_proxy_provider(auth_config)
+        
+        assert result == mock_provider
+        mock_oauth_proxy.assert_called_once_with(
+            upstream_authorization_endpoint="https://accounts.google.com/oauth/authorize",
+            upstream_token_endpoint="https://oauth2.googleapis.com/token",
+            upstream_client_id="test_client",
+            upstream_client_secret="test_secret",
+            token_verifier=mock_verifier_instance,
+            base_url="http://localhost:8000"
+        )
+    
+    def test_build_oauth_proxy_provider_missing_fields(self):
+        """Test OAuth proxy provider building with missing required fields."""
+        auth_config = {
+            "type": "oauth_proxy",
+            "client_id": "test_client"
+            # Missing client_secret, authorization_url, token_url, redirect_uri
+        }
+        
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_proxy_provider(auth_config)
+        
+        assert "requires the following fields" in str(exc_info.value)
+        assert "client_secret" in str(exc_info.value)
+        assert "authorization_url" in str(exc_info.value)
+        assert "token_url" in str(exc_info.value)
+        assert "redirect_uri" in str(exc_info.value)
+
+
+class TestProviderConfiguration:
+    """Test provider-specific configuration logic."""
+    
+    def test_google_provider_config(self):
+        """Test Google provider configuration defaults."""
+        auth_config = {}
+        config = _get_provider_config("google", auth_config)
+        
+        assert config["scopes"] == ["openid", "email", "profile"]
+    
+    def test_azure_provider_config(self):
+        """Test Azure provider configuration defaults."""
+        auth_config = {}
+        config = _get_provider_config("azure", auth_config)
+        
+        assert config["scopes"] == ["openid", "email", "profile"]
+    
+    def test_github_provider_config(self):
+        """Test GitHub provider configuration defaults."""
+        auth_config = {}
+        config = _get_provider_config("github", auth_config)
+        
+        assert config["scopes"] == ["user:email"]
+    
+    def test_provider_config_custom_scopes(self):
+        """Test provider configuration with custom scopes."""
+        auth_config = {"scopes": ["custom", "scope"]}
+        config = _get_provider_config("google", auth_config)
+        
+        assert config["scopes"] == ["custom", "scope"]
+    
+    def test_provider_config_custom_redirect_uri(self):
+        """Test provider configuration with custom redirect URI."""
+        auth_config = {"redirect_uri": "http://custom.example.com/callback"}
+        config = _get_provider_config("google", auth_config)
+        
+        assert config["redirect_uri"] == "http://custom.example.com/callback"
+        assert config["scopes"] == ["openid", "email", "profile"]
+    
+    def test_unsupported_provider_type(self):
+        """Test unsupported provider type raises exception."""
+        auth_config = {}
+        
+        with pytest.raises(ConfigurationException) as exc_info:
+            _get_provider_config("unsupported", auth_config)
+        
+        assert "Unsupported OAuth provider type" in str(exc_info.value)
+        assert "unsupported" in str(exc_info.value)
+
+
+class TestTransportCompatibility:
+    """Test transport compatibility validation."""
+    
+    def test_jwt_supports_all_transports(self):
+        """Test that JWT providers support all transport types."""
+        jwt_provider = MagicMock(spec=JWTVerifier)
+        
+        assert supports_transport(jwt_provider, "stdio")
+        assert supports_transport(jwt_provider, "sse")
+        assert supports_transport(jwt_provider, "http")
+    
+    def test_oauth_providers_support_http_transports_only(self):
+        """Test that OAuth providers only support HTTP-based transports."""
+        remote_provider = MagicMock(spec=RemoteAuthProvider)
+        oauth_proxy = MagicMock(spec=OAuthProxy)
+        oauth_provider = MagicMock(spec=OAuthProvider)
+        
+        for provider in [remote_provider, oauth_proxy, oauth_provider]:
+            assert not supports_transport(provider, "stdio")
+            assert supports_transport(provider, "sse")
+            assert supports_transport(provider, "http")
+
+
+class TestFullAuthProviderFactory:
+    """Test the complete auth provider factory."""
+    
+    def test_no_auth_provider(self):
+        """Test building no auth provider."""
+        config = Config()
+        provider = build_auth_provider(config)
+        assert provider is None
+    
+    def test_none_auth_provider(self):
+        """Test building none auth provider."""
+        config_data = {"server_auth_type": "none"}
+        config = Config(**config_data)
+        provider = build_auth_provider(config)
+        assert provider is None
+    
+    @patch("itential_mcp.auth.JWTVerifier")
+    def test_jwt_auth_provider(self, mock_jwt):
+        """Test building JWT auth provider."""
+        config_data = {
+            "server_auth_type": "jwt",
+            "server_auth_public_key": "test_key"
+        }
+        config = Config(**config_data)
+        
+        mock_provider = MagicMock()
+        mock_jwt.return_value = mock_provider
+        
+        provider = build_auth_provider(config)
+        assert provider == mock_provider
+    
+    @patch("itential_mcp.auth.OAuthProvider")
+    def test_oauth_auth_provider(self, mock_oauth_provider):
+        """Test building OAuth auth provider."""
+        config_data = {
+            "server_auth_type": "oauth",
+            "server_auth_oauth_redirect_uri": "http://localhost:8000/auth/callback"
+        }
+        config = Config(**config_data)
+        
+        mock_provider = MagicMock()
+        mock_oauth_provider.return_value = mock_provider
+        
+        provider = build_auth_provider(config)
+        assert provider == mock_provider
+    
+    @patch("itential_mcp.auth.OAuthProxy")
+    @patch("fastmcp.server.auth.StaticTokenVerifier")
+    def test_oauth_proxy_auth_provider(self, mock_token_verifier, mock_oauth_proxy):
+        """Test building OAuth proxy auth provider."""
+        config_data = {
+            "server_auth_type": "oauth_proxy",
+            "server_auth_oauth_client_id": "test_client",
+            "server_auth_oauth_client_secret": "test_secret",
+            "server_auth_oauth_authorization_url": "https://accounts.google.com/oauth/authorize",
+            "server_auth_oauth_token_url": "https://oauth2.googleapis.com/token",
+            "server_auth_oauth_redirect_uri": "http://localhost:8000/auth/callback"
+        }
+        config = Config(**config_data)
+        
+        mock_verifier_instance = MagicMock()
+        mock_token_verifier.return_value = mock_verifier_instance
+        
+        mock_provider = MagicMock()
+        mock_oauth_proxy.return_value = mock_provider
+        
+        provider = build_auth_provider(config)
+        assert provider == mock_provider
+    
+    def test_unsupported_auth_type(self):
+        """Test unsupported auth type raises exception during config validation."""
+        from pydantic import ValidationError
+        
+        config_data = {"server_auth_type": "unsupported"}
+        
+        with pytest.raises(ValidationError) as exc_info:
+            Config(**config_data)
+        
+        assert "Input should be 'none', 'jwt', 'oauth' or 'oauth_proxy'" in str(exc_info.value)


### PR DESCRIPTION
• Add oauth and oauth_proxy authentication types to config 
• Implement OAuth authorization server and proxy providers 
• Add comprehensive OAuth configuration fields with CLI support 
• Include transport compatibility validation (OAuth requires sse/http) 
• Support multiple OAuth providers (Google, Azure, GitHub, Auth0, Okta) 
• Add scopes parsing with space/comma separation support 
• Integrate with FastMCP OAuth providers and token verifiers