### PR TITLE
feat: add TTL support and comprehensive platform package tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Itential MCP Server"
 
 dependencies = [
     "fastmcp",
-    "ipsdk",
+    "ipsdk>=0.7.0",
     "toon-python",
     "wsproto",
 ]

--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -551,6 +551,12 @@ class Config(object):
         json_schema_extra=options("--platform-timeout", metavar="<secs>"),
     )
 
+    platform_ttl: int = Field(
+        description="Authentication TTL in seconds before forcing reauthentication (0 = disabled)",
+        default_factory=default_factory(env.getint, "ITENTIAL_MCP_PLATFORM_TTL"),
+        json_schema_extra=options("--platform-ttl", metavar="<secs>", type=int),
+    )
+
     tools: list[Tool] = Field(
         description="List of Itential Platform assets to be exposed as tools",
         default_factory=list,
@@ -679,6 +685,7 @@ class Config(object):
             if self.platform_client_secret == ""
             else self.platform_client_secret,
             "timeout": self.platform_timeout,
+            "ttl": self.platform_ttl,
         }
 
     def _coerce_to_set(self, value) -> list:

--- a/src/itential_mcp/defaults.py
+++ b/src/itential_mcp/defaults.py
@@ -74,3 +74,4 @@ ITENTIAL_MCP_PLATFORM_PASSWORD = "admin"  # Password for basic authentication
 ITENTIAL_MCP_PLATFORM_CLIENT_ID = None  # OAuth client ID (None = use basic auth)
 ITENTIAL_MCP_PLATFORM_CLIENT_SECRET = None  # OAuth client secret
 ITENTIAL_MCP_PLATFORM_TIMEOUT = 30  # Request timeout in seconds
+ITENTIAL_MCP_PLATFORM_TTL = 0  # Authentication TTL in seconds (0 = disabled)

--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -150,7 +150,7 @@ class Service(ServiceBase):
                 json={"name": name, "deviceType": device_type},
             )
             tree_id = res.json()["id"]
-        except ipsdk.exceptions.IpsdkError as exc:
+        except ipsdk.exceptions.HTTPStatusError as exc:
             if hasattr(exc, "response") and exc.response is not None:
                 msg = exc.response.json()
             else:
@@ -285,7 +285,7 @@ class Service(ServiceBase):
                 f"/configuration_manager/configs/{tree_id}/{version}/{path}",
                 json={"name": name},
             )
-        except ipsdk.exceptions.IpsdkError as exc:
+        except ipsdk.exceptions.HTTPStatusError as exc:
             if hasattr(exc, "response") and exc.response is not None:
                 msg = exc.response.json()
             else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,9 +13,11 @@ from itential_mcp.platform import PlatformClient
 @pytest.fixture
 def mock_config():
     """Mock configuration for testing"""
-    return MagicMock(
+    config = MagicMock(
         platform={"url": "https://test.example.com", "token": "test-token"}
     )
+    config.platform_timeout = 30
+    return config
 
 
 @pytest.fixture
@@ -189,3 +191,323 @@ def test_init_plugins_handles_service_instantiation_error(
             # Should complete without raising exception
             client = PlatformClient()
             assert not hasattr(client, "error_service")
+
+
+@pytest.mark.asyncio
+async def test_context_manager_enter(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test async context manager __aenter__ returns self"""
+    client = PlatformClient()
+
+    result = await client.__aenter__()
+
+    assert result is client
+
+
+@pytest.mark.asyncio
+async def test_context_manager_exit_with_close(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test async context manager __aexit__ calls close when available"""
+    mock_ipsdk_client.close = AsyncMock()
+
+    client = PlatformClient()
+    await client.__aexit__(None, None, None)
+
+    mock_ipsdk_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_context_manager_exit_without_close(
+    patched_platform_factory, patched_config_get
+):
+    """Test async context manager __aexit__ handles missing close method"""
+    # Create a client without close method
+    mock_client_no_close = AsyncMock(spec=[])  # Empty spec means no methods
+    with patch("itential_mcp.platform.client.ipsdk.platform_factory") as factory_mock:
+        factory_mock.return_value = mock_client_no_close
+
+        client = PlatformClient()
+        # Should complete without error when close() doesn't exist
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_context_manager_exit_with_exception(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test async context manager __aexit__ with exception info"""
+    mock_ipsdk_client.close = AsyncMock()
+
+    client = PlatformClient()
+
+    # Simulate exiting with exception
+    try:
+        raise ValueError("test exception")
+    except ValueError:
+        import sys
+
+        await client.__aexit__(*sys.exc_info())
+
+    # Should still call close even with exception
+    mock_ipsdk_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_context_manager_full_workflow(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test full context manager workflow"""
+    mock_ipsdk_client.close = AsyncMock()
+
+    async with PlatformClient() as client:
+        assert client is not None
+        assert client.client is mock_ipsdk_client
+
+    # Verify close was called
+    mock_ipsdk_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_make_response(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test _make_response wraps ipsdk Response correctly"""
+    from ipsdk.connection import Response as IpsdkResponse
+    from itential_mcp.platform.response import Response
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+
+    client = PlatformClient()
+    result = await client._make_response(mock_ipsdk_response)
+
+    assert isinstance(result, Response)
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_send_request_success(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test send_request makes correct call and wraps response"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.send_request(
+        method="GET", path="/test", params={"key": "value"}, json={"data": "test"}
+    )
+
+    # Verify the underlying client method was called correctly
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "GET", "/test", {"key": "value"}, {"data": "test"}
+    )
+
+    # Verify response was wrapped
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_send_request_error_handling(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test send_request raises ItentialMcpException on error"""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    mock_ipsdk_client._send_request = AsyncMock(
+        side_effect=Exception("Connection failed")
+    )
+
+    client = PlatformClient()
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await client.send_request(method="GET", path="/test")
+
+    assert "Connection failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_get_method(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test get method calls send_request with correct parameters"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.get("/api/test", params={"filter": "active"})
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "GET", "/api/test", {"filter": "active"}, None
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_get_method_no_params(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test get method without query parameters"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.get("/api/test")
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "GET", "/api/test", None, None
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_post_method(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test post method calls send_request with correct parameters"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.post(
+        "/api/create", params={"validate": "true"}, json={"name": "test"}
+    )
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "POST", "/api/create", {"validate": "true"}, {"name": "test"}
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_post_method_minimal(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test post method with only path parameter"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.post("/api/action")
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "POST", "/api/action", None, None
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_put_method(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test put method calls send_request with correct parameters"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.put("/api/update/123", json={"status": "active"})
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "PUT", "/api/update/123", None, {"status": "active"}
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_put_method_with_params(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test put method with both params and json"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.put(
+        "/api/update/123", params={"force": "true"}, json={"name": "updated"}
+    )
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "PUT", "/api/update/123", {"force": "true"}, {"name": "updated"}
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_delete_method(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test delete method calls send_request with correct parameters"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.delete("/api/delete/123", params={"cascade": "true"})
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "DELETE", "/api/delete/123", {"cascade": "true"}, None
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_delete_method_no_params(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test delete method without query parameters"""
+    from ipsdk.connection import Response as IpsdkResponse
+
+    mock_ipsdk_response = MagicMock(spec=IpsdkResponse)
+    mock_ipsdk_client._send_request = AsyncMock(return_value=mock_ipsdk_response)
+
+    client = PlatformClient()
+    result = await client.delete("/api/delete/123")
+
+    mock_ipsdk_client._send_request.assert_called_once_with(
+        "DELETE", "/api/delete/123", None, None
+    )
+    assert result.response is mock_ipsdk_response
+
+
+@pytest.mark.asyncio
+async def test_http_methods_error_propagation(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test that all HTTP methods properly propagate exceptions"""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    mock_ipsdk_client._send_request = AsyncMock(side_effect=Exception("Network error"))
+
+    client = PlatformClient()
+
+    # Test GET
+    with pytest.raises(ItentialMcpException):
+        await client.get("/test")
+
+    # Test POST
+    with pytest.raises(ItentialMcpException):
+        await client.post("/test")
+
+    # Test PUT
+    with pytest.raises(ItentialMcpException):
+        await client.put("/test")
+
+    # Test DELETE
+    with pytest.raises(ItentialMcpException):
+        await client.delete("/test")

--- a/tests/test_platform_response.py
+++ b/tests/test_platform_response.py
@@ -35,3 +35,226 @@ def test_text_content(mock_response):
 def test_json_parsing(mock_response):
     res = Response(mock_response)
     assert res.json() == {"message": "ok"}
+
+
+def test_status_code_404():
+    """Test Response with 404 status code"""
+    response = httpx.Response(
+        status_code=404,
+        content=b'{"error": "Not Found"}',
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.status_code == 404
+    assert res.reason == "Not Found"
+
+
+def test_status_code_500():
+    """Test Response with 500 status code"""
+    response = httpx.Response(
+        status_code=500,
+        content=b'{"error": "Internal Server Error"}',
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.status_code == 500
+    assert res.reason == "Internal Server Error"
+
+
+def test_status_code_201():
+    """Test Response with 201 created status code"""
+    response = httpx.Response(
+        status_code=201,
+        content=b'{"id": "123", "created": true}',
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.status_code == 201
+    assert res.reason == "Created"
+    assert res.json() == {"id": "123", "created": True}
+
+
+def test_empty_response_body():
+    """Test Response with empty body"""
+    response = httpx.Response(
+        status_code=204,
+        content=b"",
+        headers={},
+        request=httpx.Request("DELETE", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.status_code == 204
+    assert res.text == ""
+
+
+def test_invalid_json_raises_exception():
+    """Test that invalid JSON raises appropriate exception"""
+    response = httpx.Response(
+        status_code=200,
+        content=b"not valid json{{{",
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+
+    # httpx.Response.json() raises JSONDecodeError
+    with pytest.raises(Exception):  # Could be JSONDecodeError or similar
+        res.json()
+
+
+def test_text_with_different_encoding():
+    """Test Response with non-UTF8 content"""
+    response = httpx.Response(
+        status_code=200,
+        content="测试内容".encode("utf-8"),
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.text == "测试内容"
+
+
+def test_json_with_list():
+    """Test Response with JSON list instead of dict"""
+    response = httpx.Response(
+        status_code=200,
+        content=b'[{"id": 1}, {"id": 2}]',
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.json() == [{"id": 1}, {"id": 2}]
+
+
+def test_json_with_null():
+    """Test Response with JSON null value"""
+    response = httpx.Response(
+        status_code=200,
+        content=b"null",
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.json() is None
+
+
+def test_json_with_boolean():
+    """Test Response with JSON boolean values"""
+    response = httpx.Response(
+        status_code=200,
+        content=b"true",
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.json() is True
+
+
+def test_json_with_number():
+    """Test Response with JSON number"""
+    response = httpx.Response(
+        status_code=200,
+        content=b"42",
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.json() == 42
+
+
+def test_large_response_body():
+    """Test Response with large body content"""
+    large_content = {"data": "x" * 10000}
+    import json as json_lib
+
+    response = httpx.Response(
+        status_code=200,
+        content=json_lib.dumps(large_content).encode(),
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.json() == large_content
+
+
+def test_response_with_custom_headers():
+    """Test Response preserves custom headers"""
+    response = httpx.Response(
+        status_code=200,
+        content=b'{"message": "ok"}',
+        headers={
+            "Content-Type": "application/json",
+            "X-Custom-Header": "custom-value",
+            "X-Request-Id": "12345",
+        },
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    # Verify we can still access the underlying response
+    assert res.response.headers.get("X-Custom-Header") == "custom-value"
+    assert res.response.headers.get("X-Request-Id") == "12345"
+
+
+def test_response_wrapper_preserves_original():
+    """Test that Response wrapper preserves original response object"""
+    original_response = httpx.Response(
+        status_code=200,
+        content=b'{"message": "ok"}',
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(original_response)
+
+    # Verify the original response is accessible
+    assert res.response is original_response
+    assert isinstance(res.response, httpx.Response)
+
+
+def test_multiple_calls_to_json():
+    """Test that json() can be called multiple times"""
+    response = httpx.Response(
+        status_code=200,
+        content=b'{"count": 5}',
+        headers={"Content-Type": "application/json"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+
+    # Call json() multiple times
+    result1 = res.json()
+    result2 = res.json()
+
+    assert result1 == result2 == {"count": 5}
+
+
+def test_multiple_calls_to_text():
+    """Test that text property can be accessed multiple times"""
+    response = httpx.Response(
+        status_code=200,
+        content=b"test content",
+        headers={"Content-Type": "text/plain"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+
+    # Access text multiple times
+    text1 = res.text
+    text2 = res.text
+
+    assert text1 == text2 == "test content"
+
+
+def test_response_with_redirects():
+    """Test Response with redirect status codes"""
+    response = httpx.Response(
+        status_code=302,
+        content=b"",
+        headers={"Location": "https://example.com/new-location"},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    res = Response(response)
+    assert res.status_code == 302
+    assert res.reason == "Found"

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -344,7 +344,7 @@ class TestConfigurationManagerService:
         http_error = httpx.HTTPStatusError(
             "Server Error", request=request, response=response
         )
-        server_error = ipsdk.exceptions.IpsdkError("Server Error", http_error)
+        server_error = ipsdk.exceptions.HTTPStatusError(http_error)
         mock_client.post.side_effect = server_error
 
         with pytest.raises(exceptions.ServerException) as exc_info:
@@ -551,7 +551,7 @@ class TestConfigurationManagerService:
         http_error = httpx.HTTPStatusError(
             "Server Error", request=request, response=response
         )
-        server_error = ipsdk.exceptions.IpsdkError("Server Error", http_error)
+        server_error = ipsdk.exceptions.HTTPStatusError(http_error)
         mock_client.post.side_effect = server_error
 
         with pytest.raises(exceptions.ServerException) as exc_info:

--- a/uv.lock
+++ b/uv.lock
@@ -742,7 +742,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp" },
-    { name = "ipsdk" },
+    { name = "ipsdk", specifier = ">=0.7.0" },
     { name = "toon-python" },
     { name = "wsproto" },
 ]


### PR DESCRIPTION
- Upgrade ipsdk from 0.5.0 to 0.7.0 for TTL functionality
- Add platform_ttl configuration field with CLI, env var, and config file support
- Add TTL parameter to platform client initialization (default: 0 = disabled)
- Update ipsdk exception handling from ServerError to HTTPStatusError

Fixes #277