### PR TITLE
feat: add async context manager support to PlatformClient

### DIFF
--- a/src/itential_mcp/client.py
+++ b/src/itential_mcp/client.py
@@ -42,6 +42,40 @@ class PlatformClient(object):
         self.client = self._init_client()
         self._init_plugins()
 
+    async def __aenter__(self):
+        """Async context manager entry point.
+
+        Args:
+            None
+
+        Returns:
+            PlatformClient: Returns self for use in context manager.
+
+        Raises:
+            None
+        """
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit point.
+
+        Performs cleanup operations when exiting the context manager.
+        Closes the underlying client connection if it has a close method.
+
+        Args:
+            exc_type: Exception type if an exception occurred, None otherwise.
+            exc_val: Exception value if an exception occurred, None otherwise.
+            exc_tb: Exception traceback if an exception occurred, None otherwise.
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        if hasattr(self.client, "close") and callable(getattr(self.client, "close")):
+            await self.client.close()
+
     def _init_client(self) -> AsyncPlatform:
         """Initialize the client connection to Itential Platform.
 

--- a/src/itential_mcp/server.py
+++ b/src/itential_mcp/server.py
@@ -19,10 +19,9 @@ from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from . import auth
 from . import client
 from . import config
-from .utilities import tool as toolutils
 from . import bindings
 from .core import logging
-
+from .utilities import tool as toolutils
 from .middleware.bindings import BindingsMiddleware
 
 
@@ -55,15 +54,9 @@ async def lifespan(mcp: FastMCP) -> AsyncGenerator[dict[str | Any], None]:
         dict: Context containing:
             - client: PlatformClient instance for Itential API calls
     """
-    # Create client instance
-    client_instance = client.PlatformClient()
-
-    try:
+    # Use PlatformClient as an async context manager
+    async with client.PlatformClient() as client_instance:
         yield {"client": client_instance}
-
-    finally:
-        # No cleanup needed for client
-        pass
 
 
 class Server:


### PR DESCRIPTION
• Add __aenter__ and __aexit__ methods to PlatformClient class 
• Enable proper resource cleanup with automatic connection closing 
• Update server lifespan function to use PlatformClient as context manager 
• Simplify lifespan implementation by removing manual try/finally blocks