### PR TITLE
docs: add comprehensive third-party license attribution file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,335 @@
+# Third-Party Software Notices and Information
+
+This project incorporates components from the projects listed below. The original
+copyright notices and the licenses under which Itential received such components
+are set forth below for informational purposes. Itential licenses these components
+to you under the project's license terms (GPL-3.0-or-later).
+
+## Core Dependencies
+
+### FastMCP
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2024 Josh Robinson
+- **Project URL**: https://github.com/jlowin/fastmcp
+- **Description**: Framework for building Model Context Protocol servers
+
+### ipsdk
+- **License**: Apache-2.0
+- **Copyright**: Copyright (c) Itential, Inc.
+- **Project URL**: https://github.com/itential/itential-ipsdk
+- **Description**: Itential Platform SDK for Python
+
+### toon-python
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2024
+- **Project URL**: https://github.com/toon-python/toon-python
+- **Description**: Python utilities for Toon framework
+
+### wsproto
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2016 Benno Rice
+- **Project URL**: https://github.com/python-hyper/wsproto
+- **Description**: WebSockets state-machine based protocol implementation
+
+## Testing Dependencies
+
+### pytest
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2004 Holger Krekel and others
+- **Project URL**: https://github.com/pytest-dev/pytest
+- **Description**: Testing framework for Python
+
+### pytest-asyncio
+- **License**: Apache-2.0
+- **Copyright**: Copyright (c) pytest-asyncio contributors
+- **Project URL**: https://github.com/pytest-dev/pytest-asyncio
+- **Description**: Pytest support for asyncio
+
+### pytest-cov
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2010 pytest-cov contributors
+- **Project URL**: https://github.com/pytest-dev/pytest-cov
+- **Description**: Coverage plugin for pytest
+
+## Code Quality Tools
+
+### ruff
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2022 Charlie Marsh
+- **Project URL**: https://github.com/astral-sh/ruff
+- **Description**: An extremely fast Python linter and formatter
+
+### bandit
+- **License**: Apache-2.0
+- **Copyright**: Copyright (c) 2014 Hewlett-Packard Development Company, L.P.
+- **Project URL**: https://github.com/PyCQA/bandit
+- **Description**: Security linter for Python
+
+## Supporting Libraries
+
+### Pydantic
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2017 Samuel Colvin and other contributors
+- **Project URL**: https://github.com/pydantic/pydantic
+- **Description**: Data validation using Python type hints
+
+### pydantic-settings
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2023 Samuel Colvin and other contributors
+- **Project URL**: https://github.com/pydantic/pydantic-settings
+- **Description**: Settings management using Pydantic
+
+### httpx
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2019 Encode OSS Ltd.
+- **Project URL**: https://github.com/encode/httpx
+- **Description**: A next generation HTTP client for Python
+
+### Starlette
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2018 Encode OSS Ltd.
+- **Project URL**: https://github.com/encode/starlette
+- **Description**: The little ASGI framework that shines
+
+### uvicorn
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2017 Encode OSS Ltd.
+- **Project URL**: https://github.com/encode/uvicorn
+- **Description**: The lightning-fast ASGI server
+
+### websockets
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2013-2024 Aymeric Augustin and contributors
+- **Project URL**: https://github.com/python-websockets/websockets
+- **Description**: Library for building WebSocket servers and clients
+
+### Rich
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2020 Will McGugan
+- **Project URL**: https://github.com/Textualize/rich
+- **Description**: Rich text and formatting in the terminal
+
+### Typer
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2019 Sebastián Ramírez
+- **Project URL**: https://github.com/fastapi/typer
+- **Description**: CLI application framework based on Python type hints
+
+### click
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2014 Pallets
+- **Project URL**: https://github.com/pallets/click
+- **Description**: Composable command line interface toolkit
+
+### Authlib
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2017 Hsiaoming Yang
+- **Project URL**: https://github.com/lepture/authlib
+- **Description**: The ultimate Python library in building OAuth and OpenID Connect servers
+
+### cryptography
+- **License**: Apache-2.0 OR BSD-3-Clause
+- **Copyright**: Copyright (c) Individual contributors
+- **Project URL**: https://github.com/pyca/cryptography
+- **Description**: Cryptographic recipes and primitives for Python
+
+### PyJWT
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2015 José Padilla
+- **Project URL**: https://github.com/jpadilla/pyjwt
+- **Description**: JSON Web Token implementation in Python
+
+### requests
+- **License**: Apache-2.0
+- **Copyright**: Copyright (c) 2019 Kenneth Reitz
+- **Project URL**: https://github.com/psf/requests
+- **Description**: HTTP library for Python
+
+### redis
+- **License**: MIT License
+- **Copyright**: Copyright (c) redis-py contributors
+- **Project URL**: https://github.com/redis/redis-py
+- **Description**: Python client for Redis
+
+### fakeredis
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2012 James Saryerwinnie
+- **Project URL**: https://github.com/cunla/fakeredis-py
+- **Description**: Fake implementation of redis API for testing
+
+### anyio
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2018 Alex Grönholm
+- **Project URL**: https://github.com/agronholm/anyio
+- **Description**: High level compatibility layer for multiple async backends
+
+### attrs
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2015 Hynek Schlawack
+- **Project URL**: https://github.com/python-attrs/attrs
+- **Description**: Classes Without Boilerplate
+
+### certifi
+- **License**: MPL-2.0
+- **Copyright**: Copyright (c) certifi contributors
+- **Project URL**: https://github.com/certifi/python-certifi
+- **Description**: Python package for providing Mozilla's CA Bundle
+
+### charset-normalizer
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2019 Ahmed TAHRI
+- **Project URL**: https://github.com/Ousret/charset_normalizer
+- **Description**: The Real First Universal Charset Detector
+
+### idna
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2013-2024 Kim Davies and contributors
+- **Project URL**: https://github.com/kjd/idna
+- **Description**: Internationalized Domain Names in Applications (IDNA)
+
+### urllib3
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2008-2020 Andrey Petrov and contributors
+- **Project URL**: https://github.com/urllib3/urllib3
+- **Description**: HTTP library with thread-safe connection pooling
+
+### dnspython
+- **License**: ISC License
+- **Copyright**: Copyright (c) 2001-2024 Bob Halley
+- **Project URL**: https://github.com/rthalley/dnspython
+- **Description**: DNS toolkit for Python
+
+### python-dotenv
+- **License**: BSD-3-Clause
+- **Copyright**: Copyright (c) 2014 Saurabh Kumar
+- **Project URL**: https://github.com/theskumar/python-dotenv
+- **Description**: Read key-value pairs from .env file
+
+### PyYAML
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2017-2021 Ingy döt Net, Copyright (c) 2006-2016 Kirill Simonov
+- **Project URL**: https://github.com/yaml/pyyaml
+- **Description**: YAML parser and emitter for Python
+
+### jsonschema
+- **License**: MIT License
+- **Copyright**: Copyright (c) 2013 Julian Berman
+- **Project URL**: https://github.com/python-jsonschema/jsonschema
+- **Description**: An implementation of JSON Schema for Python
+
+### OpenTelemetry
+- **License**: Apache-2.0
+- **Copyright**: Copyright (c) OpenTelemetry Authors
+- **Project URL**: https://github.com/open-telemetry/opentelemetry-python
+- **Description**: OpenTelemetry Python API and SDK
+
+### prometheus-client
+- **License**: Apache-2.0
+- **Copyright**: Copyright (c) Prometheus Python Client contributors
+- **Project URL**: https://github.com/prometheus/client_python
+- **Description**: Python client for the Prometheus monitoring system
+
+### Pygments
+- **License**: BSD-2-Clause
+- **Copyright**: Copyright (c) 2006-2024 by the respective authors
+- **Project URL**: https://github.com/pygments/pygments
+- **Description**: Syntax highlighting package
+
+---
+
+## License Texts
+
+### MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### Apache License 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+### BSD-3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+### ISC License
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+### Mozilla Public License 2.0
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+---
+
+## Notes
+
+This NOTICE file is provided for informational purposes and license compliance.
+For complete license texts and the most up-to-date information, please refer
+to each project's official repository.
+
+The itential-mcp project itself is licensed under the GNU General Public
+License v3.0 or later (GPL-3.0-or-later). See the LICENSE file in the root
+of this repository for details.
+
+For questions about licensing, please contact: opensource@itential.com


### PR DESCRIPTION
- Create NOTICE file documenting all third-party dependencies
- Include license information for core, testing, and supporting libraries
- Provide full license texts for MIT, Apache-2.0, BSD-3-Clause, ISC, and MPL-2.0
- Ensure GPL-3.0-or-later compliance with proper attribution