### PR TITLE
fix: add missing await in apply_device_configuration

### DIFF
--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -131,7 +131,7 @@ async def apply_device_configuration(
     """
     await ctx.info("inside apply_device_configuration(...)")
     client = ctx.request_context.lifespan_context.get("client")
-    res = client.configuration_manager.apply_device_configuration(
+    res = await client.configuration_manager.apply_device_configuration(
         device=device, config=config
     )
     return models.ApplyDeviceConfigurationResponse(**res)


### PR DESCRIPTION
- Add await keyword to async call at devices.py:134
- Prevents coroutine object from being returned instead of actual result
- Aligns with async pattern used in other device tool functions