### PR TITLE
feat: add copyright header checking script with SPDX enforcement

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # Create the builder container
 FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim AS builder

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Copyright 2025 Itential Inc. All Rights Reserved
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 CONTAINER_RUNTIME ?= docker
 CONTAINER_TAG ?= itential-mcp:devel
@@ -9,6 +10,7 @@ CONTAINER_TAG ?= itential-mcp:devel
 .DEFAULT_GOAL := help
 
 .PHONY: build certs check clean container coverage fix format lint security premerge test \
+	check-headers fix-headers \
 	tox tox-py310 tox-py311 tox-py312 tox-py313 tox-coverage tox-lint \
 	tox-format tox-security tox-premerge tox-list
 
@@ -17,18 +19,20 @@ CONTAINER_TAG ?= itential-mcp:devel
 # parameters.
 help:
 	@echo "Available targets:"
-	@echo "  build      - Build the local development environment"
-	@echo "  certs      - Generate certificates for the local development environment"
-	@echo "  check      - Check code quality without making changes"
-	@echo "  clean      - Clean the development environment"
-	@echo "  container  - Build the application as a container"
-	@echo "  coverage   - Run test coverage report"
-	@echo "  fix        - Auto-fix code quality issues where possible"
-	@echo "  format     - Format code using ruff formatter"
-	@echo "  lint       - Run analysis on source files (alias for check)"
-	@echo "  security   - Run security analysis with bandit"
-	@echo "  premerge   - Run the premerge tests locally"
-	@echo "  test       - Run test suite"
+	@echo "  build         - Build the local development environment"
+	@echo "  certs         - Generate certificates for the local development environment"
+	@echo "  check         - Check code quality without making changes"
+	@echo "  check-headers - Check copyright headers in Python files"
+	@echo "  clean         - Clean the development environment"
+	@echo "  container     - Build the application as a container"
+	@echo "  coverage      - Run test coverage report"
+	@echo "  fix           - Auto-fix code quality issues where possible"
+	@echo "  fix-headers   - Fix missing copyright headers in Python files"
+	@echo "  format        - Format code using ruff formatter"
+	@echo "  lint          - Run analysis on source files (alias for check)"
+	@echo "  security      - Run security analysis with bandit"
+	@echo "  premerge      - Run the premerge tests locally"
+	@echo "  test          - Run test suite"
 	@echo ""
 	@echo "Tox targets:"
 	@echo "  tox            - Run tests across all Python versions (3.10-3.13)"
@@ -96,9 +100,19 @@ fix:
 security:
 	PYTHONDONTWRITEBYTECODE=1 uv run bandit -c pyproject.toml -r src/
 
+# The check-headers target checks that all Python files have the required
+# copyright and license header.
+check-headers:
+	PYTHONDONTWRITEBYTECODE=1 python scripts/check_headers.py
+
+# The fix-headers target adds missing copyright and license headers to
+# Python files that don't have them.
+fix-headers:
+	PYTHONDONTWRITEBYTECODE=1 python scripts/check_headers.py --fix
+
 # The premerge target will run the premerge tests locally. This is
 # the same target that is invoked in the premerge pipeline.
-premerge: clean format check security test
+premerge: clean format check check-headers security test
 
 # Build a container image that includes the MCP server. The server will start
 # when the container is run and can be configured using environment variables.

--- a/scripts/check_headers.py
+++ b/scripts/check_headers.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Check and optionally fix copyright headers in Python source files.
+
+This script scans all Python files in the repository (src/ and tests/ directories)
+to ensure they have the required copyright and license header.
+
+Usage:
+    python scripts/check_headers.py              # Check headers
+    python scripts/check_headers.py --fix        # Fix missing/incorrect headers
+    python scripts/check_headers.py --verbose    # Show detailed output
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+class HeaderCheck(NamedTuple):
+    """Result of checking a file's header."""
+
+    file_path: Path
+    has_copyright: bool
+    has_license: bool
+    has_spdx: bool
+    line_numbers: tuple[int | None, int | None, int | None]  # (copyright_line, license_line, spdx_line)
+
+
+REQUIRED_COPYRIGHT = "# Copyright (c) 2025 Itential, Inc"
+REQUIRED_LICENSE = "# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)"
+REQUIRED_SPDX = "# SPDX-License-Identifier: GPL-3.0-or-later"
+
+HEADER_LINES = [
+    REQUIRED_COPYRIGHT,
+    REQUIRED_LICENSE,
+    REQUIRED_SPDX,
+]
+
+
+def _find_python_files(base_dir: Path) -> list[Path]:
+    """Find all Python files in src/ and tests/ directories.
+
+    Args:
+        base_dir: Base directory of the repository
+
+    Returns:
+        List of Path objects for all .py files found
+    """
+    python_files = []
+
+    for directory in ["src", "tests"]:
+        dir_path = base_dir / directory
+        if dir_path.exists():
+            python_files.extend(dir_path.rglob("*.py"))
+
+    return sorted(python_files)
+
+
+def _check_file_header(file_path: Path) -> HeaderCheck:
+    """Check if a file has the required copyright header.
+
+    Args:
+        file_path: Path to the Python file to check
+
+    Returns:
+        HeaderCheck object with the results
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return HeaderCheck(file_path, False, False, False, (None, None, None))
+
+    # Check first 5 lines for copyright, license, and SPDX
+    copyright_line = None
+    license_line = None
+    spdx_line = None
+
+    for i, line in enumerate(lines[:5], start=1):
+        if REQUIRED_COPYRIGHT in line:
+            copyright_line = i
+        if REQUIRED_LICENSE in line:
+            license_line = i
+        if REQUIRED_SPDX in line:
+            spdx_line = i
+
+    has_copyright = copyright_line is not None
+    has_license = license_line is not None
+    has_spdx = spdx_line is not None
+
+    return HeaderCheck(file_path, has_copyright, has_license, has_spdx, (copyright_line, license_line, spdx_line))
+
+
+def _fix_file_header(file_path: Path) -> bool:
+    """Add or fix the copyright header in a file.
+
+    Args:
+        file_path: Path to the Python file to fix
+
+    Returns:
+        True if the file was modified, False otherwise
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        lines = content.splitlines(keepends=True)
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return False
+
+    # Find what exists and where
+    copyright_line_idx = None
+    license_line_idx = None
+    spdx_line_idx = None
+
+    for i, line in enumerate(lines[:10]):
+        if REQUIRED_COPYRIGHT in line:
+            copyright_line_idx = i
+        if REQUIRED_LICENSE in line:
+            license_line_idx = i
+        if REQUIRED_SPDX in line:
+            spdx_line_idx = i
+
+    has_copyright = copyright_line_idx is not None
+    has_license = license_line_idx is not None
+    has_spdx = spdx_line_idx is not None
+
+    if has_copyright and has_license and has_spdx:
+        return False  # Header already correct
+
+    modified = False
+
+    # If completely missing header, add all three lines
+    if not has_copyright and not has_license and not has_spdx:
+        insert_index = 0
+        if lines and lines[0].startswith("#!"):
+            insert_index = 1
+
+        header = [
+            REQUIRED_COPYRIGHT + "\n",
+            REQUIRED_LICENSE + "\n",
+            REQUIRED_SPDX + "\n",
+            "\n",
+        ]
+        lines[insert_index:insert_index] = header
+        modified = True
+    else:
+        # Header exists but is incomplete - add what's missing
+        # Add SPDX after license line if missing
+        if has_license and not has_spdx:
+            insert_idx = license_line_idx + 1
+            lines.insert(insert_idx, REQUIRED_SPDX + "\n")
+            modified = True
+
+    if not modified:
+        return False
+
+    # Write back to file
+    try:
+        file_path.write_text("".join(lines), encoding="utf-8")
+        return True
+    except Exception as e:
+        print(f"Error writing {file_path}: {e}")
+        return False
+
+
+def _check_headers(base_dir: Path, verbose: bool = False) -> tuple[list[HeaderCheck], list[HeaderCheck]]:
+    """Check all Python files for required headers.
+
+    Args:
+        base_dir: Base directory of the repository
+        verbose: Whether to show detailed output
+
+    Returns:
+        Tuple of (files_with_issues, files_ok)
+    """
+    python_files = _find_python_files(base_dir)
+
+    if verbose:
+        print(f"Found {len(python_files)} Python files to check\n")
+
+    files_with_issues = []
+    files_ok = []
+
+    for file_path in python_files:
+        result = _check_file_header(file_path)
+
+        if result.has_copyright and result.has_license and result.has_spdx:
+            files_ok.append(result)
+            if verbose:
+                print(f"✓ {file_path.relative_to(base_dir)}")
+        else:
+            files_with_issues.append(result)
+            if verbose:
+                rel_path = file_path.relative_to(base_dir)
+                missing = []
+                if not result.has_copyright:
+                    missing.append("copyright")
+                if not result.has_license:
+                    missing.append("license")
+                if not result.has_spdx:
+                    missing.append("SPDX")
+                print(f"✗ {rel_path} - missing: {', '.join(missing)}")
+
+    return files_with_issues, files_ok
+
+
+def _fix_headers(base_dir: Path, verbose: bool = False) -> tuple[int, int]:
+    """Fix headers in all Python files that are missing them.
+
+    Args:
+        base_dir: Base directory of the repository
+        verbose: Whether to show detailed output
+
+    Returns:
+        Tuple of (files_fixed, files_failed)
+    """
+    python_files = _find_python_files(base_dir)
+
+    files_fixed = 0
+    files_failed = 0
+
+    for file_path in python_files:
+        result = _check_file_header(file_path)
+
+        if not (result.has_copyright and result.has_license and result.has_spdx):
+            if verbose:
+                print(f"Fixing {file_path.relative_to(base_dir)}...")
+
+            if _fix_file_header(file_path):
+                files_fixed += 1
+                if verbose:
+                    print(f"  ✓ Fixed")
+            else:
+                files_failed += 1
+                if verbose:
+                    print(f"  ✗ Failed to fix")
+
+    return files_fixed, files_failed
+
+
+def main() -> int:
+    """Main entry point for the script.
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    parser = argparse.ArgumentParser(
+        description="Check and optionally fix copyright headers in Python files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Fix missing or incorrect headers",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show detailed output",
+    )
+
+    args = parser.parse_args()
+
+    # Find repository root (where pyproject.toml is)
+    script_dir = Path(__file__).parent.resolve()
+    repo_root = script_dir.parent
+
+    if not (repo_root / "pyproject.toml").exists():
+        print("Error: Could not find repository root (pyproject.toml not found)", file=sys.stderr)
+        return 1
+
+    if args.fix:
+        print("Fixing headers in Python files...\n")
+        files_fixed, files_failed = _fix_headers(repo_root, args.verbose)
+
+        print(f"\nSummary:")
+        print(f"  Files fixed: {files_fixed}")
+        if files_failed > 0:
+            print(f"  Files failed: {files_failed}")
+            return 1
+
+        print("\n✓ All headers fixed successfully")
+        return 0
+    else:
+        print("Checking headers in Python files...\n")
+        files_with_issues, files_ok = _check_headers(repo_root, args.verbose)
+
+        if not args.verbose and files_with_issues:
+            print("Files with missing or incorrect headers:\n")
+            for result in files_with_issues:
+                rel_path = result.file_path.relative_to(repo_root)
+                missing = []
+                if not result.has_copyright:
+                    missing.append("copyright")
+                if not result.has_license:
+                    missing.append("license")
+                if not result.has_spdx:
+                    missing.append("SPDX")
+                print(f"  ✗ {rel_path} - missing: {', '.join(missing)}")
+
+        print(f"\nSummary:")
+        print(f"  Files checked: {len(files_with_issues) + len(files_ok)}")
+        print(f"  Files OK: {len(files_ok)}")
+        print(f"  Files with issues: {len(files_with_issues)}")
+
+        if files_with_issues:
+            print("\n✗ Some files are missing required headers")
+            print("  Run with --fix to add missing headers")
+            return 1
+
+        print("\n✓ All files have correct headers")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/itential_mcp/__init__.py
+++ b/src/itential_mcp/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Itential MCP - Model Context Protocol server for Itential Platform.
 

--- a/src/itential_mcp/__main__.py
+++ b/src/itential_mcp/__main__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Entry point for running Itential MCP server as a module.
 

--- a/src/itential_mcp/app.py
+++ b/src/itential_mcp/app.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
 import asyncio

--- a/src/itential_mcp/bindings/__init__.py
+++ b/src/itential_mcp/bindings/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import importlib

--- a/src/itential_mcp/bindings/endpoint.py
+++ b/src/itential_mcp/bindings/endpoint.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import inspect
 

--- a/src/itential_mcp/bindings/service.py
+++ b/src/itential_mcp/bindings/service.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import inspect
 

--- a/src/itential_mcp/cli/__init__.py
+++ b/src/itential_mcp/cli/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from .parser import Parser
 from .argument_groups import add_platform_group, add_server_group

--- a/src/itential_mcp/cli/argument_groups.py
+++ b/src/itential_mcp/cli/argument_groups.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
 from collections.abc import Sequence

--- a/src/itential_mcp/cli/parser.py
+++ b/src/itential_mcp/cli/parser.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
 import argparse

--- a/src/itential_mcp/cli/terminal.py
+++ b/src/itential_mcp/cli/terminal.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import shutil
 

--- a/src/itential_mcp/config.py
+++ b/src/itential_mcp/config.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/core/__init__.py
+++ b/src/itential_mcp/core/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """
 Core package for Itential MCP.

--- a/src/itential_mcp/core/env.py
+++ b/src/itential_mcp/core/env.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 

--- a/src/itential_mcp/core/errors.py
+++ b/src/itential_mcp/core/errors.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 def resource_not_found(msg: str | None = None) -> dict:

--- a/src/itential_mcp/core/exceptions.py
+++ b/src/itential_mcp/core/exceptions.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """
 Itential MCP Exception Hierarchy

--- a/src/itential_mcp/core/heuristics.py
+++ b/src/itential_mcp/core/heuristics.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Heuristics scanner for filtering sensitive data from log messages.
 

--- a/src/itential_mcp/core/logging.py
+++ b/src/itential_mcp/core/logging.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Logging configuration and utilities for Itential MCP.
 

--- a/src/itential_mcp/core/metadata.py
+++ b/src/itential_mcp/core/metadata.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from importlib.metadata import version
 

--- a/src/itential_mcp/defaults.py
+++ b/src/itential_mcp/defaults.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Default configuration values for Itential MCP Server.
 

--- a/src/itential_mcp/middleware/bindings.py
+++ b/src/itential_mcp/middleware/bindings.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/middleware/serialization.py
+++ b/src/itential_mcp/middleware/serialization.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Middleware for response serialization control.
 

--- a/src/itential_mcp/models/adapters.py
+++ b/src/itential_mcp/models/adapters.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/applications.py
+++ b/src/itential_mcp/models/applications.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/command_templates.py
+++ b/src/itential_mcp/models/command_templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/compliance_plans.py
+++ b/src/itential_mcp/models/compliance_plans.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/compliance_reports.py
+++ b/src/itential_mcp/models/compliance_reports.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/configuration_manager.py
+++ b/src/itential_mcp/models/configuration_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/device_groups.py
+++ b/src/itential_mcp/models/device_groups.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/devices.py
+++ b/src/itential_mcp/models/devices.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/gateway_manager.py
+++ b/src/itential_mcp/models/gateway_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/health.py
+++ b/src/itential_mcp/models/health.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/integrations.py
+++ b/src/itential_mcp/models/integrations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/lifecycle_manager.py
+++ b/src/itential_mcp/models/lifecycle_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/operations_manager.py
+++ b/src/itential_mcp/models/operations_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/projects.py
+++ b/src/itential_mcp/models/projects.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/templates.py
+++ b/src/itential_mcp/models/templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/models/workflow_engine.py
+++ b/src/itential_mcp/models/workflow_engine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/platform/__init__.py
+++ b/src/itential_mcp/platform/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from .client import PlatformClient
 

--- a/src/itential_mcp/platform/client.py
+++ b/src/itential_mcp/platform/client.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
 import pathlib

--- a/src/itential_mcp/platform/response.py
+++ b/src/itential_mcp/platform/response.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Any
 

--- a/src/itential_mcp/platform/services/__init__.py
+++ b/src/itential_mcp/platform/services/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from ipsdk.platform import AsyncPlatform
 

--- a/src/itential_mcp/platform/services/adapters.py
+++ b/src/itential_mcp/platform/services/adapters.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
 

--- a/src/itential_mcp/platform/services/applications.py
+++ b/src/itential_mcp/platform/services/applications.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
 

--- a/src/itential_mcp/platform/services/automation_studio.py
+++ b/src/itential_mcp/platform/services/automation_studio.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import ipsdk
 

--- a/src/itential_mcp/platform/services/gateway_manager.py
+++ b/src/itential_mcp/platform/services/gateway_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from typing import Sequence, Mapping, Any

--- a/src/itential_mcp/platform/services/health.py
+++ b/src/itential_mcp/platform/services/health.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/platform/services/integrations.py
+++ b/src/itential_mcp/platform/services/integrations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Any
 

--- a/src/itential_mcp/platform/services/lifecycle_manager.py
+++ b/src/itential_mcp/platform/services/lifecycle_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
 

--- a/src/itential_mcp/platform/services/mop.py
+++ b/src/itential_mcp/platform/services/mop.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/platform/services/operations_manager.py
+++ b/src/itential_mcp/platform/services/operations_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Literal, Mapping, Any
 

--- a/src/itential_mcp/platform/services/transformations.py
+++ b/src/itential_mcp/platform/services/transformations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Mapping, Any
 

--- a/src/itential_mcp/platform/services/workflow_engine.py
+++ b/src/itential_mcp/platform/services/workflow_engine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from itential_mcp.platform.services import ServiceBase
 

--- a/src/itential_mcp/runtime/__init__.py
+++ b/src/itential_mcp/runtime/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Runtime package for Itential MCP application logic."""
 

--- a/src/itential_mcp/runtime/commands.py
+++ b/src/itential_mcp/runtime/commands.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Any, Coroutine, Sequence, Mapping, Tuple
 

--- a/src/itential_mcp/runtime/constants.py
+++ b/src/itential_mcp/runtime/constants.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Constants used throughout the Itential MCP application."""
 

--- a/src/itential_mcp/runtime/handlers.py
+++ b/src/itential_mcp/runtime/handlers.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Command handler logic for the Itential MCP application."""
 

--- a/src/itential_mcp/runtime/parser.py
+++ b/src/itential_mcp/runtime/parser.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Argument parsing logic for the Itential MCP application."""
 

--- a/src/itential_mcp/runtime/runner.py
+++ b/src/itential_mcp/runtime/runner.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 

--- a/src/itential_mcp/serializers/__init__.py
+++ b/src/itential_mcp/serializers/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from .toon import (

--- a/src/itential_mcp/serializers/toon.py
+++ b/src/itential_mcp/serializers/toon.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Itential MCP TOON serializers module.
 

--- a/src/itential_mcp/server/__init__.py
+++ b/src/itential_mcp/server/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from .server import run
 

--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 """Authentication provider factory for the Itential MCP server.
 
 This module converts application configuration into FastMCP authentication

--- a/src/itential_mcp/server/keepalive.py
+++ b/src/itential_mcp/server/keepalive.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Background keepalive module for preventing authentication session timeouts.
 

--- a/src/itential_mcp/server/routes.py
+++ b/src/itential_mcp/server/routes.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse

--- a/src/itential_mcp/server/server.py
+++ b/src/itential_mcp/server/server.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
 import inspect

--- a/src/itential_mcp/tools/adapters.py
+++ b/src/itential_mcp/tools/adapters.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/applications.py
+++ b/src/itential_mcp/tools/applications.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 from pydantic import Field

--- a/src/itential_mcp/tools/compliance_plans.py
+++ b/src/itential_mcp/tools/compliance_plans.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/compliance_reports.py
+++ b/src/itential_mcp/tools/compliance_reports.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/configuration_manager.py
+++ b/src/itential_mcp/tools/configuration_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/golden_config.py
+++ b/src/itential_mcp/tools/golden_config.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/health.py
+++ b/src/itential_mcp/tools/health.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import asyncio
 from typing import Annotated

--- a/src/itential_mcp/tools/integrations.py
+++ b/src/itential_mcp/tools/integrations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/tools/projects.py
+++ b/src/itential_mcp/tools/projects.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
 

--- a/src/itential_mcp/tools/templates.py
+++ b/src/itential_mcp/tools/templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 

--- a/src/itential_mcp/tools/workflow_engine.py
+++ b/src/itential_mcp/tools/workflow_engine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Annotated
 

--- a/src/itential_mcp/utilities/__init__.py
+++ b/src/itential_mcp/utilities/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Utilities package for common helper functions and utilities."""

--- a/src/itential_mcp/utilities/json.py
+++ b/src/itential_mcp/utilities/json.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 import traceback

--- a/src/itential_mcp/utilities/string.py
+++ b/src/itential_mcp/utilities/string.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 def tostr(s: str | None) -> str:

--- a/src/itential_mcp/utilities/time.py
+++ b/src/itential_mcp/utilities/time.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime, timezone
 

--- a/src/itential_mcp/utilities/tool.py
+++ b/src/itential_mcp/utilities/tool.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import inspect

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import patch, MagicMock
 from io import StringIO

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import inspect

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 """Unit tests for authentication provider construction."""
 
 from types import SimpleNamespace

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import patch, MagicMock

--- a/tests/test_bindings_endpoint.py
+++ b/tests/test_bindings_endpoint.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_bindings_init.py
+++ b/tests/test_bindings_init.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_bindings_service.py
+++ b/tests/test_bindings_service.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
 from unittest.mock import Mock, patch

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 import pathlib

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import inspect
 import asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import configparser

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Unit tests for the defaults module."""
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import pytest

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from itential_mcp.core.errors import (
     resource_not_found,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from itential_mcp.core.exceptions import (

--- a/tests/test_get_tools_from_env.py
+++ b/tests/test_get_tools_from_env.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import configparser

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for the heuristics sensitive data scanner module."""
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
 import logging

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 import asyncio

--- a/tests/test_middleware_serialization.py
+++ b/tests/test_middleware_serialization.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for the SerializationMiddleware."""
 

--- a/tests/test_models_adapters.py
+++ b/tests/test_models_adapters.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_command_templates.py
+++ b/tests/test_models_command_templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_compliance_plans.py
+++ b/tests/test_models_compliance_plans.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_compliance_reports.py
+++ b/tests/test_models_compliance_reports.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from itential_mcp.models import compliance_reports as models

--- a/tests/test_models_configuration_manager.py
+++ b/tests/test_models_configuration_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_device_groups.py
+++ b/tests/test_models_device_groups.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_devices.py
+++ b/tests/test_models_devices.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_gateway_manager.py
+++ b/tests/test_models_gateway_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_health.py
+++ b/tests/test_models_health.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from itential_mcp.models.health import (

--- a/tests/test_models_integrations.py
+++ b/tests/test_models_integrations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_lifecycle_manager.py
+++ b/tests/test_models_lifecycle_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_operations_manager.py
+++ b/tests/test_models_operations_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_projects.py
+++ b/tests/test_models_projects.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_templates.py
+++ b/tests/test_models_templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_models_workflow_engine.py
+++ b/tests/test_models_workflow_engine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from pydantic import ValidationError

--- a/tests/test_platform_response.py
+++ b/tests/test_platform_response.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 import httpx

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Unit tests for health check routes."""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 import pytest

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import sys
 import pytest

--- a/tests/test_server_keepalive.py
+++ b/tests/test_server_keepalive.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for server keepalive functionality."""
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock

--- a/tests/test_services_adapters.py
+++ b/tests/test_services_adapters.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 import asyncio

--- a/tests/test_services_applications.py
+++ b/tests/test_services_applications.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_services_automation_studio.py
+++ b/tests/test_services_automation_studio.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, Mock

--- a/tests/test_services_gateway_manager.py
+++ b/tests/test_services_gateway_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_services_health.py
+++ b/tests/test_services_health.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_services_integrations.py
+++ b/tests/test_services_integrations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, Mock

--- a/tests/test_services_lifecycle_manager.py
+++ b/tests/test_services_lifecycle_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_services_mop.py
+++ b/tests/test_services_mop.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_services_operations_manager.py
+++ b/tests/test_services_operations_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_services_transformations.py
+++ b/tests/test_services_transformations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_services_workflow_engine.py
+++ b/tests/test_services_workflow_engine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import Mock, patch

--- a/tests/test_tools_device_groups.py
+++ b/tests/test_tools_device_groups.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 import pytest

--- a/tests/test_tools_golden_config.py
+++ b/tests/test_tools_golden_config.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, Mock

--- a/tests/test_tools_health.py
+++ b/tests/test_tools_health.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_tools_integrations.py
+++ b/tests/test_tools_integrations.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch

--- a/tests/test_tools_lifecycle_manager.py
+++ b/tests/test_tools_lifecycle_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 import json

--- a/tests/test_tools_operations_manager.py
+++ b/tests/test_tools_operations_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_tools_projects.py
+++ b/tests/test_tools_projects.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_tools_templates.py
+++ b/tests/test_tools_templates.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_tools_workflow_engine.py
+++ b/tests/test_tools_workflow_engine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 from unittest.mock import AsyncMock

--- a/tests/utilities/__init__.py
+++ b/tests/utilities/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for utilities package."""

--- a/tests/utilities/test_json.py
+++ b/tests/utilities/test_json.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
 import pytest

--- a/tests/utilities/test_string.py
+++ b/tests/utilities/test_string.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
 

--- a/tests/utilities/test_time.py
+++ b/tests/utilities/test_time.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime, timezone
 

--- a/tests/utilities/test_tool.py
+++ b/tests/utilities/test_tool.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import tempfile


### PR DESCRIPTION
- Add check_headers.py script to validate copyright headers in Python files
- Require copyright notice, license reference, and SPDX identifier in all Python files
- Add SPDX-License-Identifier to all 157 Python files (src/ and tests/)
- Add SPDX identifier to Containerfile
- Add Makefile targets: check-headers and fix-headers
- Integrate check-headers into premerge pipeline
- Script supports check mode (validation) and fix mode (auto-repair)