### PR TITLE
test: fix RuntimeWarning coroutines not awaited in tests

### DIFF
--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -150,16 +150,26 @@ class TestCLICommands:
 
     @patch("sys.argv", ["itential-mcp", "run"])
     @patch("asyncio.run")
-    @patch("itential_mcp.server.run")
-    def test_itential_mcp_run_server(self, mock_server_run, mock_asyncio_run):
+    def test_itential_mcp_run_server(self, mock_asyncio_run):
         """Test itential-mcp run command to start server"""
-        mock_server_run.return_value = None
-        mock_asyncio_run.return_value = 0
 
-        result = app.run()
+        # Create a proper async function to replace server.run
+        async def mock_server_func():
+            return None
 
-        assert result == 0
-        mock_asyncio_run.assert_called_once()
+        # Patch server.run in the commands module where it's imported
+        with patch("itential_mcp.runtime.commands.server.run", new=mock_server_func):
+            # Configure mock to consume coroutine properly
+            def consume_coroutine(coro):
+                coro.close()
+                return 0
+
+            mock_asyncio_run.side_effect = consume_coroutine
+
+            result = app.run()
+
+            assert result == 0
+            mock_asyncio_run.assert_called_once()
 
 
 class TestCLIHelpOutput:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -175,11 +175,14 @@ class TestParseArgs:
             mock_args.server_log_level = (
                 "INFO"  # Set required attribute with valid log level
             )
-            mock_args._get_kwargs.return_value = [
-                ("server_host", "example.com"),
-                ("platform_username", "testuser"),
-                ("other_arg", "value"),
-            ]
+            # Use Mock() with side_effect to return a list, avoiding AsyncMock creation
+            mock_args._get_kwargs = Mock(
+                return_value=[
+                    ("server_host", "example.com"),
+                    ("platform_username", "testuser"),
+                    ("other_arg", "value"),
+                ]
+            )
             mock_parse.return_value = mock_args
 
             runtime.parse_args(["run"])
@@ -203,7 +206,13 @@ class TestRun:
             return 0
 
         mock_parse_args.return_value = (mock_func, (), {})
-        mock_asyncio_run.return_value = 0
+
+        # Configure mock to consume coroutine properly
+        def consume_coroutine(coro):
+            coro.close()
+            return 0
+
+        mock_asyncio_run.side_effect = consume_coroutine
 
         result = app.run()
 
@@ -221,7 +230,13 @@ class TestRun:
             return 0
 
         mock_parse_args.return_value = (mock_func, ("arg1",), {"key": "value"})
-        mock_asyncio_run.return_value = 0
+
+        # Configure mock to consume coroutine properly
+        def consume_coroutine(coro):
+            coro.close()
+            return 0
+
+        mock_asyncio_run.side_effect = consume_coroutine
 
         result = app.run()
 
@@ -262,7 +277,13 @@ class TestRun:
             return 0
 
         mock_parse_args.return_value = (mock_func, (), {})
-        mock_asyncio_run.return_value = 0
+
+        # Configure mock to consume coroutine properly
+        def consume_coroutine(coro):
+            coro.close()
+            return 0
+
+        mock_asyncio_run.side_effect = consume_coroutine
 
         result = app.run()
 
@@ -339,10 +360,13 @@ class TestIntegration:
             mock_args.server_log_level = (
                 "INFO"  # Set required attribute with valid log level
             )
-            mock_args._get_kwargs.return_value = [
-                ("server_host", "example.com"),
-                ("platform_username", "testuser"),
-            ]
+            # Use Mock() to avoid AsyncMock creation
+            mock_args._get_kwargs = Mock(
+                return_value=[
+                    ("server_host", "example.com"),
+                    ("platform_username", "testuser"),
+                ]
+            )
             mock_parse.return_value = mock_args
 
             result = runtime.parse_args(["run"])

--- a/tests/test_bindings_service.py
+++ b/tests/test_bindings_service.py
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from dataclasses import dataclass
 
 from pydantic import BaseModel
@@ -695,7 +695,8 @@ class TestServiceIntegration:
         with patch(
             "itential_mcp.bindings.service.gateway_manager.run_service"
         ) as mock_run:
-            mock_result = MagicMock(spec=BaseModel)
+            # Use Mock without spec to avoid AsyncMock creation
+            mock_result = Mock()
             mock_run.return_value = mock_result
 
             result = await service.run_service(

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -461,6 +461,11 @@ class TestConfigurationManagerService:
             }
         )
 
+        # Mock client.put for set_golden_config_template
+        mock_put_response = Mock()
+        mock_put_response.json.return_value = {"template": "interface template"}
+        mock_client.put = AsyncMock(return_value=mock_put_response)
+
         result = await service.add_golden_config_node(
             tree_name="test-tree",
             version="v1.0",


### PR DESCRIPTION
- Fix Mock._get_kwargs to avoid AsyncMock creation in environment variable tests
- Add coroutine consumption wrapper for asyncio.run mocks in test_app.py
- Replace server.run mock with proper async function in test___main__.py
- Remove BaseModel spec from MagicMock to prevent AsyncMock in bindings tests
- Add missing mock_client.put AsyncMock in configuration_manager tests
- Import Mock in test_bindings_service.py for proper mock usage