### PR TITLE
refactor: modernize type annotations across all modules

### DIFF
--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import os
 import configparser
 import re
@@ -8,7 +10,7 @@ import re
 from functools import lru_cache, partial
 from pathlib import Path
 
-from typing import Literal, List, Callable, Any
+from typing import Literal, Callable, Any
 
 from pydantic import Field, field_validator
 from pydantic.dataclasses import dataclass
@@ -482,7 +484,7 @@ class Config(object):
         json_schema_extra=options("--platform-timeout", metavar="<secs>"),
     )
 
-    tools: List[Tool] = Field(
+    tools: list[Tool] = Field(
         description="List of Itential Platform assets to be exposed as tools",
         default_factory=list,
     )

--- a/src/itential_mcp/core/exceptions.py
+++ b/src/itential_mcp/core/exceptions.py
@@ -9,7 +9,9 @@ providing structured error handling with clear categorization and appropriate
 HTTP status code mappings for REST API contexts.
 """
 
-from typing import Optional, Dict, Any
+from __future__ import annotations
+
+from typing import Any
 
 
 class ItentialMcpException(Exception):
@@ -32,8 +34,8 @@ class ItentialMcpException(Exception):
         self,
         message: str = "",
         *args,
-        details: Optional[Dict[str, Any]] = None,
-        http_status: Optional[int] = None,
+        details: dict[str, Any] | None = None,
+        http_status: int | None = None,
     ):
         # Handle backward compatibility with multiple positional arguments
         if args:
@@ -57,7 +59,7 @@ class ItentialMcpException(Exception):
         """Return the error message for string representation."""
         return self.message
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert exception to dictionary for API responses."""
         return {
             "error": self.__class__.__name__,
@@ -297,7 +299,7 @@ def get_exception_for_http_status(status_code: int) -> type[ItentialMcpException
 
 
 def create_exception_from_response(
-    status_code: int, message: str, details: Optional[Dict[str, Any]] = None
+    status_code: int, message: str, details: dict[str, Any] | None = None
 ) -> ItentialMcpException:
     """
     Create an appropriate exception from an HTTP response.

--- a/src/itential_mcp/core/heuristics.py
+++ b/src/itential_mcp/core/heuristics.py
@@ -8,8 +8,10 @@ such as API keys, passwords, tokens, and other personally
 identifiable information (PII) from log messages before they are written.
 """
 
+from __future__ import annotations
+
 import re
-from typing import Dict, List, Pattern, Callable, Optional
+from typing import Pattern, Callable
 
 
 class Scanner:
@@ -27,14 +29,14 @@ class Scanner:
         redacted = scanner.scan_and_redact("API_KEY=secret123456789")
     """
 
-    _instance: Optional["Scanner"] = None
+    _instance: Scanner | None = None
     _initialized: bool = False
 
-    def __new__(cls, custom_patterns: Optional[Dict[str, str]] = None) -> "Scanner":
+    def __new__(cls, custom_patterns: dict[str, str] | None = None) -> Scanner:
         """Create or return the singleton instance.
 
         Args:
-            custom_patterns (Optional[Dict[str, str]]): Additional patterns to scan for,
+            custom_patterns (dict[str, str] | None): Additional patterns to scan for,
                 where keys are pattern names and values are regex patterns.
 
         Returns:
@@ -47,14 +49,14 @@ class Scanner:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, custom_patterns: Optional[Dict[str, str]] = None):
+    def __init__(self, custom_patterns: dict[str, str] | None = None):
         """Initialize the sensitive data scanner.
 
         This method will only initialize the instance once due to the Singleton pattern.
         Subsequent calls will not re-initialize the patterns.
 
         Args:
-            custom_patterns (Optional[Dict[str, str]]): Additional patterns to scan for,
+            custom_patterns (dict[str, str] | None): Additional patterns to scan for,
                 where keys are pattern names and values are regex patterns.
                 Only applied on first initialization.
 
@@ -66,8 +68,8 @@ class Scanner:
         """
         # Only initialize once due to Singleton pattern
         if not self._initialized:
-            self._patterns: Dict[str, Pattern] = {}
-            self._redaction_functions: Dict[str, Callable[[str], str]] = {}
+            self._patterns: dict[str, Pattern] = {}
+            self._redaction_functions: dict[str, Callable[[str], str]] = {}
 
             # Initialize default patterns
             self._init_default_patterns()
@@ -142,14 +144,14 @@ class Scanner:
         self,
         name: str,
         pattern: str,
-        redaction_func: Optional[Callable[[str], str]] = None,
+        redaction_func: Callable[[str], str] | None = None,
     ) -> None:
         """Add a new sensitive data pattern to scan for.
 
         Args:
             name (str): Name of the pattern for identification.
             pattern (str): Regular expression pattern to match sensitive data.
-            redaction_func (Optional[Callable[[str], str]]): Custom function to redact matches.
+            redaction_func (Callable[[str], str] | None): Custom function to redact matches.
                 If None, uses default redaction with pattern name.
 
         Returns:
@@ -189,11 +191,11 @@ class Scanner:
             return True
         return False
 
-    def list_patterns(self) -> List[str]:
+    def list_patterns(self) -> list[str]:
         """Get a list of all pattern names currently registered.
 
         Returns:
-            List[str]: List of pattern names.
+            list[str]: List of pattern names.
 
         Raises:
             None
@@ -249,14 +251,14 @@ class Scanner:
 
         return False
 
-    def get_sensitive_data_types(self, text: str) -> List[str]:
+    def get_sensitive_data_types(self, text: str) -> list[str]:
         """Get a list of sensitive data types detected in the text.
 
         Args:
             text (str): The text to analyze.
 
         Returns:
-            List[str]: List of pattern names that matched in the text.
+            list[str]: List of pattern names that matched in the text.
 
         Raises:
             None
@@ -304,7 +306,7 @@ def get_scanner() -> Scanner:
 
 
 def configure_scanner(
-    custom_patterns: Optional[Dict[str, str]] = None,
+    custom_patterns: dict[str, str] | None = None,
 ) -> Scanner:
     """Configure the global scanner with custom patterns.
 
@@ -313,7 +315,7 @@ def configure_scanner(
     scanner, use reset_singleton() first.
 
     Args:
-        custom_patterns (Optional[Dict[str, str]]): Custom patterns to add to the scanner.
+        custom_patterns (dict[str, str] | None): Custom patterns to add to the scanner.
 
     Returns:
         Scanner: The configured singleton scanner instance.

--- a/src/itential_mcp/core/logging.py
+++ b/src/itential_mcp/core/logging.py
@@ -8,12 +8,14 @@ including custom log levels, file handlers, and logger management for the applic
 and its dependencies.
 """
 
+from __future__ import annotations
+
 import sys
 import logging
 
 from pathlib import Path
 from functools import partial
-from typing import Literal, Dict, Optional, List
+from typing import Literal
 
 from . import metadata
 from . import heuristics
@@ -197,8 +199,8 @@ def add_file_handler(
 
     Args:
         file_path (str): Path to the log file. Parent directories will be created if they don't exist.
-        level (Optional[int]): Logging level for the file handler. If None, uses the logger's current level.
-        format_string (Optional[str]): Custom format string for the file handler.
+        level (int | None): Logging level for the file handler. If None, uses the logger's current level.
+        format_string (str | None): Custom format string for the file handler.
                                      If None, uses the default logging_message_format.
 
     Returns:
@@ -273,7 +275,7 @@ def configure_file_logging(
         file_path (str): Path to the log file. Parent directories will be created if they don't exist.
         level (int): Logging level (e.g., logging.INFO, logging.DEBUG). Default is INFO.
         propagate (bool): Setting this value to True will also turn on logging for httpx and httpcore.
-        format_string (Optional[str]): Custom format string for the file handler.
+        format_string (str | None): Custom format string for the file handler.
                                      If None, uses the default logging_message_format.
 
     Returns:
@@ -337,8 +339,8 @@ def add_stdout_handler(
     Add a stdout handler to the logger.
 
     Args:
-        level (Optional[int]): Logging level for the stdout handler. If None, uses the logger's current level.
-        format_string (Optional[str]): Custom format string for the stdout handler.
+        level (int | None): Logging level for the stdout handler. If None, uses the logger's current level.
+        format_string (str | None): Custom format string for the stdout handler.
                                      If None, uses the default logging_message_format.
 
     Returns:
@@ -379,8 +381,8 @@ def add_stderr_handler(
     Add a stderr handler to the logger.
 
     Args:
-        level (Optional[int]): Logging level for the stderr handler. If None, uses the logger's current level.
-        format_string (Optional[str]): Custom format string for the stderr handler.
+        level (int | None): Logging level for the stderr handler. If None, uses the logger's current level.
+        format_string (str | None): Custom format string for the stderr handler.
                                      If None, uses the default logging_message_format.
 
     Returns:
@@ -459,12 +461,12 @@ def is_sensitive_data_filtering_enabled() -> bool:
 
 
 def configure_sensitive_data_patterns(
-    custom_patterns: Optional[Dict[str, str]] = None,
+    custom_patterns: dict[str, str] | None = None,
 ) -> None:
     """Configure custom patterns for sensitive data detection.
 
     Args:
-        custom_patterns (Optional[Dict[str, str]]): Custom regex patterns to add
+        custom_patterns (dict[str, str] | None): Custom regex patterns to add
             to the sensitive data scanner, where keys are pattern names and
             values are regex patterns.
 
@@ -477,11 +479,11 @@ def configure_sensitive_data_patterns(
     heuristics.configure_scanner(custom_patterns)
 
 
-def get_sensitive_data_patterns() -> List[str]:
+def get_sensitive_data_patterns() -> list[str]:
     """Get a list of all sensitive data patterns currently configured.
 
     Returns:
-        List[str]: List of pattern names that are being scanned for.
+        list[str]: List of pattern names that are being scanned for.
 
     Raises:
         None

--- a/src/itential_mcp/models/adapters.py
+++ b/src/itential_mcp/models/adapters.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Literal, List, Annotated
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class GetAdaptersElement(BaseModel):
@@ -90,7 +92,7 @@ class GetAdaptersResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetAdaptersElement],
+        list[GetAdaptersElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/applications.py
+++ b/src/itential_mcp/models/applications.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import inspect
-from typing import Annotated, Literal, List
+from __future__ import annotations
 
-from pydantic import BaseModel, RootModel, Field
+import inspect
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, RootModel
 
 
 class GetApplicationsElement(BaseModel):
@@ -82,7 +84,7 @@ class GetApplicationsResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetApplicationsElement],
+        list[GetApplicationsElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/command_templates.py
+++ b/src/itential_mcp/models/command_templates.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Any, List, Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -91,7 +93,7 @@ class GetCommandTemplatesResponse(BaseModel):
     """
 
     templates: Annotated[
-        List[CommandTemplate],
+        list[CommandTemplate],
         Field(
             description=inspect.cleandoc(
                 """
@@ -141,7 +143,7 @@ class CommandTemplateDetail(BaseModel):
     ]
 
     commands: Annotated[
-        List[dict[str, Any]],
+        list[dict[str, Any]],
         Field(
             description=inspect.cleandoc(
                 """
@@ -323,7 +325,7 @@ class CommandResult(BaseModel):
     ]
 
     rules: Annotated[
-        List[RuleEvaluation],
+        list[RuleEvaluation],
         Field(
             description=inspect.cleandoc(
                 """
@@ -370,7 +372,7 @@ class RunCommandTemplateResponse(BaseModel):
     ]
 
     command_results: Annotated[
-        List[CommandResult],
+        list[CommandResult],
         Field(
             description=inspect.cleandoc(
                 """
@@ -438,7 +440,7 @@ class RunCommandResponse(BaseModel):
     """
 
     results: Annotated[
-        List[DeviceCommandResult],
+        list[DeviceCommandResult],
         Field(
             description=inspect.cleandoc(
                 """
@@ -477,7 +479,7 @@ class CreateCommandTemplateRequest(BaseModel):
     ]
 
     commands: Annotated[
-        List[dict[str, Any]],
+        list[dict[str, Any]],
         Field(
             description=inspect.cleandoc(
                 """
@@ -573,7 +575,7 @@ class CreateCommandTemplateResponse(BaseModel):
     ]
 
     ops: Annotated[
-        List[dict[str, Any]],
+        list[dict[str, Any]],
         Field(
             description=inspect.cleandoc(
                 """
@@ -636,7 +638,7 @@ class UpdateCommandTemplateRequest(BaseModel):
     ]
 
     commands: Annotated[
-        List[dict[str, Any]],
+        list[dict[str, Any]],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/compliance_plans.py
+++ b/src/itential_mcp/models/compliance_plans.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import List, Annotated
+from typing import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -79,7 +81,7 @@ class GetCompliancePlansResponse(BaseModel):
     """
 
     plans: Annotated[
-        List[CompliancePlan],
+        list[CompliancePlan],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/compliance_reports.py
+++ b/src/itential_mcp/models/compliance_reports.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Any, Dict, Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -18,7 +20,7 @@ class DescribeComplianceReportResponse(BaseModel):
     """
 
     result: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/configuration_manager.py
+++ b/src/itential_mcp/models/configuration_manager.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import List, Annotated
+from typing import Annotated
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class GoldenConfigTree(BaseModel):
@@ -44,7 +46,7 @@ class GoldenConfigTree(BaseModel):
     ]
 
     versions: Annotated[
-        List[str],
+        list[str],
         Field(
             description=inspect.cleandoc(
                 """
@@ -55,7 +57,7 @@ class GoldenConfigTree(BaseModel):
     ]
 
 
-class GetGoldenConfigTreesResponse(RootModel[List[GoldenConfigTree]]):
+class GetGoldenConfigTreesResponse(RootModel[list[GoldenConfigTree]]):
     """Response model for get_golden_config_trees function.
 
     This model represents the complete response from the get_golden_config_trees
@@ -63,7 +65,7 @@ class GetGoldenConfigTreesResponse(RootModel[List[GoldenConfigTree]]):
     in the Configuration Manager.
     """
 
-    root: List[GoldenConfigTree]
+    root: list[GoldenConfigTree]
 
 
 class CreateGoldenConfigTreeResponse(BaseModel):

--- a/src/itential_mcp/models/device_groups.py
+++ b/src/itential_mcp/models/device_groups.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import inspect
-from typing import Annotated, List
+from __future__ import annotations
 
-from pydantic import BaseModel, RootModel, Field
+import inspect
+from typing import Annotated
+
+from pydantic import BaseModel, Field, RootModel
 
 
 class DeviceGroupElement(BaseModel):
@@ -41,7 +43,7 @@ class DeviceGroupElement(BaseModel):
     ]
 
     devices: Annotated[
-        List[str],
+        list[str],
         Field(
             description=inspect.cleandoc(
                 """
@@ -74,7 +76,7 @@ class GetDeviceGroupsResponse(RootModel):
     """
 
     root: Annotated[
-        List[DeviceGroupElement],
+        list[DeviceGroupElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/devices.py
+++ b/src/itential_mcp/models/devices.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import List, Annotated
+from typing import Annotated
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class Device(BaseModel):
@@ -73,14 +75,14 @@ class Device(BaseModel):
     model_config = {"extra": "allow"}
 
 
-class GetDevicesResponse(RootModel[List[Device]]):
+class GetDevicesResponse(RootModel[list[Device]]):
     """Response model for get_devices function.
 
     This model represents the complete response from the get_devices function,
     which returns a list of devices available in the Configuration Manager.
     """
 
-    root: List[Device]
+    root: list[Device]
 
 
 class GetDeviceConfigurationResponse(RootModel[str]):

--- a/src/itential_mcp/models/gateway_manager.py
+++ b/src/itential_mcp/models/gateway_manager.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import List, Annotated, Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class ServiceElement(BaseModel):
@@ -90,7 +92,7 @@ class GetServicesResponse(RootModel):
     """
 
     root: Annotated[
-        List[ServiceElement],
+        list[ServiceElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -183,7 +185,7 @@ class GetGatewaysResponse(RootModel):
     """
 
     root: Annotated[
-        List[GatewayElement],
+        list[GatewayElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/health.py
+++ b/src/itential_mcp/models/health.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
-from typing import Annotated, Literal, List, Optional, Dict, Union
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -70,7 +72,7 @@ class PlatformStatus(BaseModel):
     ]
 
     server_name: Annotated[
-        Optional[str],
+        str | None,
         Field(
             alias="serverName",
             description=inspect.cleandoc(
@@ -83,7 +85,7 @@ class PlatformStatus(BaseModel):
     ]
 
     services: Annotated[
-        List[ServiceStatus],
+        list[ServiceStatus],
         Field(
             description=inspect.cleandoc(
                 """
@@ -300,7 +302,7 @@ class SystemInfo(BaseModel):
     ]
 
     load_avg: Annotated[
-        List[float],
+        list[float],
         Field(
             alias="loadavg",
             description=inspect.cleandoc(
@@ -312,7 +314,7 @@ class SystemInfo(BaseModel):
     ]
 
     cpus: Annotated[
-        List[CpuInfo],
+        list[CpuInfo],
         Field(
             description=inspect.cleandoc(
                 """
@@ -435,7 +437,7 @@ class ServerVersions(BaseModel):
     ada: Annotated[str, Field(description="Ada URL parser version")]
     ares: Annotated[str, Field(description="c-ares DNS resolver version")]
     base64: Annotated[
-        Optional[str],
+        str | None,
         Field(description="Base64 encoding library version", default=None),
     ]
     brotli: Annotated[str, Field(description="Brotli compression library version")]
@@ -450,10 +452,10 @@ class ServerVersions(BaseModel):
     napi: Annotated[str, Field(description="Node-API version")]
     nghttp2: Annotated[str, Field(description="HTTP/2 library version")]
     nghttp3: Annotated[
-        Optional[str], Field(description="HTTP/3 library version", default=None)
+        str | None, Field(description="HTTP/3 library version", default=None)
     ]
     ngtcp2: Annotated[
-        Optional[str], Field(description="QUIC library version", default=None)
+        str | None, Field(description="QUIC library version", default=None)
     ]
     openssl: Annotated[str, Field(description="OpenSSL cryptographic library version")]
     simdutf: Annotated[str, Field(description="SIMD UTF validation library version")]
@@ -576,7 +578,7 @@ class ServerInfo(BaseModel):
     ]
 
     dependencies: Annotated[
-        Dict[str, str],
+        dict[str, str],
         Field(
             description=inspect.cleandoc(
                 """
@@ -639,7 +641,7 @@ class LoggerConfig(BaseModel):
     ]
 
     syslog: Annotated[
-        Union[str, Dict],
+        str | dict,
         Field(
             description=inspect.cleandoc(
                 """
@@ -760,7 +762,7 @@ class ApplicationInfo(BaseModel):
     ]
 
     connection: Annotated[
-        Optional[ConnectionInfo],
+        ConnectionInfo | None,
         Field(
             description=inspect.cleandoc(
                 """
@@ -1075,7 +1077,7 @@ class HealthResponse(BaseModel):
     ]
 
     applications: Annotated[
-        List[ApplicationInfo],
+        list[ApplicationInfo],
         Field(
             description=inspect.cleandoc(
                 """
@@ -1087,7 +1089,7 @@ class HealthResponse(BaseModel):
     ]
 
     adapters: Annotated[
-        List[AdapterInfo],
+        list[AdapterInfo],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/integrations.py
+++ b/src/itential_mcp/models/integrations.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Literal, List, Annotated, Optional
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class GetIntegrationModelsElement(BaseModel):
@@ -56,7 +58,7 @@ class GetIntegrationModelsElement(BaseModel):
     ]
 
     description: Annotated[
-        Optional[str],
+        str | None,
         Field(
             default=None,
             description=inspect.cleandoc(
@@ -79,7 +81,7 @@ class GetIntegrationModelsResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetIntegrationModelsElement],
+        list[GetIntegrationModelsElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -183,7 +185,7 @@ class GetIntegrationsResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetIntegrationsElement],
+        list[GetIntegrationsElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/lifecycle_manager.py
+++ b/src/itential_mcp/models/lifecycle_manager.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Annotated, List, Literal, Mapping, Any
+from typing import Annotated, Any, Literal, Mapping
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class GetResourcesElement(BaseModel):
@@ -57,7 +59,7 @@ class GetResourcesResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetResourcesElement],
+        list[GetResourcesElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -120,7 +122,7 @@ class Action(BaseModel):
     ]
 
     input_schema: Annotated[
-        Mapping[str, Any] | List[Any],
+        Mapping[str, Any] | list[Any],
         Field(
             description=inspect.cleandoc(
                 """
@@ -171,7 +173,7 @@ class DescribeResourceResponse(BaseModel):
     ]
 
     actions: Annotated[
-        List[Action],
+        list[Action],
         Field(
             description=inspect.cleandoc(
                 """
@@ -302,7 +304,7 @@ class GetInstancesResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetInstancesElement],
+        list[GetInstancesElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -763,7 +765,7 @@ class ActionExecutionElement(BaseModel):
     ]
 
     errors: Annotated[
-        List[ActionExecutionError],
+        list[ActionExecutionError],
         Field(
             description=inspect.cleandoc(
                 """
@@ -775,7 +777,7 @@ class ActionExecutionElement(BaseModel):
     ]
 
     initial_instance_data: Annotated[
-        Mapping[str, Any] | List[str] | None,
+        Mapping[str, Any] | list[str] | None,
         Field(
             description=inspect.cleandoc(
                 """
@@ -788,7 +790,7 @@ class ActionExecutionElement(BaseModel):
     ]
 
     final_instance_data: Annotated[
-        Mapping[str, Any] | List[str] | None,
+        Mapping[str, Any] | list[str] | None,
         Field(
             description=inspect.cleandoc(
                 """
@@ -814,7 +816,7 @@ class GetActionExecutionsResponse(RootModel):
     """
 
     root: Annotated[
-        List[ActionExecutionElement],
+        list[ActionExecutionElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/operations_manager.py
+++ b/src/itential_mcp/models/operations_manager.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Annotated, List, Literal, Mapping, Any
+from typing import Annotated, Any, Literal, Mapping
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class WorkflowElement(BaseModel):
@@ -99,7 +101,7 @@ class GetWorkflowsResponse(RootModel):
     """
 
     root: Annotated[
-        List[WorkflowElement],
+        list[WorkflowElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -322,7 +324,7 @@ class GetJobsResponse(RootModel):
     """
 
     root: Annotated[
-        List[JobElement],
+        list[JobElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/projects.py
+++ b/src/itential_mcp/models/projects.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import List, Annotated
+from typing import Annotated
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -69,7 +71,7 @@ class GetProjectsResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetProjectsElement],
+        list[GetProjectsElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -153,7 +155,7 @@ class DescribeProjectResponse(GetProjectsElement):
     """
 
     components: Annotated[
-        List[DescribeProjectComponent],
+        list[DescribeProjectComponent],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/templates.py
+++ b/src/itential_mcp/models/templates.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import List, Annotated, Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class GetTemplatesElement(BaseModel):
@@ -81,7 +83,7 @@ class GetTemplatesResponse(RootModel):
     """
 
     root: Annotated[
-        List[GetTemplatesElement],
+        list[GetTemplatesElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/models/workflow_engine.py
+++ b/src/itential_mcp/models/workflow_engine.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Annotated, List, Mapping, Any
+from typing import Annotated, Any, Mapping
 
-from pydantic import BaseModel, RootModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class JobMetricElement(BaseModel):
@@ -65,7 +67,7 @@ class JobMetricElement(BaseModel):
     ]
 
     metrics: Annotated[
-        List[Mapping[str, Any]],
+        list[Mapping[str, Any]],
         Field(
             description=inspect.cleandoc(
                 """
@@ -139,7 +141,7 @@ class GetJobMetricsResponse(RootModel):
     """
 
     root: Annotated[
-        List[JobMetricElement],
+        list[JobMetricElement],
         Field(
             description=inspect.cleandoc(
                 """
@@ -254,7 +256,7 @@ class TaskMetricElement(BaseModel):
     ]
 
     metrics: Annotated[
-        List[Mapping[str, Any]],
+        list[Mapping[str, Any]],
         Field(
             description=inspect.cleandoc(
                 """
@@ -329,7 +331,7 @@ class GetTaskMetricsResponse(RootModel):
     """
 
     root: Annotated[
-        List[TaskMetricElement],
+        list[TaskMetricElement],
         Field(
             description=inspect.cleandoc(
                 """

--- a/src/itential_mcp/platform/services/automation_studio.py
+++ b/src/itential_mcp/platform/services/automation_studio.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from typing import Mapping, Any, List, Literal
+from __future__ import annotations
+
+from typing import Mapping, Any, Literal
 
 from itential_mcp.core import exceptions
 
@@ -364,7 +366,7 @@ class Service(ServiceBase):
 
         return res.json()["updated"]
 
-    async def get_projects(self) -> List[Mapping[str, Any]]:
+    async def get_projects(self) -> list[Mapping[str, Any]]:
         """Get all projects from Automation Studio.
 
         Retrieves all projects from the Automation Studio. Projects in Automation
@@ -377,7 +379,7 @@ class Service(ServiceBase):
         on the total count returned by the API.
 
         Returns:
-            List[Mapping[str, Any]]: A list of project objects containing project
+            list[Mapping[str, Any]]: A list of project objects containing project
                 metadata including unique identifier, name, description, and other
                 project-specific attributes.
 

--- a/src/itential_mcp/platform/services/health.py
+++ b/src/itential_mcp/platform/services/health.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from typing import Dict, Any
+from __future__ import annotations
+
+from typing import Any
 
 from itential_mcp.platform.services import ServiceBase
 
@@ -16,7 +18,7 @@ class Service(ServiceBase):
 
     name: str = "health"
 
-    async def get_status_health(self) -> Dict[str, Any]:
+    async def get_status_health(self) -> dict[str, Any]:
         """
         Get overall platform status information.
 
@@ -29,7 +31,7 @@ class Service(ServiceBase):
         res = await self.client.get("/health/status")
         return res.json()
 
-    async def get_system_health(self) -> Dict[str, Any]:
+    async def get_system_health(self) -> dict[str, Any]:
         """
         Get system-level hardware and OS information.
 
@@ -42,7 +44,7 @@ class Service(ServiceBase):
         res = await self.client.get("/health/system")
         return res.json()
 
-    async def get_server_health(self) -> Dict[str, Any]:
+    async def get_server_health(self) -> dict[str, Any]:
         """
         Get Node.js server runtime information and performance metrics.
 
@@ -55,7 +57,7 @@ class Service(ServiceBase):
         res = await self.client.get("/health/server")
         return res.json()
 
-    async def get_applications_health(self) -> Dict[str, Any]:
+    async def get_applications_health(self) -> dict[str, Any]:
         """
         Get comprehensive application health and status information.
 
@@ -68,7 +70,7 @@ class Service(ServiceBase):
         res = await self.client.get("/health/applications")
         return res.json()
 
-    async def get_adapters_health(self) -> Dict[str, Any]:
+    async def get_adapters_health(self) -> dict[str, Any]:
         """
         Get comprehensive adapter health and connectivity information.
 

--- a/src/itential_mcp/platform/services/mop.py
+++ b/src/itential_mcp/platform/services/mop.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import time
-from typing import Dict, Any, List
+from typing import Any
 
 from itential_mcp.platform.services import ServiceBase
 
@@ -47,7 +49,7 @@ class Service(ServiceBase):
 
         return data["data"][0]["_id"]
 
-    async def get_command_templates(self) -> List[Dict[str, Any]]:
+    async def get_command_templates(self) -> list[dict[str, Any]]:
         """
         Get all command templates from Itential Platform.
 
@@ -71,7 +73,7 @@ class Service(ServiceBase):
 
     async def describe_command_template(
         self, name: str, project: str | None = None
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Get detailed information about a specific command template.
 
@@ -105,8 +107,8 @@ class Service(ServiceBase):
         return data[0]
 
     async def run_command_template(
-        self, name: str, devices: List[str], project: str | None = None
-    ) -> Dict[str, Any]:
+        self, name: str, devices: list[str], project: str | None = None
+    ) -> dict[str, Any]:
         """
         Execute a command template against specified devices with rule evaluation.
 
@@ -145,7 +147,7 @@ class Service(ServiceBase):
 
         return res.json()
 
-    async def run_command(self, cmd: str, devices: List[str]) -> List[Dict[str, Any]]:
+    async def run_command(self, cmd: str, devices: list[str]) -> list[dict[str, Any]]:
         """
         Run a single command against multiple devices.
 
@@ -174,13 +176,13 @@ class Service(ServiceBase):
     async def create_command_template(
         self,
         name: str,
-        commands: List[Dict[str, Any]],
+        commands: list[dict[str, Any]],
         project: str | None = None,
         description: str | None = None,
         os: str = "",
         pass_rule: bool = True,
         ignore_warnings: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Create a new command template in Itential Platform.
 
@@ -189,7 +191,7 @@ class Service(ServiceBase):
 
         Args:
             name (str): Name for the command template
-            commands (List[Dict[str, Any]]): List of commands with their validation rules
+            commands (list[dict[str, Any]]): List of commands with their validation rules
             project (str | None): Project name to create the template in (None for global)
             description (str | None): Optional description for the template
             os (str): Operating system type (default: empty string)
@@ -238,13 +240,13 @@ class Service(ServiceBase):
     async def update_command_template(
         self,
         name: str,
-        commands: List[Dict[str, Any]],
+        commands: list[dict[str, Any]],
         project: str | None = None,
         description: str | None = None,
         os: str = "",
         pass_rule: bool = True,
         ignore_warnings: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Update an existing command template in Itential Platform.
 
@@ -253,7 +255,7 @@ class Service(ServiceBase):
 
         Args:
             name (str): Name of the command template to update
-            commands (List[Dict[str, Any]]): List of commands with their validation rules
+            commands (list[dict[str, Any]]): List of commands with their validation rules
             project (str | None): Project name containing the template (None for global)
             description (str | None): Optional description for the template
             os (str): Operating system type (default: empty string)

--- a/src/itential_mcp/runtime/constants.py
+++ b/src/itential_mcp/runtime/constants.py
@@ -3,7 +3,9 @@
 
 """Constants used throughout the Itential MCP application."""
 
-from typing import Dict, Any
+from __future__ import annotations
+
+from typing import Any
 from dataclasses import dataclass
 
 # Application constants
@@ -32,7 +34,7 @@ class CommandConfig:
 
     name: str
     description: str
-    arguments: Dict[str, Any]
+    arguments: dict[str, Any]
     add_platform_group: bool = False
     add_server_group: bool = False
 

--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -6,7 +6,9 @@ OAuth 2.0 flows via RemoteAuthProvider and OAuthProxy, and is designed to be
 extended with additional providers in the future.
 """
 
-from typing import Dict, Any
+from __future__ import annotations
+
+from typing import Any
 
 from fastmcp.server.auth import (
     AuthProvider,
@@ -55,11 +57,11 @@ def build_auth_provider(cfg: Config) -> AuthProvider | None:
         )
 
 
-def _build_jwt_provider(auth_config: Dict[str, Any]) -> AuthProvider:
+def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
     """Build a JWT authentication provider.
 
     Args:
-        auth_config (Dict[str, Any]): Authentication configuration dictionary.
+        auth_config (dict[str, Any]): Authentication configuration dictionary.
 
     Returns:
         AuthProvider: Configured JWT authentication provider.
@@ -82,11 +84,11 @@ def _build_jwt_provider(auth_config: Dict[str, Any]) -> AuthProvider:
     return provider
 
 
-def _build_oauth_provider(auth_config: Dict[str, Any]) -> AuthProvider:
+def _build_oauth_provider(auth_config: dict[str, Any]) -> AuthProvider:
     """Build a full OAuth 2.0 authorization server.
 
     Args:
-        auth_config (Dict[str, Any]): Authentication configuration dictionary.
+        auth_config (dict[str, Any]): Authentication configuration dictionary.
 
     Returns:
         AuthProvider: Configured OAuth authorization server provider.
@@ -123,11 +125,11 @@ def _build_oauth_provider(auth_config: Dict[str, Any]) -> AuthProvider:
     return provider
 
 
-def _build_oauth_proxy_provider(auth_config: Dict[str, Any]) -> AuthProvider:
+def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
     """Build an OAuthProxy for upstream OAuth providers.
 
     Args:
-        auth_config (Dict[str, Any]): Authentication configuration dictionary.
+        auth_config (dict[str, Any]): Authentication configuration dictionary.
 
     Returns:
         AuthProvider: Configured OAuth proxy authentication provider.
@@ -189,16 +191,16 @@ def _build_oauth_proxy_provider(auth_config: Dict[str, Any]) -> AuthProvider:
 
 
 def _get_provider_config(
-    provider_type: str, auth_config: Dict[str, Any]
-) -> Dict[str, Any]:
+    provider_type: str, auth_config: dict[str, Any]
+) -> dict[str, Any]:
     """Get provider-specific OAuth configuration.
 
     Args:
         provider_type (str): The OAuth provider type (google, azure, etc.)
-        auth_config (Dict[str, Any]): Full authentication configuration.
+        auth_config (dict[str, Any]): Full authentication configuration.
 
     Returns:
-        Dict[str, Any]: Provider-specific configuration parameters.
+        dict[str, Any]: Provider-specific configuration parameters.
 
     Raises:
         ConfigurationException: If provider type is not supported.

--- a/src/itential_mcp/tools/templates.py
+++ b/src/itential_mcp/tools/templates.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 import inspect
 
-from typing import Annotated, Literal, List, Mapping, Any
+from typing import Annotated, Literal, Mapping, Any
 
 from pydantic import Field
 
@@ -21,7 +23,7 @@ async def get_templates(
         Literal["textfsm", "jinja2"] | None,
         Field(description="Retrieve only templates of this type", default=None),
     ],
-) -> List[Mapping[str, Any]]:
+) -> list[Mapping[str, Any]]:
     """Get all templates from Automation Studio.
 
     Retrieves all templates from the Automation Studio, with optional filtering
@@ -42,7 +44,7 @@ async def get_templates(
             templating. Defaults to None to retrieve all template types.
 
     Returns:
-        List[Mapping[str, Any]]: A list of template objects containing template
+        list[Mapping[str, Any]]: A list of template objects containing template
             metadata including id, name, description, and type fields transformed
             into GetTemplatesElement model objects.
 


### PR DESCRIPTION
- Replace Optional[X] with X | None for cleaner union syntax
- Replace Dict[K, V] with dict[K, V] using PEP 585 generics
- Replace List[X] with list[X] using built-in generic types
- Replace Union[X, Y] with X | Y using PEP 604 union operator
- Add 'from __future__ import annotations' for forward references
- Remove deprecated typing imports (Optional, Dict, List, Union)