### PR TITLE
fix: resolve websockets deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "fastmcp",
     "ipsdk",
     "toon-python",
+    "wsproto",
 ]
 
 dynamic = [ "version" ]

--- a/src/itential_mcp/server/server.py
+++ b/src/itential_mcp/server/server.py
@@ -229,6 +229,7 @@ class Server:
                 port=self.config.server.get("port"),
                 ssl_certfile=self.config.server.get("certificate_file"),
                 ssl_keyfile=self.config.server.get("private_key_file"),
+                ws="wsproto",
             )
 
             srv = uvicorn.Server(uvicorn_config)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -760,6 +760,7 @@ class TestServerClass:
                 port=8080,
                 ssl_certfile=None,
                 ssl_keyfile=None,
+                ws="wsproto",
             )
 
             # Verify uvicorn Server was created and serve was called
@@ -804,6 +805,7 @@ class TestServerClass:
                 port=3000,
                 ssl_certfile="/path/to/cert.pem",
                 ssl_keyfile="/path/to/key.pem",
+                ws="wsproto",
             )
 
             # Verify uvicorn Server was created and serve was called
@@ -916,6 +918,7 @@ class TestServerClass:
                     port=8000,
                     ssl_certfile=case["expected_cert"],
                     ssl_keyfile=case["expected_key"],
+                    ws="wsproto",
                 )
 
             # Reset mocks for next iteration

--- a/uv.lock
+++ b/uv.lock
@@ -688,6 +688,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "ipsdk" },
     { name = "toon-python" },
+    { name = "wsproto" },
 ]
 
 [package.dev-dependencies]
@@ -706,6 +707,7 @@ requires-dist = [
     { name = "fastmcp" },
     { name = "ipsdk" },
     { name = "toon-python" },
+    { name = "wsproto" },
 ]
 
 [package.metadata.requires-dev]
@@ -1760,6 +1762,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Configure uvicorn to use wsproto instead of websockets legacy API
- Add wsproto dependency to pyproject.toml
- Eliminates DeprecationWarning from websockets.legacy module