### PR TITLE
fix: service tool env config

### DIFF
--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -744,6 +744,8 @@ def get() -> Config:
 
                 if t["type"] == "endpoint":
                     tools.append(EndpointTool(**t))
+                elif t["type"] == "service":
+                    tools.append(ServiceTool(**t))
                 else:
                     tools.append(Tool(**t))
 


### PR DESCRIPTION
- Add ServiceTool handling in config.get() method for service type tools
- Ensure service tools are properly instantiated alongside endpoint tools