### PR TITLE
fix: correct tool discovery path in utilities

### DIFF
--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -638,7 +638,7 @@ def _get_tools_from_env() -> dict:
     and returns a nested dictionary structure organized by tool name.
 
     Expected format: ITENTIAL_MCP_TOOL_<tool_name>_<key>=<value>
-    
+
     The parsing splits on the LAST underscore to support underscores in tool names.
     For example: ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_TYPE splits into:
     - tool_name: RUN_CLI_COMMAND
@@ -662,14 +662,14 @@ def _get_tools_from_env() -> dict:
 
         # Remove prefix
         remaining = env_key[len(prefix) :]
-        
+
         # Split on the LAST underscore to support underscores in tool names
         if "_" not in remaining:
             raise ValueError(
                 f"Invalid tool environment variable format: {env_key}. "
                 f"Expected format: {prefix}<tool_name>_<key>=<value>"
             )
-        
+
         # Split from the right on the last underscore
         tool_name, config_key = remaining.rsplit("_", 1)
 

--- a/src/itential_mcp/utilities/tool.py
+++ b/src/itential_mcp/utilities/tool.py
@@ -153,7 +153,8 @@ async def display_tools():
     """
     tools = {}
     maxlen = 0
-    path = pathlib.Path(__file__).parent / "tools"
+
+    path = pathlib.Path(__file__).parent.parent / "tools"
 
     for f, _ in itertools(path):
         if len(f.__name__) > maxlen:
@@ -196,7 +197,8 @@ async def display_tags():
     print("TAGS")
 
     tags = set()
-    path = pathlib.Path(__file__).parent / "tools"
+
+    path = pathlib.Path(__file__).parent.parent / "tools"
 
     for _, t in itertools(path):
         tags = tags.union(t)

--- a/tests/test_get_tools_from_env.py
+++ b/tests/test_get_tools_from_env.py
@@ -85,7 +85,7 @@ class TestGetToolsFromEnv:
 
     def test_get_tools_from_env_config_keys_no_underscores(self, monkeypatch):
         """Test _get_tools_from_env with simple config keys (no underscores in keys).
-        
+
         Note: With rsplit on last underscore to support underscores in tool names,
         config keys cannot contain underscores.
         """
@@ -244,8 +244,13 @@ class TestGetToolsFromEnv:
         # Test the exact scenario from the user's config
         monkeypatch.setenv("ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_TYPE", "service")
         monkeypatch.setenv("ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_NAME", "run-cli-command")
-        monkeypatch.setenv("ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_CLUSTER", "autocon_cluster")
-        monkeypatch.setenv("ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_DESCRIPTION", "Execute CLI command on network devices")
+        monkeypatch.setenv(
+            "ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_CLUSTER", "autocon_cluster"
+        )
+        monkeypatch.setenv(
+            "ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_DESCRIPTION",
+            "Execute CLI command on network devices",
+        )
         monkeypatch.setenv("ITENTIAL_MCP_TOOL_RUN_CLI_COMMAND_TAGS", "custom")
 
         result = _get_tools_from_env()


### PR DESCRIPTION
- Fixed incorrect path resolution in display_tools() and display_tags()
- Changed from parent/tools to parent.parent/tools to properly locate tools directory
- Applied code formatting improvements for consistency