### PR TITLE
fix: use attribute access for AuthConfig instead of dictionary access

### DIFF
--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -23,7 +23,7 @@ from fastmcp.server.auth import (
 )
 
 from ..core import logging
-from ..config import Config
+from ..config import Config, AuthConfig
 from ..core.exceptions import ConfigurationException
 
 
@@ -43,7 +43,7 @@ def build_auth_provider(cfg: Config) -> AuthProvider | None:
             is invalid or references an unsupported provider type.
     """
     auth_config = cfg.auth
-    auth_type = (auth_config.get("type") or "none").strip().lower()
+    auth_type = (auth_config.type or "none").strip().lower()
 
     if auth_type in {"", "none"}:
         logging.debug("Server authentication disabled; no provider constructed")
@@ -61,11 +61,11 @@ def build_auth_provider(cfg: Config) -> AuthProvider | None:
         )
 
 
-def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
+def _build_jwt_provider(auth_config: AuthConfig) -> AuthProvider:
     """Build a JWT authentication provider.
 
     Args:
-        auth_config (dict[str, Any]): Authentication configuration dictionary.
+        auth_config (AuthConfig): Authentication configuration dataclass.
 
     Returns:
         AuthProvider: Configured JWT authentication provider.
@@ -73,7 +73,19 @@ def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
     Raises:
         ConfigurationException: If JWT provider initialization fails.
     """
-    jwt_kwargs = {key: value for key, value in auth_config.items() if key != "type"}
+    jwt_kwargs = {}
+    if auth_config.jwks_uri:
+        jwt_kwargs["jwks_uri"] = auth_config.jwks_uri
+    if auth_config.public_key:
+        jwt_kwargs["public_key"] = auth_config.public_key
+    if auth_config.issuer:
+        jwt_kwargs["issuer"] = auth_config.issuer
+    if auth_config.audience:
+        jwt_kwargs["audience"] = auth_config.audience
+    if auth_config.algorithm:
+        jwt_kwargs["algorithm"] = auth_config.algorithm
+    if auth_config.required_scopes:
+        jwt_kwargs["required_scopes"] = auth_config.required_scopes
 
     try:
         provider = JWTVerifier(**jwt_kwargs)
@@ -88,11 +100,11 @@ def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
     return provider
 
 
-def _build_oauth_provider(auth_config: dict[str, Any]) -> AuthProvider:
+def _build_oauth_provider(auth_config: AuthConfig) -> AuthProvider:
     """Build a full OAuth 2.0 authorization server.
 
     Args:
-        auth_config (dict[str, Any]): Authentication configuration dictionary.
+        auth_config (AuthConfig): Authentication configuration dataclass.
 
     Returns:
         AuthProvider: Configured OAuth authorization server provider.
@@ -100,21 +112,18 @@ def _build_oauth_provider(auth_config: dict[str, Any]) -> AuthProvider:
     Raises:
         ConfigurationException: If OAuth provider initialization fails.
     """
-    required_fields = ["redirect_uri"]
-    missing_fields = [field for field in required_fields if not auth_config.get(field)]
-
-    if missing_fields:
+    if not auth_config.oauth_redirect_uri:
         raise ConfigurationException(
-            f"OAuth server requires the following fields: {', '.join(missing_fields)}"
+            "OAuth server requires the following fields: oauth_redirect_uri"
         )
 
     oauth_kwargs = {
-        "base_url": auth_config["redirect_uri"].rstrip("/auth/callback"),
+        "base_url": auth_config.oauth_redirect_uri.rstrip("/auth/callback"),
     }
 
     # Add optional parameters
-    if auth_config.get("scopes"):
-        oauth_kwargs["required_scopes"] = auth_config["scopes"]
+    if auth_config.oauth_scopes:
+        oauth_kwargs["required_scopes"] = auth_config.oauth_scopes
 
     try:
         provider = OAuthProvider(**oauth_kwargs)
@@ -129,11 +138,11 @@ def _build_oauth_provider(auth_config: dict[str, Any]) -> AuthProvider:
     return provider
 
 
-def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
+def _build_oauth_proxy_provider(auth_config: AuthConfig) -> AuthProvider:
     """Build an OAuthProxy for upstream OAuth providers.
 
     Args:
-        auth_config (dict[str, Any]): Authentication configuration dictionary.
+        auth_config (AuthConfig): Authentication configuration dataclass.
 
     Returns:
         AuthProvider: Configured OAuth proxy authentication provider.
@@ -141,14 +150,17 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
     Raises:
         ConfigurationException: If OAuth proxy provider initialization fails.
     """
-    required_fields = [
-        "client_id",
-        "client_secret",
-        "authorization_url",
-        "token_url",
-        "redirect_uri",
-    ]
-    missing_fields = [field for field in required_fields if not auth_config.get(field)]
+    missing_fields = []
+    if not auth_config.oauth_client_id:
+        missing_fields.append("oauth_client_id")
+    if not auth_config.oauth_client_secret:
+        missing_fields.append("oauth_client_secret")
+    if not auth_config.oauth_authorization_url:
+        missing_fields.append("oauth_authorization_url")
+    if not auth_config.oauth_token_url:
+        missing_fields.append("oauth_token_url")
+    if not auth_config.oauth_redirect_uri:
+        missing_fields.append("oauth_redirect_uri")
 
     if missing_fields:
         raise ConfigurationException(
@@ -164,22 +176,22 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
         # Fallback to JWT verifier if StaticTokenVerifier not available
         token_verifier = JWTVerifier()
 
-    base_url = auth_config["redirect_uri"].rstrip("/auth/callback")
+    base_url = auth_config.oauth_redirect_uri.rstrip("/auth/callback")
 
     oauth_kwargs = {
-        "upstream_authorization_endpoint": auth_config["authorization_url"],
-        "upstream_token_endpoint": auth_config["token_url"],
-        "upstream_client_id": auth_config["client_id"],
-        "upstream_client_secret": auth_config["client_secret"],
+        "upstream_authorization_endpoint": auth_config.oauth_authorization_url,
+        "upstream_token_endpoint": auth_config.oauth_token_url,
+        "upstream_client_id": auth_config.oauth_client_id,
+        "upstream_client_secret": auth_config.oauth_client_secret,
         "token_verifier": token_verifier,
         "base_url": base_url,
     }
 
     # Add optional parameters
-    if auth_config.get("userinfo_url"):
-        oauth_kwargs["upstream_revocation_endpoint"] = auth_config["userinfo_url"]
-    if auth_config.get("scopes"):
-        oauth_kwargs["valid_scopes"] = auth_config["scopes"]
+    if auth_config.oauth_userinfo_url:
+        oauth_kwargs["upstream_revocation_endpoint"] = auth_config.oauth_userinfo_url
+    if auth_config.oauth_scopes:
+        oauth_kwargs["valid_scopes"] = auth_config.oauth_scopes
 
     try:
         provider = OAuthProxy(**oauth_kwargs)
@@ -195,13 +207,13 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
 
 
 def _get_provider_config(
-    provider_type: str, auth_config: dict[str, Any]
+    provider_type: str, auth_config: AuthConfig
 ) -> dict[str, Any]:
     """Get provider-specific OAuth configuration.
 
     Args:
         provider_type (str): The OAuth provider type (google, azure, etc.)
-        auth_config (dict[str, Any]): Full authentication configuration.
+        auth_config (AuthConfig): Authentication configuration dataclass.
 
     Returns:
         dict[str, Any]: Provider-specific configuration parameters.
@@ -209,31 +221,31 @@ def _get_provider_config(
     Raises:
         ConfigurationException: If provider type is not supported.
     """
-    config = {}
+    config: dict[str, Any] = {}
 
     # Add custom scopes if specified
-    if auth_config.get("scopes"):
-        config["scopes"] = auth_config["scopes"]
+    if auth_config.oauth_scopes:
+        config["scopes"] = auth_config.oauth_scopes
 
     # Add custom redirect URI if specified
-    if auth_config.get("redirect_uri"):
-        config["redirect_uri"] = auth_config["redirect_uri"]
+    if auth_config.oauth_redirect_uri:
+        config["redirect_uri"] = auth_config.oauth_redirect_uri
 
     # Provider-specific defaults and overrides
     if provider_type == "google":
-        if not auth_config.get("scopes"):
+        if not auth_config.oauth_scopes:
             config["scopes"] = ["openid", "email", "profile"]
     elif provider_type == "azure":
-        if not auth_config.get("scopes"):
+        if not auth_config.oauth_scopes:
             config["scopes"] = ["openid", "email", "profile"]
     elif provider_type == "auth0":
-        if not auth_config.get("scopes"):
+        if not auth_config.oauth_scopes:
             config["scopes"] = ["openid", "email", "profile"]
     elif provider_type == "github":
-        if not auth_config.get("scopes"):
+        if not auth_config.oauth_scopes:
             config["scopes"] = ["user:email"]
     elif provider_type == "okta":
-        if not auth_config.get("scopes"):
+        if not auth_config.oauth_scopes:
             config["scopes"] = ["openid", "email", "profile"]
     elif provider_type == "generic":
         # Generic provider requires explicit configuration

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,7 +10,38 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from itential_mcp.server import auth
+from itential_mcp.config import AuthConfig
 from itential_mcp.core.exceptions import ConfigurationException
+
+
+def make_auth_config(**kwargs) -> AuthConfig:
+    """Create an AuthConfig instance with sensible defaults for testing.
+
+    Args:
+        **kwargs: Override any AuthConfig field.
+
+    Returns:
+        AuthConfig: Configured auth config instance.
+    """
+    defaults = {
+        "type": "none",
+        "jwks_uri": None,
+        "public_key": None,
+        "issuer": None,
+        "audience": None,
+        "algorithm": None,
+        "required_scopes": None,
+        "oauth_client_id": None,
+        "oauth_client_secret": None,
+        "oauth_authorization_url": None,
+        "oauth_token_url": None,
+        "oauth_userinfo_url": None,
+        "oauth_scopes": None,
+        "oauth_redirect_uri": None,
+        "oauth_provider_type": None,
+    }
+    defaults.update(kwargs)
+    return AuthConfig(**defaults)
 
 
 class TestBuildAuthProvider:
@@ -18,7 +49,7 @@ class TestBuildAuthProvider:
 
     def test_returns_none_when_auth_disabled(self):
         """Authentication provider is not created when type is none."""
-        cfg = SimpleNamespace(auth={"type": "none"})
+        cfg = SimpleNamespace(auth=make_auth_config(type="none"))
 
         provider = auth.build_auth_provider(cfg)
 
@@ -28,13 +59,13 @@ class TestBuildAuthProvider:
     def test_creates_jwt_provider_with_expected_arguments(self, mock_jwt_verifier):
         """JWT provider receives configuration from the Config object."""
         cfg = SimpleNamespace(
-            auth={
-                "type": "jwt",
-                "public_key": "shared-secret",
-                "algorithm": "HS256",
-                "required_scopes": ["read:all", "write:all"],
-                "audience": ["aud1", "aud2"],
-            }
+            auth=make_auth_config(
+                type="jwt",
+                public_key="shared-secret",
+                algorithm="HS256",
+                required_scopes="read:all,write:all",
+                audience="aud1,aud2",
+            )
         )
 
         provider = auth.build_auth_provider(cfg)
@@ -43,13 +74,15 @@ class TestBuildAuthProvider:
         kwargs = mock_jwt_verifier.call_args.kwargs
         assert kwargs["public_key"] == "shared-secret"
         assert kwargs["algorithm"] == "HS256"
-        assert kwargs["required_scopes"] == ["read:all", "write:all"]
-        assert kwargs["audience"] == ["aud1", "aud2"]
+        assert kwargs["required_scopes"] == "read:all,write:all"
+        assert kwargs["audience"] == "aud1,aud2"
         assert provider is mock_jwt_verifier.return_value
 
     def test_unsupported_auth_type_raises_configuration_exception(self):
         """Unsupported auth types raise ConfigurationException."""
-        cfg = SimpleNamespace(auth={"type": "oauth"})
+        # Create a mock auth config that bypasses Pydantic validation
+        mock_auth = SimpleNamespace(type="unsupported")
+        cfg = SimpleNamespace(auth=mock_auth)
 
         with pytest.raises(ConfigurationException):
             auth.build_auth_provider(cfg)
@@ -59,7 +92,7 @@ class TestBuildAuthProvider:
     )
     def test_jwt_verifier_errors_are_wrapped(self, mock_jwt_verifier):
         """JWT verifier errors are wrapped in ConfigurationException."""
-        cfg = SimpleNamespace(auth={"type": "jwt"})
+        cfg = SimpleNamespace(auth=make_auth_config(type="jwt"))
 
         with pytest.raises(ConfigurationException) as exc:
             auth.build_auth_provider(cfg)
@@ -69,7 +102,7 @@ class TestBuildAuthProvider:
 
     def test_build_auth_provider_with_direct_auth_config(self):
         """Auth provider can be built with direct auth config (bypassing Config validation)."""
-        cfg = SimpleNamespace(auth={"type": "jwt", "public_key": "test-key"})
+        cfg = SimpleNamespace(auth=make_auth_config(type="jwt", public_key="test-key"))
 
         with patch("itential_mcp.server.auth.JWTVerifier") as mock_jwt_verifier:
             mock_provider = MagicMock()
@@ -81,16 +114,36 @@ class TestBuildAuthProvider:
             mock_jwt_verifier.assert_called_once_with(public_key="test-key")
 
     def test_auth_type_case_handling_in_auth_config(self):
-        """Auth type is properly handled regardless of case in auth config dict."""
-        cfg = SimpleNamespace(auth={"type": "JWT"})
+        """Auth type is properly handled regardless of case in auth config."""
+        # Create a mock auth config that bypasses Pydantic validation to test case handling
+        mock_auth = SimpleNamespace(
+            type="JWT",
+            jwks_uri=None,
+            public_key=None,
+            issuer=None,
+            audience=None,
+            algorithm=None,
+            required_scopes=None,
+        )
+        cfg = SimpleNamespace(auth=mock_auth)
 
         with patch("itential_mcp.server.auth.JWTVerifier") as mock_jwt_verifier:
             auth.build_auth_provider(cfg)
             mock_jwt_verifier.assert_called_once()
 
     def test_auth_type_whitespace_handling_in_auth_config(self):
-        """Auth type whitespace is properly stripped in auth config dict."""
-        cfg = SimpleNamespace(auth={"type": "  jwt  "})
+        """Auth type whitespace is properly stripped in auth config."""
+        # Create a mock auth config that bypasses Pydantic validation to test whitespace handling
+        mock_auth = SimpleNamespace(
+            type="  jwt  ",
+            jwks_uri=None,
+            public_key=None,
+            issuer=None,
+            audience=None,
+            algorithm=None,
+            required_scopes=None,
+        )
+        cfg = SimpleNamespace(auth=mock_auth)
 
         with patch("itential_mcp.server.auth.JWTVerifier") as mock_jwt_verifier:
             auth.build_auth_provider(cfg)
@@ -101,7 +154,7 @@ class TestBuildAuthProvider:
     )
     def test_jwt_general_errors_are_wrapped(self, mock_jwt_verifier):
         """General JWT verifier errors are wrapped in ConfigurationException."""
-        cfg = SimpleNamespace(auth={"type": "jwt"})
+        cfg = SimpleNamespace(auth=make_auth_config(type="jwt"))
 
         with pytest.raises(ConfigurationException) as exc:
             auth.build_auth_provider(cfg)
@@ -114,11 +167,11 @@ class TestBuildAuthProvider:
     def test_jwt_provider_excludes_type_field(self, mock_jwt_verifier):
         """JWT provider configuration excludes the 'type' field."""
         cfg = SimpleNamespace(
-            auth={
-                "type": "jwt",
-                "public_key": "test-key",
-                "algorithm": "HS256",
-            }
+            auth=make_auth_config(
+                type="jwt",
+                public_key="test-key",
+                algorithm="HS256",
+            )
         )
 
         auth.build_auth_provider(cfg)
@@ -135,7 +188,7 @@ class TestJWTProviderBuilder:
     @patch("itential_mcp.server.auth.JWTVerifier")
     def test_builds_jwt_provider_with_minimal_config(self, mock_jwt_verifier):
         """JWT provider can be built with minimal configuration."""
-        auth_config = {"type": "jwt"}
+        auth_config = make_auth_config(type="jwt")
         mock_provider = MagicMock()
         mock_jwt_verifier.return_value = mock_provider
 
@@ -147,13 +200,13 @@ class TestJWTProviderBuilder:
     @patch("itential_mcp.server.auth.JWTVerifier")
     def test_builds_jwt_provider_with_full_config(self, mock_jwt_verifier):
         """JWT provider receives all configuration parameters."""
-        auth_config = {
-            "type": "jwt",
-            "public_key": "test-key",
-            "algorithm": "HS256",
-            "audience": ["aud1", "aud2"],
-            "required_scopes": ["read", "write"],
-        }
+        auth_config = make_auth_config(
+            type="jwt",
+            public_key="test-key",
+            algorithm="HS256",
+            audience="aud1,aud2",
+            required_scopes="read,write",
+        )
         mock_provider = MagicMock()
         mock_jwt_verifier.return_value = mock_provider
 
@@ -163,8 +216,8 @@ class TestJWTProviderBuilder:
         mock_jwt_verifier.assert_called_once_with(
             public_key="test-key",
             algorithm="HS256",
-            audience=["aud1", "aud2"],
-            required_scopes=["read", "write"],
+            audience="aud1,aud2",
+            required_scopes="read,write",
         )
 
     @patch(
@@ -172,7 +225,7 @@ class TestJWTProviderBuilder:
     )
     def test_handles_jwt_value_error(self, mock_jwt_verifier):
         """JWT provider builder handles ValueError exceptions."""
-        auth_config = {"type": "jwt"}
+        auth_config = make_auth_config(type="jwt")
 
         with pytest.raises(ConfigurationException) as exc:
             auth._build_jwt_provider(auth_config)
@@ -185,7 +238,7 @@ class TestJWTProviderBuilder:
     )
     def test_handles_jwt_general_error(self, mock_jwt_verifier):
         """JWT provider builder handles general exceptions."""
-        auth_config = {"type": "jwt"}
+        auth_config = make_auth_config(type="jwt")
 
         with pytest.raises(ConfigurationException) as exc:
             auth._build_jwt_provider(auth_config)
@@ -262,10 +315,10 @@ class TestOAuthProviderBuilder:
     @patch("itential_mcp.server.auth.OAuthProvider")
     def test_build_oauth_provider_minimal_config(self, mock_oauth_provider):
         """OAuth provider can be built with minimal configuration."""
-        auth_config = {
-            "type": "oauth",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
         mock_provider = MagicMock()
         mock_oauth_provider.return_value = mock_provider
 
@@ -275,30 +328,30 @@ class TestOAuthProviderBuilder:
         mock_oauth_provider.assert_called_once_with(base_url="http://localhost:8000")
 
     def test_build_oauth_provider_missing_redirect_uri(self):
-        """OAuth provider building fails without redirect_uri."""
-        auth_config = {"type": "oauth"}
+        """OAuth provider building fails without oauth_redirect_uri."""
+        auth_config = make_auth_config(type="oauth")
 
         with pytest.raises(ConfigurationException) as exc:
             auth._build_oauth_provider(auth_config)
 
         assert "OAuth server requires the following fields" in str(exc.value)
-        assert "redirect_uri" in str(exc.value)
+        assert "oauth_redirect_uri" in str(exc.value)
 
     @patch("itential_mcp.server.auth.OAuthProvider")
     def test_build_oauth_provider_with_scopes(self, mock_oauth_provider):
         """OAuth provider includes scopes when provided."""
-        auth_config = {
-            "type": "oauth",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-            "scopes": ["read", "write"],
-        }
+        auth_config = make_auth_config(
+            type="oauth",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+            oauth_scopes="read,write",
+        )
         mock_provider = MagicMock()
         mock_oauth_provider.return_value = mock_provider
 
         auth._build_oauth_provider(auth_config)
 
         mock_oauth_provider.assert_called_once_with(
-            base_url="http://localhost:8000", required_scopes=["read", "write"]
+            base_url="http://localhost:8000", required_scopes="read,write"
         )
 
     @patch(
@@ -307,10 +360,10 @@ class TestOAuthProviderBuilder:
     )
     def test_build_oauth_provider_value_error(self, mock_oauth_provider):
         """OAuth provider builder handles ValueError exceptions."""
-        auth_config = {
-            "type": "oauth",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
 
         with pytest.raises(ConfigurationException) as exc:
             auth._build_oauth_provider(auth_config)
@@ -323,10 +376,10 @@ class TestOAuthProviderBuilder:
     )
     def test_build_oauth_provider_general_error(self, mock_oauth_provider):
         """OAuth provider builder handles general exceptions."""
-        auth_config = {
-            "type": "oauth",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
 
         with pytest.raises(ConfigurationException) as exc:
             auth._build_oauth_provider(auth_config)
@@ -340,14 +393,14 @@ class TestOAuthProviderBuilder:
         self, mock_static_verifier, mock_oauth_proxy
     ):
         """OAuth proxy provider can be built with minimal configuration."""
-        auth_config = {
-            "type": "oauth_proxy",
-            "client_id": "test_client",
-            "client_secret": "test_secret",
-            "authorization_url": "https://auth.example.com/oauth/authorize",
-            "token_url": "https://auth.example.com/oauth/token",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth_proxy",
+            oauth_client_id="test_client",
+            oauth_client_secret="test_secret",
+            oauth_authorization_url="https://auth.example.com/oauth/authorize",
+            oauth_token_url="https://auth.example.com/oauth/token",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
         mock_verifier = MagicMock()
         mock_static_verifier.return_value = mock_verifier
         mock_provider = MagicMock()
@@ -367,7 +420,9 @@ class TestOAuthProviderBuilder:
 
     def test_build_oauth_proxy_provider_missing_fields(self):
         """OAuth proxy provider building fails with missing required fields."""
-        auth_config = {"type": "oauth_proxy", "client_id": "test_client"}
+        auth_config = make_auth_config(
+            type="oauth_proxy", oauth_client_id="test_client"
+        )
 
         with pytest.raises(ConfigurationException) as exc:
             auth._build_oauth_proxy_provider(auth_config)
@@ -376,10 +431,10 @@ class TestOAuthProviderBuilder:
             exc.value
         )
         for field in [
-            "client_secret",
-            "authorization_url",
-            "token_url",
-            "redirect_uri",
+            "oauth_client_secret",
+            "oauth_authorization_url",
+            "oauth_token_url",
+            "oauth_redirect_uri",
         ]:
             assert field in str(exc.value)
 
@@ -389,16 +444,16 @@ class TestOAuthProviderBuilder:
         self, mock_static_verifier, mock_oauth_proxy
     ):
         """OAuth proxy provider includes optional fields when provided."""
-        auth_config = {
-            "type": "oauth_proxy",
-            "client_id": "test_client",
-            "client_secret": "test_secret",
-            "authorization_url": "https://auth.example.com/oauth/authorize",
-            "token_url": "https://auth.example.com/oauth/token",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-            "userinfo_url": "https://auth.example.com/oauth/userinfo",
-            "scopes": ["openid", "email"],
-        }
+        auth_config = make_auth_config(
+            type="oauth_proxy",
+            oauth_client_id="test_client",
+            oauth_client_secret="test_secret",
+            oauth_authorization_url="https://auth.example.com/oauth/authorize",
+            oauth_token_url="https://auth.example.com/oauth/token",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+            oauth_userinfo_url="https://auth.example.com/oauth/userinfo",
+            oauth_scopes="openid,email",
+        )
         mock_verifier = MagicMock()
         mock_static_verifier.return_value = mock_verifier
         mock_provider = MagicMock()
@@ -411,7 +466,7 @@ class TestOAuthProviderBuilder:
             kwargs["upstream_revocation_endpoint"]
             == "https://auth.example.com/oauth/userinfo"
         )
-        assert kwargs["valid_scopes"] == ["openid", "email"]
+        assert kwargs["valid_scopes"] == "openid,email"
 
     @patch("itential_mcp.server.auth.OAuthProxy")
     @patch("fastmcp.server.auth.StaticTokenVerifier", side_effect=ImportError)
@@ -420,14 +475,14 @@ class TestOAuthProviderBuilder:
         self, mock_jwt_verifier, mock_static_verifier, mock_oauth_proxy
     ):
         """OAuth proxy provider falls back to JWT verifier when StaticTokenVerifier unavailable."""
-        auth_config = {
-            "type": "oauth_proxy",
-            "client_id": "test_client",
-            "client_secret": "test_secret",
-            "authorization_url": "https://auth.example.com/oauth/authorize",
-            "token_url": "https://auth.example.com/oauth/token",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth_proxy",
+            oauth_client_id="test_client",
+            oauth_client_secret="test_secret",
+            oauth_authorization_url="https://auth.example.com/oauth/authorize",
+            oauth_token_url="https://auth.example.com/oauth/token",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
         mock_jwt_instance = MagicMock()
         mock_jwt_verifier.return_value = mock_jwt_instance
         mock_provider = MagicMock()
@@ -446,7 +501,7 @@ class TestGetProviderConfig:
 
     def test_google_provider_default_scopes(self):
         """Google provider gets default scopes when none specified."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         config = auth._get_provider_config("google", auth_config)
 
@@ -454,7 +509,7 @@ class TestGetProviderConfig:
 
     def test_azure_provider_default_scopes(self):
         """Azure provider gets default scopes when none specified."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         config = auth._get_provider_config("azure", auth_config)
 
@@ -462,7 +517,7 @@ class TestGetProviderConfig:
 
     def test_auth0_provider_default_scopes(self):
         """Auth0 provider gets default scopes when none specified."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         config = auth._get_provider_config("auth0", auth_config)
 
@@ -470,7 +525,7 @@ class TestGetProviderConfig:
 
     def test_github_provider_default_scopes(self):
         """GitHub provider gets default scopes when none specified."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         config = auth._get_provider_config("github", auth_config)
 
@@ -478,7 +533,7 @@ class TestGetProviderConfig:
 
     def test_okta_provider_default_scopes(self):
         """Okta provider gets default scopes when none specified."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         config = auth._get_provider_config("okta", auth_config)
 
@@ -486,7 +541,7 @@ class TestGetProviderConfig:
 
     def test_generic_provider_no_default_scopes(self):
         """Generic provider gets no default scopes."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         config = auth._get_provider_config("generic", auth_config)
 
@@ -494,15 +549,17 @@ class TestGetProviderConfig:
 
     def test_provider_config_custom_scopes_override_defaults(self):
         """Custom scopes override default scopes for any provider."""
-        auth_config = {"scopes": ["custom", "scope"]}
+        auth_config = make_auth_config(oauth_scopes="custom,scope")
 
         config = auth._get_provider_config("google", auth_config)
 
-        assert config["scopes"] == ["custom", "scope"]
+        assert config["scopes"] == "custom,scope"
 
     def test_provider_config_custom_redirect_uri(self):
         """Custom redirect URI is included in provider config."""
-        auth_config = {"redirect_uri": "http://custom.example.com/callback"}
+        auth_config = make_auth_config(
+            oauth_redirect_uri="http://custom.example.com/callback"
+        )
 
         config = auth._get_provider_config("google", auth_config)
 
@@ -510,19 +567,19 @@ class TestGetProviderConfig:
 
     def test_provider_config_both_custom_fields(self):
         """Provider config includes both custom scopes and redirect URI."""
-        auth_config = {
-            "scopes": ["custom", "scope"],
-            "redirect_uri": "http://custom.example.com/callback",
-        }
+        auth_config = make_auth_config(
+            oauth_scopes="custom,scope",
+            oauth_redirect_uri="http://custom.example.com/callback",
+        )
 
         config = auth._get_provider_config("azure", auth_config)
 
-        assert config["scopes"] == ["custom", "scope"]
+        assert config["scopes"] == "custom,scope"
         assert config["redirect_uri"] == "http://custom.example.com/callback"
 
     def test_unsupported_provider_type_raises_exception(self):
         """Unsupported provider type raises ConfigurationException."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         with pytest.raises(ConfigurationException) as exc:
             auth._get_provider_config("unsupported_provider", auth_config)

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -13,6 +13,7 @@ from itential_mcp.server.auth import (
     _get_provider_config,
     supports_transport,
 )
+from itential_mcp.config import AuthConfig
 from itential_mcp.core.exceptions import ConfigurationException
 
 from fastmcp.server.auth import (
@@ -21,6 +22,36 @@ from fastmcp.server.auth import (
     OAuthProxy,
     OAuthProvider,
 )
+
+
+def make_auth_config(**kwargs) -> AuthConfig:
+    """Create an AuthConfig instance with sensible defaults for testing.
+
+    Args:
+        **kwargs: Override any AuthConfig field.
+
+    Returns:
+        AuthConfig: Configured auth config instance.
+    """
+    defaults = {
+        "type": "none",
+        "jwks_uri": None,
+        "public_key": None,
+        "issuer": None,
+        "audience": None,
+        "algorithm": None,
+        "required_scopes": None,
+        "oauth_client_id": None,
+        "oauth_client_secret": None,
+        "oauth_authorization_url": None,
+        "oauth_token_url": None,
+        "oauth_userinfo_url": None,
+        "oauth_scopes": None,
+        "oauth_redirect_uri": None,
+        "oauth_provider_type": None,
+    }
+    defaults.update(kwargs)
+    return AuthConfig(**defaults)
 
 
 class TestOAuthConfiguration:
@@ -100,10 +131,10 @@ class TestOAuthProviderBuilding:
     @patch("itential_mcp.server.auth.OAuthProvider")
     def test_build_oauth_provider_success(self, mock_oauth_provider):
         """Test successful OAuth provider building."""
-        auth_config = {
-            "type": "oauth",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
 
         mock_provider = MagicMock()
         mock_oauth_provider.return_value = mock_provider
@@ -115,25 +146,22 @@ class TestOAuthProviderBuilding:
 
     def test_build_oauth_provider_missing_required_fields(self):
         """Test OAuth provider building with missing required fields."""
-        auth_config = {
-            "type": "oauth"
-            # Missing redirect_uri
-        }
+        auth_config = make_auth_config(type="oauth")
 
         with pytest.raises(ConfigurationException) as exc_info:
             _build_oauth_provider(auth_config)
 
         assert "requires the following fields" in str(exc_info.value)
-        assert "redirect_uri" in str(exc_info.value)
+        assert "oauth_redirect_uri" in str(exc_info.value)
 
     @patch("itential_mcp.server.auth.OAuthProvider")
     def test_build_oauth_provider_with_optional_fields(self, mock_oauth_provider):
         """Test OAuth provider building with optional fields."""
-        auth_config = {
-            "type": "oauth",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-            "scopes": ["openid", "email"],
-        }
+        auth_config = make_auth_config(
+            type="oauth",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+            oauth_scopes="openid,email",
+        )
 
         mock_provider = MagicMock()
         mock_oauth_provider.return_value = mock_provider
@@ -141,7 +169,7 @@ class TestOAuthProviderBuilding:
         _build_oauth_provider(auth_config)
 
         mock_oauth_provider.assert_called_once_with(
-            base_url="http://localhost:8000", required_scopes=["openid", "email"]
+            base_url="http://localhost:8000", required_scopes="openid,email"
         )
 
     @patch("itential_mcp.server.auth.OAuthProxy")
@@ -150,14 +178,14 @@ class TestOAuthProviderBuilding:
         self, mock_token_verifier, mock_oauth_proxy
     ):
         """Test successful OAuth proxy provider building."""
-        auth_config = {
-            "type": "oauth_proxy",
-            "client_id": "test_client",
-            "client_secret": "test_secret",
-            "authorization_url": "https://accounts.google.com/oauth/authorize",
-            "token_url": "https://oauth2.googleapis.com/token",
-            "redirect_uri": "http://localhost:8000/auth/callback",
-        }
+        auth_config = make_auth_config(
+            type="oauth_proxy",
+            oauth_client_id="test_client",
+            oauth_client_secret="test_secret",
+            oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+            oauth_token_url="https://oauth2.googleapis.com/token",
+            oauth_redirect_uri="http://localhost:8000/auth/callback",
+        )
 
         mock_verifier_instance = MagicMock()
         mock_token_verifier.return_value = mock_verifier_instance
@@ -179,20 +207,19 @@ class TestOAuthProviderBuilding:
 
     def test_build_oauth_proxy_provider_missing_fields(self):
         """Test OAuth proxy provider building with missing required fields."""
-        auth_config = {
-            "type": "oauth_proxy",
-            "client_id": "test_client",
-            # Missing client_secret, authorization_url, token_url, redirect_uri
-        }
+        auth_config = make_auth_config(
+            type="oauth_proxy",
+            oauth_client_id="test_client",
+        )
 
         with pytest.raises(ConfigurationException) as exc_info:
             _build_oauth_proxy_provider(auth_config)
 
         assert "requires the following fields" in str(exc_info.value)
-        assert "client_secret" in str(exc_info.value)
-        assert "authorization_url" in str(exc_info.value)
-        assert "token_url" in str(exc_info.value)
-        assert "redirect_uri" in str(exc_info.value)
+        assert "oauth_client_secret" in str(exc_info.value)
+        assert "oauth_authorization_url" in str(exc_info.value)
+        assert "oauth_token_url" in str(exc_info.value)
+        assert "oauth_redirect_uri" in str(exc_info.value)
 
 
 class TestProviderConfiguration:
@@ -200,35 +227,37 @@ class TestProviderConfiguration:
 
     def test_google_provider_config(self):
         """Test Google provider configuration defaults."""
-        auth_config = {}
+        auth_config = make_auth_config()
         config = _get_provider_config("google", auth_config)
 
         assert config["scopes"] == ["openid", "email", "profile"]
 
     def test_azure_provider_config(self):
         """Test Azure provider configuration defaults."""
-        auth_config = {}
+        auth_config = make_auth_config()
         config = _get_provider_config("azure", auth_config)
 
         assert config["scopes"] == ["openid", "email", "profile"]
 
     def test_github_provider_config(self):
         """Test GitHub provider configuration defaults."""
-        auth_config = {}
+        auth_config = make_auth_config()
         config = _get_provider_config("github", auth_config)
 
         assert config["scopes"] == ["user:email"]
 
     def test_provider_config_custom_scopes(self):
         """Test provider configuration with custom scopes."""
-        auth_config = {"scopes": ["custom", "scope"]}
+        auth_config = make_auth_config(oauth_scopes="custom,scope")
         config = _get_provider_config("google", auth_config)
 
-        assert config["scopes"] == ["custom", "scope"]
+        assert config["scopes"] == "custom,scope"
 
     def test_provider_config_custom_redirect_uri(self):
         """Test provider configuration with custom redirect URI."""
-        auth_config = {"redirect_uri": "http://custom.example.com/callback"}
+        auth_config = make_auth_config(
+            oauth_redirect_uri="http://custom.example.com/callback"
+        )
         config = _get_provider_config("google", auth_config)
 
         assert config["redirect_uri"] == "http://custom.example.com/callback"
@@ -236,7 +265,7 @@ class TestProviderConfiguration:
 
     def test_unsupported_provider_type(self):
         """Test unsupported provider type raises exception."""
-        auth_config = {}
+        auth_config = make_auth_config()
 
         with pytest.raises(ConfigurationException) as exc_info:
             _get_provider_config("unsupported", auth_config)
@@ -273,20 +302,22 @@ class TestFullAuthProviderFactory:
 
     def test_no_auth_provider(self):
         """Test building no auth provider."""
-        config = SimpleNamespace(auth={"type": "none"})
+        config = SimpleNamespace(auth=make_auth_config(type="none"))
         provider = build_auth_provider(config)
         assert provider is None
 
     def test_none_auth_provider(self):
         """Test building none auth provider."""
-        config = SimpleNamespace(auth={"type": "none"})
+        config = SimpleNamespace(auth=make_auth_config(type="none"))
         provider = build_auth_provider(config)
         assert provider is None
 
     @patch("itential_mcp.server.auth.JWTVerifier")
     def test_jwt_auth_provider(self, mock_jwt):
         """Test building JWT auth provider."""
-        config = SimpleNamespace(auth={"type": "jwt", "public_key": "test_key"})
+        config = SimpleNamespace(
+            auth=make_auth_config(type="jwt", public_key="test_key")
+        )
 
         mock_provider = MagicMock()
         mock_jwt.return_value = mock_provider
@@ -298,10 +329,10 @@ class TestFullAuthProviderFactory:
     def test_oauth_auth_provider(self, mock_oauth_provider):
         """Test building OAuth auth provider."""
         config = SimpleNamespace(
-            auth={
-                "type": "oauth",
-                "redirect_uri": "http://localhost:8000/auth/callback",
-            }
+            auth=make_auth_config(
+                type="oauth",
+                oauth_redirect_uri="http://localhost:8000/auth/callback",
+            )
         )
 
         mock_provider = MagicMock()
@@ -315,14 +346,14 @@ class TestFullAuthProviderFactory:
     def test_oauth_proxy_auth_provider(self, mock_token_verifier, mock_oauth_proxy):
         """Test building OAuth proxy auth provider."""
         config = SimpleNamespace(
-            auth={
-                "type": "oauth_proxy",
-                "client_id": "test_client",
-                "client_secret": "test_secret",
-                "authorization_url": "https://accounts.google.com/oauth/authorize",
-                "token_url": "https://oauth2.googleapis.com/token",
-                "redirect_uri": "http://localhost:8000/auth/callback",
-            }
+            auth=make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="http://localhost:8000/auth/callback",
+            )
         )
 
         mock_verifier_instance = MagicMock()
@@ -336,7 +367,9 @@ class TestFullAuthProviderFactory:
 
     def test_unsupported_auth_type(self):
         """Test unsupported auth type raises exception."""
-        config = SimpleNamespace(auth={"type": "unsupported"})
+        # Use SimpleNamespace to bypass Pydantic validation for testing invalid type
+        mock_auth = SimpleNamespace(type="unsupported")
+        config = SimpleNamespace(auth=mock_auth)
 
         with pytest.raises(ConfigurationException) as exc_info:
             build_auth_provider(config)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -647,9 +647,9 @@ class TestIntegration:
         mock_config.server.log_level = "INFO"
         mock_config.server.tools_path = None
         mock_config.tools = []
-        # Mock auth as a dict-like object
+        # Mock auth as an AuthConfig-like object with attribute access
         mock_auth = MagicMock()
-        mock_auth.get.return_value = "none"
+        mock_auth.type = "none"
         mock_config.auth = mock_auth
         mock_config_get.return_value = mock_config
         mock_auth_builder.return_value = None
@@ -958,9 +958,9 @@ class TestServerClass:
         mock_config = MagicMock()
         mock_config.server.transport = "stdio"
         mock_config.server.tools_path = None
-        # Mock auth as a dict-like object
+        # Mock auth as an AuthConfig-like object with attribute access
         mock_auth = MagicMock()
-        mock_auth.get.return_value = "none"
+        mock_auth.type = "none"
         mock_config.auth = mock_auth
         mock_config.tools = []
         mock_auth_builder.return_value = None


### PR DESCRIPTION
## 📒 Description

Fixes server startup failure in v0.11.0 caused by `auth.py` using dictionary-style access on `AuthConfig` after the config module was refactored to use frozen Pydantic dataclasses.

Fixes #296

## 🔍 Type of Change

- [x] Bug fix

## 🔧 Changes Made

- Updated `src/itential_mcp/server/auth.py` to use attribute access instead of `.get()` and `[]` dictionary access
- Changed type hints from `dict[str, Any]` to `AuthConfig`
- Fixed field name mappings (e.g., `redirect_uri` → `oauth_redirect_uri`)
- Updated tests to use `AuthConfig` dataclass instances

## 🧪 Testing

- All 2069 tests pass
- Ruff linter passes with no issues
- Verified attribute access works correctly for all auth types (none, jwt, oauth, oauth_proxy)

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed