### PR TITLE
refactor: convert server.py to server package structure

### DIFF
--- a/src/itential_mcp/runner.py
+++ b/src/itential_mcp/runner.py
@@ -8,7 +8,7 @@ from typing import Mapping, Any
 from fastmcp import Client
 
 from itential_mcp import config
-from itential_mcp import server
+from itential_mcp.server.server import Server
 
 
 async def run(tool: str, params: Mapping[str, Any] | None = None) -> None:
@@ -42,7 +42,7 @@ async def run(tool: str, params: Mapping[str, Any] | None = None) -> None:
 
         ValueError: If there are invalid parameters
     """
-    async with server.Server(config.get()) as srv:
+    async with Server(config.get()) as srv:
         async with Client(srv.mcp) as client:
             # Basic server interaction
             if await client.ping() is False:

--- a/src/itential_mcp/server/__init__.py
+++ b/src/itential_mcp/server/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from .server import run
+
+__all__ = ("run",)

--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -10,9 +10,9 @@ from typing import Dict, Any
 
 from fastmcp.server.auth import AuthProvider, JWTVerifier, RemoteAuthProvider, OAuthProxy, OAuthProvider
 
-from .core import logging
-from .config import Config
-from .core.exceptions import ConfigurationException
+from ..core import logging
+from ..config import Config
+from ..core.exceptions import ConfigurationException
 
 
 def build_auth_provider(cfg: Config) -> AuthProvider | None:

--- a/src/itential_mcp/server/server.py
+++ b/src/itential_mcp/server/server.py
@@ -18,14 +18,14 @@ from fastmcp.server.middleware.logging import LoggingMiddleware
 from fastmcp.server.middleware.timing import DetailedTimingMiddleware
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 
-from . import auth
-from .platform import PlatformClient
-from . import config
-from . import bindings
-from .core import logging
-from .core import metadata
-from .utilities import tool as toolutils
-from .middleware.bindings import BindingsMiddleware
+from .auth import build_auth_provider, supports_transport
+from ..platform import PlatformClient
+from .. import config
+from .. import bindings
+from ..core import logging
+from ..core import metadata
+from ..utilities import tool as toolutils
+from ..middleware.bindings import BindingsMiddleware
 
 
 INSTRUCTIONS = """
@@ -103,12 +103,12 @@ class Server:
         """Initialize a new FastMCP server instance with Itential Platform integration."""
         logging.info("Initializing the MCP server instance")
 
-        auth_provider = auth.build_auth_provider(self.config)
-        
+        auth_provider = build_auth_provider(self.config)
+
         # Validate auth provider compatibility with transport
         transport = self.config.server.get("transport")
-        if auth_provider and not auth.supports_transport(auth_provider, transport):
-            from .core.exceptions import ConfigurationException
+        if auth_provider and not supports_transport(auth_provider, transport):
+            from ..core.exceptions import ConfigurationException
             raise ConfigurationException(
                 f"Authentication provider {type(auth_provider).__name__} "
                 f"is not supported for transport '{transport}'. "
@@ -166,7 +166,7 @@ class Server:
         """Initialize tools."""
         logging.info("Adding tools to MCP server")
 
-        tool_paths = [pathlib.Path(__file__).parent / "tools"]
+        tool_paths = [pathlib.Path(__file__).parent.parent / "tools"]
 
         if self.config.server.get("tools_path") is not None:
             tool_paths.append(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from itential_mcp import auth
+from itential_mcp.server import auth
 from itential_mcp.config import Config
 from itential_mcp.core.exceptions import ConfigurationException
 
@@ -21,7 +21,7 @@ class TestBuildAuthProvider:
 
         assert provider is None
 
-    @patch("itential_mcp.auth.JWTVerifier")
+    @patch("itential_mcp.server.auth.JWTVerifier")
     def test_creates_jwt_provider_with_expected_arguments(self, mock_jwt_verifier):
         """JWT provider receives configuration from the Config object."""
         cfg = Config(
@@ -49,7 +49,7 @@ class TestBuildAuthProvider:
         with pytest.raises(ConfigurationException):
             auth.build_auth_provider(cfg)
 
-    @patch("itential_mcp.auth.JWTVerifier", side_effect=ValueError("invalid config"))
+    @patch("itential_mcp.server.auth.JWTVerifier", side_effect=ValueError("invalid config"))
     def test_jwt_verifier_errors_are_wrapped(self, mock_jwt_verifier):
         """JWT verifier errors are wrapped in ConfigurationException."""
         cfg = Config(server_auth_type="jwt")

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -4,7 +4,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from itential_mcp.auth import (
+from itential_mcp.server.auth import (
     build_auth_provider,
     _build_oauth_provider,
     _build_oauth_proxy_provider,
@@ -93,7 +93,7 @@ class TestOAuthConfiguration:
 class TestOAuthProviderBuilding:
     """Test OAuth provider building logic."""
     
-    @patch("itential_mcp.auth.OAuthProvider")
+    @patch("itential_mcp.server.auth.OAuthProvider")
     def test_build_oauth_provider_success(self, mock_oauth_provider):
         """Test successful OAuth provider building."""
         auth_config = {
@@ -124,7 +124,7 @@ class TestOAuthProviderBuilding:
         assert "requires the following fields" in str(exc_info.value)
         assert "redirect_uri" in str(exc_info.value)
     
-    @patch("itential_mcp.auth.OAuthProvider")
+    @patch("itential_mcp.server.auth.OAuthProvider")
     def test_build_oauth_provider_with_optional_fields(self, mock_oauth_provider):
         """Test OAuth provider building with optional fields."""
         auth_config = {
@@ -143,7 +143,7 @@ class TestOAuthProviderBuilding:
             required_scopes=["openid", "email"]
         )
     
-    @patch("itential_mcp.auth.OAuthProxy")
+    @patch("itential_mcp.server.auth.OAuthProxy")
     @patch("fastmcp.server.auth.StaticTokenVerifier")
     def test_build_oauth_proxy_provider_success(self, mock_token_verifier, mock_oauth_proxy):
         """Test successful OAuth proxy provider building."""
@@ -281,7 +281,7 @@ class TestFullAuthProviderFactory:
         provider = build_auth_provider(config)
         assert provider is None
     
-    @patch("itential_mcp.auth.JWTVerifier")
+    @patch("itential_mcp.server.auth.JWTVerifier")
     def test_jwt_auth_provider(self, mock_jwt):
         """Test building JWT auth provider."""
         config_data = {
@@ -296,7 +296,7 @@ class TestFullAuthProviderFactory:
         provider = build_auth_provider(config)
         assert provider == mock_provider
     
-    @patch("itential_mcp.auth.OAuthProvider")
+    @patch("itential_mcp.server.auth.OAuthProvider")
     def test_oauth_auth_provider(self, mock_oauth_provider):
         """Test building OAuth auth provider."""
         config_data = {
@@ -311,7 +311,7 @@ class TestFullAuthProviderFactory:
         provider = build_auth_provider(config)
         assert provider == mock_provider
     
-    @patch("itential_mcp.auth.OAuthProxy")
+    @patch("itential_mcp.server.auth.OAuthProxy")
     @patch("fastmcp.server.auth.StaticTokenVerifier")
     def test_oauth_proxy_auth_provider(self, mock_token_verifier, mock_oauth_proxy):
         """Test building OAuth proxy auth provider."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,7 +27,7 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_basic_tool_no_params(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout
@@ -85,7 +85,7 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_tool_with_params(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout
@@ -145,7 +145,7 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_server_ping_failure(
         self, mock_config_get, mock_server_class, mock_client_class
@@ -178,7 +178,7 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_invalid_tool(
         self, mock_config_get, mock_server_class, mock_client_class
@@ -220,7 +220,7 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_missing_required_params(
         self, mock_config_get, mock_server_class, mock_client_class
@@ -276,7 +276,7 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_invalid_params(
         self, mock_config_get, mock_server_class, mock_client_class
@@ -322,7 +322,7 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_tool_no_required_params(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout
@@ -376,7 +376,7 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_multiple_tools_available(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout
@@ -433,7 +433,7 @@ class TestRun:
 
     @pytest.mark.asyncio
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_invalid_json_params(
         self, mock_config_get, mock_server_class, mock_client_class
@@ -473,7 +473,7 @@ class TestRun:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_complex_result_formatting(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout
@@ -535,7 +535,7 @@ class TestRunEdgeCases:
 
     @pytest.mark.asyncio
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_empty_tool_list(
         self, mock_config_get, mock_server_class, mock_client_class
@@ -570,7 +570,7 @@ class TestRunEdgeCases:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_empty_params_string(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout
@@ -621,7 +621,7 @@ class TestRunIntegration:
     @pytest.mark.asyncio
     @patch("sys.stdout", new_callable=StringIO)
     @patch("itential_mcp.runner.Client")
-    @patch("itential_mcp.runner.server.Server")
+    @patch("itential_mcp.runner.Server")
     @patch("itential_mcp.runner.config.get")
     async def test_run_full_workflow(
         self, mock_config_get, mock_server_class, mock_client_class, mock_stdout

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from itential_mcp import server
+from itential_mcp.server import server as server_module
 from itential_mcp.platform import PlatformClient
 from itential_mcp.middleware.bindings import BindingsMiddleware
 
@@ -31,7 +32,7 @@ class TestLifespan:
         """Test that lifespan yields client instance"""
         mcp = MagicMock()
 
-        async with server.lifespan(mcp) as context:
+        async with server_module.lifespan(mcp) as context:
             assert "client" in context
             assert isinstance(context["client"], PlatformClient)
 
@@ -41,7 +42,7 @@ class TestLifespan:
         mcp = MagicMock()
 
         # Test that the async context manager completes without error
-        async with server.lifespan(mcp) as context:
+        async with server_module.lifespan(mcp) as context:
             # Verify we get the expected context
             assert len(context) == 1
             assert "client" in context
@@ -177,9 +178,9 @@ class TestRun:
     """Test the run() function for server execution"""
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_stdio_transport_success(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -209,9 +210,9 @@ class TestRun:
         mock_server_instance.__aexit__.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_sse_transport_success(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -240,9 +241,9 @@ class TestRun:
         mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_http_transport_success(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -272,9 +273,9 @@ class TestRun:
         mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_tool_registration_failure(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -302,9 +303,9 @@ class TestRun:
             mock_exit.assert_called_with(1)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_keyboard_interrupt(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -328,9 +329,9 @@ class TestRun:
             mock_exit.assert_called_with(0)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_unexpected_exception(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -358,9 +359,9 @@ class TestRun:
             mock_exit.assert_called_with(1)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_no_tools_loaded(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -383,9 +384,9 @@ class TestRun:
         mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_multiple_tools_registration(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -409,9 +410,9 @@ class TestRun:
         mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_partial_tool_failure(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -439,9 +440,9 @@ class TestRun:
             mock_exit.assert_called_with(1)
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_config_variations(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -465,9 +466,9 @@ class TestRun:
         mock_server_instance.run.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.Server")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.Server")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_run_missing_server_config_keys(
         self, mock_set_level, mock_config_get, mock_server_class
     ):
@@ -495,10 +496,10 @@ class TestIntegration:
 
     @patch("itential_mcp.server.auth.build_auth_provider")
     @pytest.mark.asyncio
-    @patch("itential_mcp.server.bindings.iterbindings")
-    @patch("itential_mcp.server.toolutils.itertools")
-    @patch("itential_mcp.server.config.get")
-    @patch("itential_mcp.server.logging.set_level")
+    @patch("itential_mcp.server.server.bindings.iterbindings")
+    @patch("itential_mcp.server.server.toolutils.itertools")
+    @patch("itential_mcp.server.server.config.get")
+    @patch("itential_mcp.server.server.logging.set_level")
     async def test_full_server_lifecycle(
         self,
         mock_set_level,
@@ -517,6 +518,7 @@ class TestIntegration:
         }
         mock_config.server_log_level = "INFO"
         mock_config.tools = []
+        mock_config.auth = {"type": "none"}
         mock_config_get.return_value = mock_config
         mock_auth_builder.return_value = None
 
@@ -535,7 +537,7 @@ class TestIntegration:
         mock_iterbindings.return_value = empty_aiter()
 
         # Mock FastMCP to simulate server lifecycle
-        with patch("itential_mcp.server.FastMCP") as mock_fastmcp_class:
+        with patch("itential_mcp.server.server.FastMCP") as mock_fastmcp_class:
             mock_mcp = MagicMock()
             mock_mcp.run_async = AsyncMock()
             mock_fastmcp_class.return_value = mock_mcp
@@ -549,8 +551,8 @@ class TestIntegration:
             # Verify FastMCP was created with correct parameters
             mock_fastmcp_class.assert_called_once_with(
                 name="Itential Platform MCP",
-                instructions=server.inspect.cleandoc(server.INSTRUCTIONS),
-                lifespan=server.lifespan,
+                instructions=server_module.inspect.cleandoc(server_module.INSTRUCTIONS),
+                lifespan=server_module.lifespan,
                 include_tags=["system"],
                 exclude_tags=["deprecated"],
                 auth=None,


### PR DESCRIPTION
• Move server.py → server/server.py with Server class and core functionality 
• Move auth.py → server/auth.py to consolidate authentication within server package 
• Create server/__init__.py exposing only run() function for public API 
• Update runner.py imports to use new Server location 
• Fix all test imports and patch decorators for new module structure 
• Maintain backward compatibility through package-level exports