### PR TITLE
fix: sometimes API returns get_gateways data inconsistently

### DIFF
--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -89,16 +89,20 @@ async def get_gateways(
     # XXX (privateip) The results are filtered to only return gateways that
     # have a connection status of `connected` since we do not care about
     # disconnected gateways.  Additionally if a gateway status is disconnected,
-    # the API does not return the gateway_name property.
-    for ele in data["results"]:
-        if ele["connection_status"] == "connected":
+    # the API does not return the name property.
+    
+    # Handle both response formats: direct array or wrapped in "results" key
+    gateway_list = data.get("results", data) if isinstance(data, dict) else data
+    
+    for ele in gateway_list:
+        if ele.get("connection_status") == "connected" or ele.get("status") == "connected":
             results.append(
                 models.GatewayElement(
-                    name=ele["gateway_name"],
-                    cluster=ele["cluster_id"],
-                    description=ele["description"],
-                    status=ele["connection_status"],
-                    enabled=ele["enabled"],
+                    name=ele.get("name", ele.get("gateway_name", "")),
+                    cluster=ele.get("cluster", ele.get("cluster_id", "")),
+                    description=ele.get("description", ""),
+                    status=ele.get("status", ele.get("connection_status", "")),
+                    enabled=ele.get("enabled", False),
                 )
             )
 

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -850,12 +850,13 @@ class TestGatewayManagerErrorHandling:
 
     @pytest.mark.asyncio
     async def test_get_gateways_missing_gateway_fields(self):
-        """Test get_gateways handling malformed gateway data."""
+        """Test get_gateways handling malformed gateway data with missing fields."""
         mock_data = {
             "results": [
                 {
                     "gateway_name": "incomplete-gateway",
-                    # Missing cluster_id, description, connection_status, enabled
+                    "connection_status": "connected",
+                    # Missing cluster_id, description, enabled - should use defaults
                 }
             ]
         }
@@ -865,8 +866,16 @@ class TestGatewayManagerErrorHandling:
             return_value=mock_data
         )
 
-        with pytest.raises(KeyError):
-            await get_gateways(self.mock_context)
+        # Should not raise an error, but handle missing fields gracefully with defaults
+        result = await get_gateways(self.mock_context)
+        
+        # Verify it returns a result with default values for missing fields
+        assert isinstance(result, GetGatewaysResponse)
+        assert len(result.root) == 1
+        assert result.root[0].name == "incomplete-gateway"
+        assert result.root[0].cluster == ""  # Default value
+        assert result.root[0].description == ""  # Default value
+        assert result.root[0].enabled is False  # Default value
 
     @pytest.mark.asyncio
     async def test_run_service_missing_result_fields(self):


### PR DESCRIPTION
…lister id

__Solution__: Modified `itential-mcp/src/itential_mcp/tools/gateway_manager.py` to:

- Handle both API response formats (direct array or wrapped in "results" key)
- Use `.get()` method with fallback values for all fields
- Support multiple field naming conventions (name/gateway_name, cluster/cluster_id)
- Provide sensible defaults for missing fields

__Verification__: All 31 tests pass in `test_tools_gateway_manager.py` 

__Files Modified__:

- `itential-mcp/src/itential_mcp/tools/gateway_manager.py`
- `itential-mcp/tests/test_tools_gateway_manager.py`
