### PR TITLE
feat: add get_integrations tool with model filtering

### DIFF
--- a/src/itential_mcp/models/integrations.py
+++ b/src/itential_mcp/models/integrations.py
@@ -123,3 +123,74 @@ class CreateIntegrationModelResponse(BaseModel):
             )
         ),
     ]
+
+
+class GetIntegrationsElement(BaseModel):
+    """Represents a single integration instance element.
+
+    This model represents an individual integration instance returned by the
+    get integrations API endpoint, containing information about the
+    integration's name, associated model, and configuration properties.
+
+    Attributes:
+        name: Name of the integration instance.
+        model: Integration model associated with this instance.
+        properties: The integration model schema and configuration.
+    """
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Name of the integration instance
+                """
+            )
+        ),
+    ]
+
+    model: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Integration model assoicated with this instance
+                """
+            )
+        ),
+    ]
+
+    properties: Annotated[
+        dict,
+        Field(
+            description=inspect.cleandoc(
+                """
+                The integration model schema
+                """
+            )
+        ),
+    ]
+
+class GetIntegrationsResponse(RootModel):
+    """Response model for the get integrations API endpoint.
+
+    This root model wraps a list of GetIntegrationsElement objects representing
+    all integration instances on the Itential Platform server.
+
+    Attributes:
+        root: List of integration instance elements, each containing instance details.
+    """
+
+    root: Annotated[
+        List[GetIntegrationsElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                A list of elements where each element represents an integration
+                instance from the server
+                """
+            )
+        ),
+    ]
+
+

--- a/src/itential_mcp/platform/services/integrations.py
+++ b/src/itential_mcp/platform/services/integrations.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import Any
 
 from itential_mcp.core import exceptions
 
@@ -19,6 +20,62 @@ class Service(ServiceBase):
     """
 
     name: str = "integrations"
+
+    async def get_integrations(self, model: str | None = None) -> list[dict[str, Any]]:
+        """
+        Get all integration instances from Itential Platform with optional filtering.
+
+        Integration instances are configured implementations of integration models
+        that define connections to external systems. This method retrieves all
+        instances or filters by a specific model type.
+
+        Args:
+            model (str | None): Optional model name to filter results. If provided,
+                only returns integration instances associated with the specified model.
+                Defaults to None (returns all instances).
+
+        Returns:
+            list[dict[str, Any]]: List of integration instance dictionaries containing:
+                - name: The integration instance name
+                - model: The associated integration model
+                - properties: Configuration schema and properties
+
+        Raises:
+            ConnectionException: If there is an error connecting to the platform
+            AuthenticationException: If authentication credentials are invalid
+        """
+        limit = 100
+        skip = 0
+
+        params = {"limit": limit}
+
+        if model is not None:
+            params.update({
+                "containsField": "model",
+                "contains": model
+            })
+
+        results = list()
+
+        while True:
+            params["skip"] = skip
+
+            res = await self.client.get(
+                "/integrations",
+                params=params,
+            )
+
+            data = res.json()
+
+            results.extend([x["data"] for x in data["results"]])
+
+            if len(results) == data["total"]:
+                break
+
+            skip += limit
+
+        return results
+
 
     async def get_integration_models(self) -> dict:
         """

--- a/src/itential_mcp/tools/integrations.py
+++ b/src/itential_mcp/tools/integrations.py
@@ -14,6 +14,58 @@ from itential_mcp.models import integrations as models
 __tags__ = ("integrations",)
 
 
+async def get_integrations(
+    ctx: Annotated[Context, Field(
+        description="The FastMCP Context object"
+    )],
+    model: Annotated[str | None, Field(
+        description="Return only integrations for the specified model",
+        default=None
+    )]
+) -> models.GetIntegrationsResponse:
+    """
+    Get all integration instances from Itential Platform with optional model filtering.
+
+    This function retrieves integration instances from the Itential Platform.
+    Integration instances are configured implementations of integration models
+    that define connections to external systems.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+        model (str | None): Optional model name to filter results. If provided,
+            only returns integration instances associated with the specified model.
+            Defaults to None (returns all instances).
+
+    Returns:
+        GetIntegrationsResponse: Response containing a list of integration instance
+            objects with the following fields:
+                - name: The integration instance name
+                - model: The associated integration model
+                - properties: Configuration schema and properties
+
+    Raises:
+        Exception: If there is an error retrieving integrations from the platform
+    """
+    await ctx.info("inside get_integrations(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    res = await client.integrations.get_integrations(model=model)
+
+    results = list()
+
+    for ele in res:
+        results.append(
+            models.GetIntegrationsElement(
+                name=ele["name"],
+                model=ele["model"],
+                properties=ele["properties"],
+            )
+        )
+
+    return models.GetIntegrationsResponse(root=results)
+
+
 async def get_integration_models(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetIntegrationModelsResponse:

--- a/tests/test_models_integrations.py
+++ b/tests/test_models_integrations.py
@@ -8,6 +8,8 @@ from itential_mcp.models.integrations import (
     GetIntegrationModelsElement,
     GetIntegrationModelsResponse,
     CreateIntegrationModelResponse,
+    GetIntegrationsElement,
+    GetIntegrationsResponse,
 )
 
 
@@ -613,3 +615,404 @@ class TestModelValidationEdgeCases:
                 description="Version format test",
             )
             assert element.version == version
+
+
+class TestGetIntegrationsElement:
+    """Test cases for GetIntegrationsElement model"""
+
+    def test_get_integrations_element_valid_creation(self):
+        """Test creating GetIntegrationsElement with valid data"""
+        element = GetIntegrationsElement(
+            name="cisco-switch-01",
+            model="cisco-ios",
+            properties={
+                "hostname": "192.168.1.1",
+                "username": "admin",
+                "protocol": "ssh"
+            },
+        )
+
+        assert element.name == "cisco-switch-01"
+        assert element.model == "cisco-ios"
+        assert element.properties["hostname"] == "192.168.1.1"
+        assert element.properties["username"] == "admin"
+        assert element.properties["protocol"] == "ssh"
+
+    def test_get_integrations_element_missing_required_fields(self):
+        """Test GetIntegrationsElement with missing required fields"""
+        with pytest.raises(ValidationError) as exc_info:
+            GetIntegrationsElement()
+
+        errors = exc_info.value.errors()
+        required_fields = {"name", "model", "properties"}
+        missing_fields = {
+            error["loc"][0] for error in errors if error["type"] == "missing"
+        }
+
+        assert required_fields == missing_fields
+
+    def test_get_integrations_element_serialization(self):
+        """Test GetIntegrationsElement serialization to dict"""
+        element = GetIntegrationsElement(
+            name="test-router",
+            model="juniper-junos",
+            properties={
+                "device_type": "router",
+                "management_ip": "10.0.0.1",
+                "enabled": True
+            },
+        )
+
+        expected_dict = {
+            "name": "test-router",
+            "model": "juniper-junos",
+            "properties": {
+                "device_type": "router",
+                "management_ip": "10.0.0.1",
+                "enabled": True
+            },
+        }
+
+        assert element.model_dump() == expected_dict
+
+    def test_get_integrations_element_json_serialization(self):
+        """Test GetIntegrationsElement JSON serialization"""
+        element = GetIntegrationsElement(
+            name="json-test-device",
+            model="generic-snmp",
+            properties={"community": "public", "version": "v2c"},
+        )
+
+        json_str = element.model_dump_json()
+        assert '"name":"json-test-device"' in json_str
+        assert '"model":"generic-snmp"' in json_str
+        assert '"community":"public"' in json_str
+
+    def test_get_integrations_element_field_validation(self):
+        """Test GetIntegrationsElement field type validation"""
+        # Test non-string name
+        with pytest.raises(ValidationError):
+            GetIntegrationsElement(name=123, model="test", properties={})
+
+        # Test non-string model
+        with pytest.raises(ValidationError):
+            GetIntegrationsElement(name="test", model=456, properties={})
+
+        # Test non-dict properties
+        with pytest.raises(ValidationError):
+            GetIntegrationsElement(name="test", model="test", properties="invalid")
+
+    def test_get_integrations_element_empty_properties(self):
+        """Test GetIntegrationsElement with empty properties dict"""
+        element = GetIntegrationsElement(
+            name="minimal-device", model="minimal-model", properties={}
+        )
+
+        assert element.name == "minimal-device"
+        assert element.model == "minimal-model"
+        assert element.properties == {}
+
+    def test_get_integrations_element_complex_properties(self):
+        """Test GetIntegrationsElement with complex nested properties"""
+        complex_properties = {
+            "connection": {
+                "host": "192.168.1.100",
+                "port": 22,
+                "timeout": 30,
+                "credentials": {
+                    "username": "netadmin",
+                    "auth_method": "key"
+                }
+            },
+            "capabilities": ["ssh", "netconf", "snmp"],
+            "metadata": {
+                "location": "datacenter-1",
+                "rack": "A-12",
+                "environment": "production"
+            },
+            "monitoring": {
+                "enabled": True,
+                "interval": 60,
+                "thresholds": {
+                    "cpu": 80,
+                    "memory": 90,
+                    "disk": 95
+                }
+            }
+        }
+
+        element = GetIntegrationsElement(
+            name="complex-device",
+            model="multi-vendor-network",
+            properties=complex_properties,
+        )
+
+        assert element.name == "complex-device"
+        assert element.model == "multi-vendor-network"
+        assert element.properties["connection"]["host"] == "192.168.1.100"
+        assert "netconf" in element.properties["capabilities"]
+        assert element.properties["monitoring"]["thresholds"]["cpu"] == 80
+
+    def test_get_integrations_element_unicode_support(self):
+        """Test GetIntegrationsElement with Unicode characters"""
+        element = GetIntegrationsElement(
+            name="设备-测试-01",
+            model="multi-语言-model",
+            properties={"描述": "测试设备", "位置": "北京机房 🏢"},
+        )
+
+        assert element.name == "设备-测试-01"
+        assert element.model == "multi-语言-model"
+        assert element.properties["描述"] == "测试设备"
+        assert "🏢" in element.properties["位置"]
+
+    def test_get_integrations_element_realistic_data(self):
+        """Test GetIntegrationsElement with realistic network device data"""
+        element = GetIntegrationsElement(
+            name="core-switch-01",
+            model="cisco-catalyst-9000",
+            properties={
+                "management_ip": "10.1.1.10",
+                "snmp_community": "network_ro",
+                "ssh_port": 22,
+                "device_type": "switch",
+                "os_version": "16.12.09",
+                "serial_number": "FDO2048A1B2",
+                "location": "Main DC - Rack 15",
+                "vlans": [10, 20, 30, 100, 200],
+                "interfaces": {
+                    "GigabitEthernet1/0/1": {"status": "up", "vlan": 10},
+                    "GigabitEthernet1/0/2": {"status": "up", "vlan": 20}
+                }
+            },
+        )
+
+        assert element.name == "core-switch-01"
+        assert element.model == "cisco-catalyst-9000"
+        assert element.properties["management_ip"] == "10.1.1.10"
+        assert 100 in element.properties["vlans"]
+        assert element.properties["interfaces"]["GigabitEthernet1/0/1"]["vlan"] == 10
+
+
+class TestGetIntegrationsResponse:
+    """Test cases for GetIntegrationsResponse model"""
+
+    def test_get_integrations_response_empty_list(self):
+        """Test GetIntegrationsResponse with empty integrations list"""
+        response = GetIntegrationsResponse(root=[])
+        assert response.root == []
+
+    def test_get_integrations_response_single_integration(self):
+        """Test GetIntegrationsResponse with single integration"""
+        integration = GetIntegrationsElement(
+            name="single-device",
+            model="single-model",
+            properties={"ip": "192.168.1.1"},
+        )
+
+        response = GetIntegrationsResponse(root=[integration])
+        assert len(response.root) == 1
+        assert response.root[0].name == "single-device"
+
+    def test_get_integrations_response_multiple_integrations(self):
+        """Test GetIntegrationsResponse with multiple integrations"""
+        integrations = [
+            GetIntegrationsElement(
+                name=f"device-{i}",
+                model=f"model-{i}",
+                properties={"id": i, "status": "active"},
+            )
+            for i in range(5)
+        ]
+
+        response = GetIntegrationsResponse(root=integrations)
+        assert len(response.root) == 5
+
+        for i, integration in enumerate(response.root):
+            assert integration.name == f"device-{i}"
+            assert integration.model == f"model-{i}"
+            assert integration.properties["id"] == i
+
+    def test_get_integrations_response_different_models(self):
+        """Test GetIntegrationsResponse with integrations using different models"""
+        integrations = [
+            GetIntegrationsElement(
+                name="cisco-switch",
+                model="cisco-ios",
+                properties={"vendor": "cisco", "os": "ios"},
+            ),
+            GetIntegrationsElement(
+                name="juniper-router",
+                model="juniper-junos",
+                properties={"vendor": "juniper", "os": "junos"},
+            ),
+            GetIntegrationsElement(
+                name="arista-switch",
+                model="arista-eos",
+                properties={"vendor": "arista", "os": "eos"},
+            ),
+        ]
+
+        response = GetIntegrationsResponse(root=integrations)
+        models = [integration.model for integration in response.root]
+
+        assert "cisco-ios" in models
+        assert "juniper-junos" in models
+        assert "arista-eos" in models
+
+    def test_get_integrations_response_serialization(self):
+        """Test GetIntegrationsResponse serialization"""
+        integration = GetIntegrationsElement(
+            name="serialize-test",
+            model="test-model",
+            properties={"test": True},
+        )
+
+        response = GetIntegrationsResponse(root=[integration])
+        serialized = response.model_dump()
+
+        # GetIntegrationsResponse is a RootModel, so it serializes directly as a list
+        assert isinstance(serialized, list)
+        assert len(serialized) == 1
+        assert serialized[0]["name"] == "serialize-test"
+
+    def test_get_integrations_response_invalid_integration_data(self):
+        """Test GetIntegrationsResponse with invalid integration data"""
+        with pytest.raises(ValidationError):
+            GetIntegrationsResponse(
+                root=[
+                    {
+                        "name": "test-device",
+                        "model": "test-model",
+                        # Missing required properties field
+                    }
+                ]
+            )
+
+    def test_get_integrations_response_iteration(self):
+        """Test that GetIntegrationsResponse can be iterated"""
+        integrations = [
+            GetIntegrationsElement(
+                name=f"iter-device-{i}",
+                model=f"iter-model-{i}",
+                properties={"index": i},
+            )
+            for i in range(3)
+        ]
+
+        response = GetIntegrationsResponse(root=integrations)
+
+        # Test direct access
+        assert len(response.root) == 3
+
+        # Test iteration
+        names = [integration.name for integration in response.root]
+        assert names == ["iter-device-0", "iter-device-1", "iter-device-2"]
+
+    def test_get_integrations_response_mixed_properties(self):
+        """Test GetIntegrationsResponse with integrations having different property structures"""
+        integrations = [
+            GetIntegrationsElement(
+                name="simple-device",
+                model="simple-model",
+                properties={"ip": "192.168.1.1"},
+            ),
+            GetIntegrationsElement(
+                name="complex-device",
+                model="complex-model",
+                properties={
+                    "connection": {"ip": "192.168.1.2", "port": 22},
+                    "capabilities": ["ssh", "snmp"],
+                    "metadata": {"location": "dc1"}
+                },
+            ),
+            GetIntegrationsElement(
+                name="empty-device",
+                model="empty-model",
+                properties={},
+            ),
+        ]
+
+        response = GetIntegrationsResponse(root=integrations)
+        assert len(response.root) == 3
+
+        # Verify different property structures are preserved
+        simple_props = response.root[0].properties
+        complex_props = response.root[1].properties
+        empty_props = response.root[2].properties
+
+        assert simple_props == {"ip": "192.168.1.1"}
+        assert "connection" in complex_props
+        assert "capabilities" in complex_props
+        assert empty_props == {}
+
+
+class TestIntegrationsModelInteroperability:
+    """Test cases for integrations model interoperability"""
+
+    def test_integrations_response_from_elements(self):
+        """Test creating response from individual elements"""
+        elements = [
+            GetIntegrationsElement(
+                name=f"network-device-{i}",
+                model="generic-network",
+                properties={
+                    "ip": f"192.168.1.{i+10}",
+                    "port": 22,
+                    "enabled": i % 2 == 0
+                },
+            )
+            for i in range(3)
+        ]
+
+        response = GetIntegrationsResponse(root=elements)
+
+        assert len(response.root) == 3
+        for i, element in enumerate(response.root):
+            assert element.name == f"network-device-{i}"
+            assert element.model == "generic-network"
+            assert element.properties["ip"] == f"192.168.1.{i+10}"
+
+    def test_integration_model_field_descriptions_exist(self):
+        """Test that integration models have proper field descriptions"""
+        # Test GetIntegrationsElement
+        element_schema = GetIntegrationsElement.model_json_schema()
+        properties = element_schema["properties"]
+
+        for field in ["name", "model", "properties"]:
+            assert field in properties
+            assert "description" in properties[field]
+            assert len(properties[field]["description"]) > 0
+
+    def test_integration_json_schema_generation(self):
+        """Test JSON schema generation for integration models"""
+        models = [
+            GetIntegrationsElement,
+            GetIntegrationsResponse,
+        ]
+
+        for model_class in models:
+            schema = model_class.model_json_schema()
+            assert "type" in schema
+
+            # GetIntegrationsResponse is a RootModel which has different schema structure
+            if model_class == GetIntegrationsResponse:
+                # RootModel schema has "items" instead of "properties"
+                assert "items" in schema
+            else:
+                assert "properties" in schema
+
+    def test_integration_model_equality_behavior(self):
+        """Test integration model equality behavior"""
+        element1 = GetIntegrationsElement(
+            name="test-device", model="test-model", properties={"test": True}
+        )
+        element2 = GetIntegrationsElement(
+            name="test-device", model="test-model", properties={"test": True}
+        )
+        element3 = GetIntegrationsElement(
+            name="different-device", model="different-model", properties={"test": False}
+        )
+
+        assert element1 == element2
+        assert element1 != element3

--- a/tests/test_services_integrations.py
+++ b/tests/test_services_integrations.py
@@ -377,3 +377,220 @@ class TestServiceErrorHandling:
             await service.create_integration_model(model)
 
         assert "Creation failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_success_no_filter(self, service, mock_client):
+        """Test successful retrieval of all integrations without filtering."""
+        expected_response_data = [
+            {
+                "name": "cisco-switch-01",
+                "model": "cisco-ios",
+                "properties": {
+                    "host": "192.168.1.10",
+                    "username": "admin",
+                    "protocol": "ssh"
+                }
+            },
+            {
+                "name": "juniper-router-01",
+                "model": "juniper-junos",
+                "properties": {
+                    "host": "192.168.1.20",
+                    "username": "netadmin",
+                    "protocol": "netconf"
+                }
+            }
+        ]
+
+        # Mock the paginated API response
+        first_page_response = {
+            "results": [
+                {"data": expected_response_data[0]},
+                {"data": expected_response_data[1]}
+            ],
+            "total": 2
+        }
+
+        mock_response = Mock(spec=Response)
+        mock_response.json.return_value = first_page_response
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_integrations()
+
+        # Verify the call was made with correct parameters
+        mock_client.get.assert_called_once_with(
+            "/integrations",
+            params={"limit": 100, "skip": 0}
+        )
+        assert result == expected_response_data
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_success_with_model_filter(self, service, mock_client):
+        """Test successful retrieval of integrations filtered by model."""
+        expected_response_data = [
+            {
+                "name": "cisco-switch-01",
+                "model": "cisco-ios",
+                "properties": {"host": "192.168.1.10"}
+            },
+            {
+                "name": "cisco-switch-02",
+                "model": "cisco-ios",
+                "properties": {"host": "192.168.1.11"}
+            }
+        ]
+
+        # Mock the filtered API response
+        filtered_response = {
+            "results": [
+                {"data": expected_response_data[0]},
+                {"data": expected_response_data[1]}
+            ],
+            "total": 2
+        }
+
+        mock_response = Mock(spec=Response)
+        mock_response.json.return_value = filtered_response
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_integrations(model="cisco-ios")
+
+        # Verify the call was made with model filter parameters
+        mock_client.get.assert_called_once_with(
+            "/integrations",
+            params={
+                "limit": 100,
+                "skip": 0,
+                "containsField": "model",
+                "contains": "cisco-ios"
+            }
+        )
+        assert result == expected_response_data
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_pagination(self):
+        """Test get_integrations handles pagination correctly."""
+        # Create a fresh mock client for this test
+        fresh_mock_client = Mock()
+        fresh_mock_client.get = AsyncMock()
+        fresh_service = Service(fresh_mock_client)
+        # Create test data that requires pagination
+        first_page_data = [
+            {
+                "name": f"device-{i}",
+                "model": "test-model",
+                "properties": {"id": i}
+            }
+            for i in range(100)
+        ]
+        
+        second_page_data = [
+            {
+                "name": f"device-{i}",
+                "model": "test-model",
+                "properties": {"id": i}
+            }
+            for i in range(100, 150)
+        ]
+
+        # Mock responses for pagination
+        first_response = {
+            "results": [{"data": item} for item in first_page_data],
+            "total": 150  # Total indicates more data available
+        }
+        
+        second_response = {
+            "results": [{"data": item} for item in second_page_data],
+            "total": 150
+        }
+
+        mock_response_1 = Mock(spec=Response)
+        mock_response_1.json.return_value = first_response
+        
+        mock_response_2 = Mock(spec=Response)
+        mock_response_2.json.return_value = second_response
+
+        # Configure mock to return different responses on subsequent calls
+        fresh_mock_client.get.side_effect = [mock_response_1, mock_response_2]
+
+        result = await fresh_service.get_integrations()
+
+        # Verify both pagination calls were made
+        assert fresh_mock_client.get.call_count == 2
+        
+        # Verify the calls were made (params dict is modified in-place so we can't check exact values)
+        # But we can verify the calls were made with the correct path and that it's the GET method
+        calls = fresh_mock_client.get.call_args_list
+        assert len(calls) == 2
+        
+        # Verify all calls were to the correct endpoint
+        for call in calls:
+            assert call[0][0] == "/integrations"  # First positional argument is the path
+            assert "params" in call[1]  # Keyword arguments should include params
+            assert "limit" in call[1]["params"]  # Should have limit parameter
+            assert call[1]["params"]["limit"] == 100  # Limit should be 100
+        
+        # Verify all data was collected
+        assert len(result) == 150
+        assert result == first_page_data + second_page_data
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_empty_response(self, service, mock_client):
+        """Test get_integrations with empty response."""
+        empty_response = {
+            "results": [],
+            "total": 0
+        }
+
+        mock_response = Mock(spec=Response)
+        mock_response.json.return_value = empty_response
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_integrations()
+
+        mock_client.get.assert_called_once_with(
+            "/integrations",
+            params={"limit": 100, "skip": 0}
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_single_page_exact_limit(self, service, mock_client):
+        """Test get_integrations with exactly one page of results (100 items)."""
+        test_data = [
+            {
+                "name": f"device-{i}",
+                "model": "test-model",
+                "properties": {"id": i}
+            }
+            for i in range(100)
+        ]
+
+        single_page_response = {
+            "results": [{"data": item} for item in test_data],
+            "total": 100  # Exactly matches the page size
+        }
+
+        mock_response = Mock(spec=Response)
+        mock_response.json.return_value = single_page_response
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_integrations()
+
+        # Should only make one call since total matches results length
+        mock_client.get.assert_called_once_with(
+            "/integrations",
+            params={"limit": 100, "skip": 0}
+        )
+        assert result == test_data
+        assert len(result) == 100
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_client_error(self, service, mock_client):
+        """Test get_integrations handles client errors properly."""
+        mock_client.get.side_effect = Exception("Connection failed")
+
+        with pytest.raises(Exception) as exc_info:
+            await service.get_integrations()
+
+        assert "Connection failed" in str(exc_info.value)

--- a/tests/test_tools_integrations.py
+++ b/tests/test_tools_integrations.py
@@ -633,3 +633,331 @@ class TestIntegrationModelsErrorScenarios:
                 await integrations.create_integration_model(mock_context, model)
 
             assert "model duplicate-api:1.0.0 already exists" in str(exc_info.value)
+
+
+class TestGetIntegrations:
+    """Test cases for the get_integrations tool function."""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock FastMCP Context for testing."""
+        context = Mock(spec=Context)
+        context.info = AsyncMock()
+
+        # Mock the lifespan context
+        mock_client = Mock()
+        mock_client.integrations = Mock()
+        mock_client.integrations.get_integrations = AsyncMock()
+
+        context.request_context = Mock()
+        context.request_context.lifespan_context = Mock()
+        context.request_context.lifespan_context.get = Mock(return_value=mock_client)
+
+        return context
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_success_no_model_filter(self, mock_context):
+        """Test successful retrieval of integrations without model filter."""
+        # Mock the client response
+        mock_response = [
+            {
+                "name": "cisco-switch-01",
+                "model": "cisco-ios",
+                "properties": {
+                    "host": "192.168.1.10",
+                    "username": "admin",
+                    "protocol": "ssh"
+                }
+            },
+            {
+                "name": "juniper-router-01",
+                "model": "juniper-junos",
+                "properties": {
+                    "host": "192.168.1.20",
+                    "username": "netadmin",
+                    "protocol": "netconf"
+                }
+            }
+        ]
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model=None)
+
+        # Verify context.info was called
+        mock_context.info.assert_called_once_with("inside get_integrations(...)")
+
+        # Verify client was retrieved and method called
+        mock_context.request_context.lifespan_context.get.assert_called_once_with(
+            "client"
+        )
+        client.integrations.get_integrations.assert_called_once_with(model=None)
+
+        # Verify the result is properly transformed
+        from itential_mcp.models.integrations import GetIntegrationsResponse, GetIntegrationsElement
+
+        expected_result = GetIntegrationsResponse(
+            root=[
+                GetIntegrationsElement(
+                    name="cisco-switch-01",
+                    model="cisco-ios",
+                    properties={
+                        "host": "192.168.1.10",
+                        "username": "admin",
+                        "protocol": "ssh"
+                    }
+                ),
+                GetIntegrationsElement(
+                    name="juniper-router-01",
+                    model="juniper-junos",
+                    properties={
+                        "host": "192.168.1.20",
+                        "username": "netadmin",
+                        "protocol": "netconf"
+                    }
+                ),
+            ]
+        )
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_success_with_model_filter(self, mock_context):
+        """Test successful retrieval of integrations with model filter."""
+        # Mock the client response (filtered to cisco-ios only)
+        mock_response = [
+            {
+                "name": "cisco-switch-01",
+                "model": "cisco-ios",
+                "properties": {"host": "192.168.1.10", "username": "admin"}
+            },
+            {
+                "name": "cisco-switch-02",
+                "model": "cisco-ios",
+                "properties": {"host": "192.168.1.11", "username": "admin"}
+            }
+        ]
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model="cisco-ios")
+
+        # Verify context.info was called
+        mock_context.info.assert_called_once_with("inside get_integrations(...)")
+
+        # Verify client was retrieved and method called with model filter
+        mock_context.request_context.lifespan_context.get.assert_called_once_with(
+            "client"
+        )
+        client.integrations.get_integrations.assert_called_once_with(model="cisco-ios")
+
+        # Verify the result
+        from itential_mcp.models.integrations import GetIntegrationsResponse, GetIntegrationsElement
+
+        expected_result = GetIntegrationsResponse(
+            root=[
+                GetIntegrationsElement(
+                    name="cisco-switch-01",
+                    model="cisco-ios",
+                    properties={"host": "192.168.1.10", "username": "admin"}
+                ),
+                GetIntegrationsElement(
+                    name="cisco-switch-02",
+                    model="cisco-ios",
+                    properties={"host": "192.168.1.11", "username": "admin"}
+                ),
+            ]
+        )
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_empty_response(self, mock_context):
+        """Test get_integrations with empty response."""
+        mock_response = []
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model=None)
+
+        from itential_mcp.models.integrations import GetIntegrationsResponse
+        
+        assert result == GetIntegrationsResponse(root=[])
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_with_complex_properties(self, mock_context):
+        """Test get_integrations with complex nested properties."""
+        mock_response = [
+            {
+                "name": "complex-device",
+                "model": "multi-vendor-network",
+                "properties": {
+                    "connection": {
+                        "host": "192.168.1.100",
+                        "port": 22,
+                        "timeout": 30
+                    },
+                    "capabilities": ["ssh", "netconf", "snmp"],
+                    "metadata": {
+                        "location": "datacenter-1",
+                        "rack": "A-12",
+                        "environment": "production"
+                    },
+                    "monitoring": {
+                        "enabled": True,
+                        "thresholds": {"cpu": 80, "memory": 90}
+                    }
+                }
+            }
+        ]
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model=None)
+
+        # Verify complex properties are preserved
+        from itential_mcp.models.integrations import GetIntegrationsResponse, GetIntegrationsElement
+
+        expected_result = GetIntegrationsResponse(
+            root=[
+                GetIntegrationsElement(
+                    name="complex-device",
+                    model="multi-vendor-network",
+                    properties={
+                        "connection": {
+                            "host": "192.168.1.100",
+                            "port": 22,
+                            "timeout": 30
+                        },
+                        "capabilities": ["ssh", "netconf", "snmp"],
+                        "metadata": {
+                            "location": "datacenter-1",
+                            "rack": "A-12",
+                            "environment": "production"
+                        },
+                        "monitoring": {
+                            "enabled": True,
+                            "thresholds": {"cpu": 80, "memory": 90}
+                        }
+                    }
+                )
+            ]
+        )
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_client_error(self, mock_context):
+        """Test get_integrations handles client errors."""
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.side_effect = Exception(
+            "Connection failed"
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await integrations.get_integrations(mock_context, model=None)
+
+        assert "Connection failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_with_various_model_types(self, mock_context):
+        """Test get_integrations with integrations of various model types."""
+        mock_response = [
+            {
+                "name": "network-switch",
+                "model": "cisco-catalyst",
+                "properties": {"type": "switch", "ports": 48}
+            },
+            {
+                "name": "backup-server",
+                "model": "linux-ubuntu",
+                "properties": {"type": "server", "os": "ubuntu-20.04"}
+            },
+            {
+                "name": "cloud-api",
+                "model": "aws-ec2",
+                "properties": {"type": "cloud", "region": "us-east-1"}
+            }
+        ]
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model=None)
+
+        # Verify all different model types are handled
+        assert len(result.root) == 3
+        models = [integration.model for integration in result.root]
+        assert "cisco-catalyst" in models
+        assert "linux-ubuntu" in models
+        assert "aws-ec2" in models
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_with_empty_properties(self, mock_context):
+        """Test get_integrations with integrations having empty properties."""
+        mock_response = [
+            {
+                "name": "minimal-device",
+                "model": "minimal-model",
+                "properties": {}
+            }
+        ]
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model=None)
+
+        from itential_mcp.models.integrations import GetIntegrationsResponse, GetIntegrationsElement
+
+        expected_result = GetIntegrationsResponse(
+            root=[
+                GetIntegrationsElement(
+                    name="minimal-device",
+                    model="minimal-model",
+                    properties={}
+                )
+            ]
+        )
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_get_integrations_large_dataset(self, mock_context):
+        """Test get_integrations with large number of integrations."""
+        # Create mock data for 200 integrations
+        mock_response = [
+            {
+                "name": f"device-{i:03d}",
+                "model": f"model-{i % 5}",  # 5 different models
+                "properties": {
+                    "id": i,
+                    "status": "active" if i % 2 == 0 else "inactive",
+                    "location": f"rack-{i // 10}"
+                }
+            }
+            for i in range(200)
+        ]
+
+        client = mock_context.request_context.lifespan_context.get.return_value
+        client.integrations.get_integrations.return_value = mock_response
+
+        result = await integrations.get_integrations(mock_context, model=None)
+
+        # Verify all 200 integrations are processed correctly
+        assert len(result.root) == 200
+        
+        # Verify first and last elements
+        first_integration = result.root[0]
+        assert first_integration.name == "device-000"
+        assert first_integration.model == "model-0"
+        assert first_integration.properties["id"] == 0
+        
+        last_integration = result.root[199]
+        assert last_integration.name == "device-199"
+        assert last_integration.model == "model-4"
+        assert last_integration.properties["id"] == 199


### PR DESCRIPTION
Add new get_integrations functionality to retrieve integration instances from Itential Platform with optional model filtering. This includes:

- New GetIntegrationsElement and GetIntegrationsResponse models
- Service method with pagination support for efficient data retrieval
- Tool function with optional model parameter for filtering results