### PR TITLE
perf: optimize bindings middleware from O(n) to O(1) lookup

### DIFF
--- a/src/itential_mcp/middleware/bindings.py
+++ b/src/itential_mcp/middleware/bindings.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from .. import config
@@ -19,10 +21,14 @@ class BindingsMiddleware(Middleware):
 
     Attributes:
         config (config.Config): The application configuration containing tool definitions.
+        tool_lookup (dict[str, config.Tool]): O(1) lookup dictionary mapping tool names to tool configs.
     """
 
     def __init__(self, cfg: config.Config):
         """Initialize the middleware with configuration.
+
+        Creates an O(1) lookup dictionary from tool names to tool configurations
+        for efficient tool config injection during request handling.
 
         Args:
             cfg (config.Config): The application configuration containing tool definitions.
@@ -34,6 +40,10 @@ class BindingsMiddleware(Middleware):
             None
         """
         self.config = cfg
+        # Create O(1) lookup dictionary: tool_name -> tool config
+        self.tool_lookup: dict[str, config.Tool] = {
+            tool.tool_name: tool for tool in cfg.tools
+        }
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
         """Inject tool configuration into MCP tool calls.
@@ -41,6 +51,9 @@ class BindingsMiddleware(Middleware):
         Automatically adds the `_tool_config` parameter to tool arguments when
         the tool name matches a configured dynamic tool. The configuration is
         removed after the tool execution completes.
+
+        Uses O(1) dictionary lookup for efficient tool config retrieval instead
+        of O(n) linear search through all configured tools.
 
         Args:
             context (MiddlewareContext): The middleware context containing the
@@ -53,15 +66,15 @@ class BindingsMiddleware(Middleware):
         Raises:
             Any exceptions from the next handler in the chain.
         """
-        for t in self.config.tools:
-            if t.tool_name == context.message.name:
-                context.message.arguments["_tool_config"] = t
+        # O(1) dictionary lookup instead of O(n) loop
+        tool_config = self.tool_lookup.get(context.message.name)
+
+        if tool_config:
+            context.message.arguments["_tool_config"] = tool_config
 
         res = await call_next(context)
 
-        for t in self.config.tools:
-            if t.tool_name == context.message.name:
-                context.message.arguments.pop("_tool_config", None)
-                break
+        if tool_config:
+            context.message.arguments.pop("_tool_config", None)
 
         return res


### PR DESCRIPTION
- Replace O(n) linear search loops with O(1) dictionary lookup
- Create tool_lookup hash map in __init__ for constant-time access
- Eliminate redundant tool list iterations (was searching twice per call)
- Add modern type annotations with 'from __future__ import annotations'
- Improve scalability for applications with many configured tools
- Maintain identical behavior with significantly better performance