### PR TITLE
test: improve test coverage to 99%

### DIFF
--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Additional tests for auth module to achieve better coverage."""
+
+import pytest
+from unittest.mock import patch
+
+from itential_mcp.server.auth import (
+    _build_oauth_provider,
+    _build_oauth_proxy_provider,
+    _get_provider_config,
+)
+from itential_mcp.core.exceptions import ConfigurationException
+
+
+class TestOAuthProviderExceptionHandling:
+    """Test exception handling in OAuth provider builders"""
+
+    @patch("itential_mcp.server.auth.OAuthProvider")
+    def test_oauth_provider_value_error(self, mock_oauth_provider):
+        """Test _build_oauth_provider handles ValueError"""
+        mock_oauth_provider.side_effect = ValueError("Invalid base_url")
+
+        auth_config = {"redirect_uri": "https://example.com/auth/callback"}
+
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_provider(auth_config)
+
+        assert "Invalid base_url" in str(exc_info.value)
+
+    @patch("itential_mcp.server.auth.OAuthProvider")
+    def test_oauth_provider_general_exception(self, mock_oauth_provider):
+        """Test _build_oauth_provider handles general Exception"""
+        mock_oauth_provider.side_effect = RuntimeError("Unexpected error")
+
+        auth_config = {"redirect_uri": "https://example.com/auth/callback"}
+
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_provider(auth_config)
+
+        assert "Failed to initialize OAuth authorization server" in str(exc_info.value)
+        assert "Unexpected error" in str(exc_info.value)
+
+
+class TestOAuthProxyProviderCoverage:
+    """Test OAuth proxy provider for missing coverage"""
+
+    def test_oauth_proxy_missing_client_id(self):
+        """Test _build_oauth_proxy_provider with missing client_id"""
+        auth_config = {
+            # client_id is missing
+            "client_secret": "secret",
+            "authorization_url": "https://auth.example.com/oauth/authorize",
+            "token_url": "https://auth.example.com/oauth/token",
+            "redirect_uri": "https://example.com/auth/callback",
+        }
+
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_proxy_provider(auth_config)
+
+        assert "client_id" in str(exc_info.value)
+
+
+class TestProviderConfigurationDefaults:
+    """Test provider-specific configuration defaults"""
+
+    def test_auth0_default_scopes(self):
+        """Test _get_provider_config returns auth0 default scopes"""
+        auth_config = {}  # No scopes provided
+
+        config = _get_provider_config("auth0", auth_config)
+
+        assert "scopes" in config
+        assert config["scopes"] == ["openid", "email", "profile"]
+
+    def test_okta_default_scopes(self):
+        """Test _get_provider_config returns okta default scopes"""
+        auth_config = {}  # No scopes provided
+
+        config = _get_provider_config("okta", auth_config)
+
+        assert "scopes" in config
+        assert config["scopes"] == ["openid", "email", "profile"]
+
+    def test_generic_provider_no_defaults(self):
+        """Test _get_provider_config returns empty config for generic provider"""
+        auth_config = {}
+
+        config = _get_provider_config("generic", auth_config)
+
+        # Generic provider should have no default scopes
+        assert (
+            "scopes" not in config
+            or config.get("scopes") is None
+            or len(config.get("scopes", [])) == 0
+        )
+
+    def test_generic_provider_with_custom_scopes(self):
+        """Test _get_provider_config respects custom scopes for generic provider"""
+        auth_config = {"scopes": ["custom", "scopes"]}
+
+        config = _get_provider_config("generic", auth_config)
+
+        assert config["scopes"] == ["custom", "scopes"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -593,3 +593,643 @@ class TestCommandsIntegration:
 
         with pytest.raises(AttributeError):
             commands.call(PartialArgs())
+
+
+class TestTestCommand:
+    """Test cases for the test command function"""
+
+    def test_test_function_exists(self):
+        """Test that the test function exists and is callable"""
+        assert hasattr(commands, "test")
+        assert callable(commands.test)
+
+    def test_test_returns_correct_tuple_structure(self):
+        """Test that test function returns the expected tuple structure"""
+        args = Mock()
+        args.config = None
+        args.format = "human"
+        args.verbose = False
+        args.timeout = 30
+        args.quiet = False
+
+        result = commands.test(args)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert asyncio.iscoroutinefunction(result[0])
+        assert result[1] is None
+        assert isinstance(result[2], dict)
+
+    def test_test_with_all_options(self):
+        """Test test function with all arguments specified"""
+        args = Mock()
+        args.config = "/path/to/config.ini"
+        args.format = "json"
+        args.verbose = True
+        args.timeout = 60
+        args.quiet = True
+
+        result = commands.test(args)
+
+        assert result[0] == commands._execute_test_connection
+        assert result[1] is None
+        assert result[2]["config_file"] == "/path/to/config.ini"
+        assert result[2]["format"] == "json"
+        assert result[2]["verbose"] is True
+        assert result[2]["timeout"] == 60
+        assert result[2]["quiet"] is True
+
+    def test_test_with_default_values(self):
+        """Test test function with default values"""
+        args = Mock(spec=[])  # Empty spec means no attributes
+
+        result = commands.test(args)
+
+        assert result[2]["config_file"] is None
+        assert result[2]["format"] == "human"
+        assert result[2]["verbose"] is False
+        assert result[2]["timeout"] == 30
+        assert result[2]["quiet"] is False
+
+    def test_test_function_signature(self):
+        """Test that test function has correct signature"""
+        sig = inspect.signature(commands.test)
+        params = list(sig.parameters.keys())
+
+        assert len(params) == 1
+        assert params[0] == "args"
+
+    def test_test_function_docstring(self):
+        """Test that test function has proper docstring"""
+        assert commands.test.__doc__ is not None
+        assert "Implement the `itential-mcp test` command" in commands.test.__doc__
+
+
+class TestExecuteTestConnection:
+    """Test cases for _execute_test_connection function"""
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_exists(self):
+        """Test that _execute_test_connection function exists"""
+        assert hasattr(commands, "_execute_test_connection")
+        assert callable(commands._execute_test_connection)
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_is_async(self):
+        """Test that _execute_test_connection is a coroutine function"""
+        assert asyncio.iscoroutinefunction(commands._execute_test_connection)
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_config_load_failure(self, monkeypatch):
+        """Test _execute_test_connection with configuration load failure"""
+        from itential_mcp import config
+
+        # Mock config.get to raise an exception
+        def mock_get():
+            raise RuntimeError("Config load failed")
+
+        monkeypatch.setattr(config, "get", mock_get)
+
+        result = await commands._execute_test_connection()
+
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_with_config_file(
+        self, tmp_path, monkeypatch
+    ):
+        """Test _execute_test_connection with config file parameter"""
+        import os
+        from itential_mcp import config
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Create a temporary config file
+        config_file = tmp_path / "test.ini"
+        config_file.write_text("[server]\ntransport = stdio\n")
+
+        # Clear the cache
+        config.get.cache_clear()
+
+        # Mock ConnectionTestService
+        mock_service = Mock()
+        mock_result = Mock()
+        mock_result.success = True
+        mock_result.checks = []
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+        mock_result.duration_ms = 100.5
+        mock_result.error = None
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+
+        # Clear environment
+        monkeypatch.delenv("ITENTIAL_MCP_CONFIG", raising=False)
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(
+                config_file=str(config_file), format="human", quiet=True
+            )
+
+        assert result == 0
+        assert os.environ.get("ITENTIAL_MCP_CONFIG") == str(config_file)
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_success_human_format(self):
+        """Test _execute_test_connection with successful test in human format"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Mock ConnectionTestService
+        mock_service = Mock()
+        mock_result = Mock()
+        mock_result.success = True
+        mock_result.checks = []
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+        mock_result.duration_ms = 100.5
+        mock_result.error = None
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(format="human", quiet=True)
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_failure(self):
+        """Test _execute_test_connection with failed test"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Mock ConnectionTestService
+        mock_service = Mock()
+        mock_result = Mock()
+        mock_result.success = False
+        mock_result.checks = []
+        mock_result.error = "Connection failed"
+        mock_result.duration_ms = 100.0  # Add duration for JSON output
+        mock_result.platform_version = None
+        mock_result.authenticated_user = None
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(format="json", quiet=True)
+
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_exception_during_check(self):
+        """Test _execute_test_connection with exception during check execution"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Mock ConnectionTestService to raise exception
+        mock_service = Mock()
+        mock_service.run_all_checks = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(quiet=True)
+
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_json_format(self, capsys):
+        """Test _execute_test_connection with JSON output format"""
+        from unittest.mock import AsyncMock, Mock, patch
+        import json
+
+        # Mock ConnectionTestService
+        mock_service = Mock()
+        mock_result = Mock()
+        mock_result.success = True
+        mock_result.checks = []
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+        mock_result.duration_ms = 100.5
+        mock_result.error = None
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(format="json", quiet=True)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        # Should output JSON
+        assert captured.out.strip()
+        output = json.loads(captured.out)
+        assert "success" in output
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_with_timeout(self):
+        """Test _execute_test_connection with custom timeout"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Mock ConnectionTestService
+        mock_service = Mock()
+        mock_result = Mock()
+        mock_result.success = True
+        mock_result.checks = []
+        mock_result.duration_ms = 150.0
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+        mock_result.error = None
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(timeout=60, quiet=True)
+
+        assert result == 0
+        mock_service.run_all_checks.assert_called_once_with(timeout=60)
+
+    @pytest.mark.asyncio
+    async def test_execute_test_connection_with_progress_messages(self, capsys):
+        """Test _execute_test_connection shows progress messages when not quiet"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Mock ConnectionTestService
+        mock_service = Mock()
+        mock_result = Mock()
+        mock_result.success = True
+        mock_result.checks = []
+        mock_result.duration_ms = 150.0
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+        mock_result.error = None
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "itential_mcp.platform.connection_test.ConnectionTestService",
+            return_value=mock_service,
+        ):
+            result = await commands._execute_test_connection(
+                format="human", quiet=False
+            )
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Testing connection to Itential Platform" in captured.out
+
+
+class TestOutputHuman:
+    """Test cases for _output_human function"""
+
+    def test_output_human_exists(self):
+        """Test that _output_human function exists"""
+        assert hasattr(commands, "_output_human")
+        assert callable(commands._output_human)
+
+    def test_output_human_with_passed_checks(self, capsys):
+        """Test _output_human with all checks passed"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        result = Mock()
+        result.success = True
+        result.platform_version = "2024.1"
+        result.authenticated_user = "admin"
+        result.duration_ms = 150.5
+
+        check = Mock()
+        check.status = CheckStatus.PASSED
+        check.message = "DNS resolution: Successful"
+        check.duration_ms = 50.2
+        check.details = None
+        check.error = None
+        check.suggestion = None
+
+        result.checks = [check]
+        result.error = None
+
+        commands._output_human(result)
+
+        captured = capsys.readouterr()
+        assert "✓" in captured.out
+        assert "DNS resolution: Successful" in captured.out
+        assert "SUCCESS" in captured.out
+
+    def test_output_human_with_failed_checks(self, capsys):
+        """Test _output_human with failed checks"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        result = Mock()
+        result.success = False
+        result.platform_version = None
+        result.authenticated_user = None
+        result.error = "Connection timeout"
+
+        check = Mock()
+        check.status = CheckStatus.FAILED
+        check.message = "Connection: Failed"
+        check.duration_ms = 5000.0
+        check.details = None
+        check.error = None
+        check.suggestion = "Check firewall settings"
+
+        result.checks = [check]
+
+        commands._output_human(result)
+
+        captured = capsys.readouterr()
+        assert "✗" in captured.out
+        assert "Connection: Failed" in captured.out
+        assert "FAILED" in captured.out
+        assert "Suggestion" in captured.out
+        assert "Check firewall settings" in captured.out
+
+    def test_output_human_with_skipped_checks(self, capsys):
+        """Test _output_human with skipped checks"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        result = Mock()
+        result.success = True
+        result.platform_version = "2024.1"
+        result.authenticated_user = "admin"
+        result.duration_ms = 100.0
+        result.error = None
+
+        check = Mock()
+        check.status = CheckStatus.SKIPPED
+        check.message = "Optional check: Skipped"
+        check.duration_ms = 0.0
+        check.details = None
+        check.error = None
+        check.suggestion = None
+
+        result.checks = [check]
+
+        commands._output_human(result)
+
+        captured = capsys.readouterr()
+        assert "○" in captured.out
+        assert "Optional check: Skipped" in captured.out
+
+    def test_output_human_with_warning_checks(self, capsys):
+        """Test _output_human with warning checks"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        result = Mock()
+        result.success = True
+        result.platform_version = "2024.1"
+        result.authenticated_user = "admin"
+        result.duration_ms = 100.0
+        result.error = None
+
+        check = Mock()
+        check.status = CheckStatus.WARNING
+        check.message = "Performance warning"
+        check.duration_ms = 1000.0
+        check.details = None
+        check.error = None
+        check.suggestion = None
+
+        result.checks = [check]
+
+        commands._output_human(result)
+
+        captured = capsys.readouterr()
+        assert "⚠" in captured.out
+        assert "Performance warning" in captured.out
+
+    def test_output_human_verbose_mode(self, capsys):
+        """Test _output_human in verbose mode showing details"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        result = Mock()
+        result.success = True
+        result.platform_version = "2024.1"
+        result.authenticated_user = "admin"
+        result.duration_ms = 150.5
+        result.error = None
+
+        check = Mock()
+        check.status = CheckStatus.PASSED
+        check.message = "API check: Successful"
+        check.duration_ms = 75.3
+        check.details = {"endpoint": "/health", "status_code": 200}
+        check.error = None
+        check.suggestion = None
+
+        result.checks = [check]
+
+        commands._output_human(result, verbose=True)
+
+        captured = capsys.readouterr()
+        assert "Duration:" in captured.out
+        assert "75ms" in captured.out
+        assert "Details:" in captured.out
+        assert "endpoint:" in captured.out
+        assert "/health" in captured.out
+
+    def test_output_human_verbose_mode_with_error(self, capsys):
+        """Test _output_human in verbose mode showing error details"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        result = Mock()
+        result.success = False
+        result.error = "Test failed"
+
+        check = Mock()
+        check.status = CheckStatus.FAILED
+        check.message = "Test failed"
+        check.duration_ms = 50.0
+        check.details = None
+        check.error = RuntimeError("Connection refused")
+        check.suggestion = None
+
+        result.checks = [check]
+
+        commands._output_human(result, verbose=True)
+
+        captured = capsys.readouterr()
+        assert "Error:" in captured.out
+        assert "RuntimeError" in captured.out
+        assert "Connection refused" in captured.out
+
+
+class TestOutputJson:
+    """Test cases for _output_json function"""
+
+    def test_output_json_exists(self):
+        """Test that _output_json function exists"""
+        assert hasattr(commands, "_output_json")
+        assert callable(commands._output_json)
+
+    def test_output_json_basic_structure(self, capsys):
+        """Test _output_json outputs valid JSON with correct structure"""
+        from unittest.mock import Mock
+        import json
+
+        result = Mock()
+        result.success = True
+        result.duration_ms = 150.5
+        result.platform_version = "2024.1"
+        result.authenticated_user = "admin"
+        result.error = None
+        result.checks = []
+
+        commands._output_json(result)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is True
+        assert output["duration_ms"] == 150.5
+        assert "timestamp" in output
+        assert "checks" in output
+        assert "summary" in output
+        assert output["platform_version"] == "2024.1"
+        assert output["authenticated_user"] == "admin"
+
+    def test_output_json_with_checks(self, capsys):
+        """Test _output_json with check results"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+        import json
+
+        result = Mock()
+        result.success = True
+        result.duration_ms = 150.5
+        result.platform_version = None
+        result.authenticated_user = None
+        result.error = None
+
+        check = Mock()
+        check.name = "dns_resolution"
+        check.status = CheckStatus.PASSED
+        check.message = "DNS resolution successful"
+        check.duration_ms = 50.2
+        check.details = {"resolved_ip": "192.168.1.1"}
+        check.suggestion = None
+        check.error = None
+
+        result.checks = [check]
+
+        commands._output_json(result)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert len(output["checks"]) == 1
+        assert output["checks"][0]["name"] == "dns_resolution"
+        assert output["checks"][0]["status"] == CheckStatus.PASSED
+        assert output["checks"][0]["message"] == "DNS resolution successful"
+        assert output["checks"][0]["duration_ms"] == 50.2
+        assert output["checks"][0]["details"]["resolved_ip"] == "192.168.1.1"
+
+    def test_output_json_with_error(self, capsys):
+        """Test _output_json with error information"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+        import json
+
+        result = Mock()
+        result.success = False
+        result.duration_ms = 100.0
+        result.platform_version = None
+        result.authenticated_user = None
+        result.error = "Connection timeout"
+
+        check = Mock()
+        check.name = "connectivity"
+        check.status = CheckStatus.FAILED
+        check.message = "Connection failed"
+        check.duration_ms = 100.0
+        check.details = None
+        check.suggestion = "Check network settings"
+        check.error = TimeoutError("Connection timeout")
+
+        result.checks = [check]
+
+        commands._output_json(result)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["success"] is False
+        assert output["error"] == "Connection timeout"
+        assert output["checks"][0]["suggestion"] == "Check network settings"
+        assert output["checks"][0]["error"]["type"] == "TimeoutError"
+        assert output["checks"][0]["error"]["message"] == "Connection timeout"
+
+    def test_output_json_summary_statistics(self, capsys):
+        """Test _output_json includes correct summary statistics"""
+        from unittest.mock import Mock
+        from itential_mcp.platform.connection_test import CheckStatus
+        import json
+
+        result = Mock()
+        result.success = True
+        result.duration_ms = 200.0
+        result.platform_version = None
+        result.authenticated_user = None
+        result.error = None
+
+        check1 = Mock()
+        check1.name = "check1"
+        check1.status = CheckStatus.PASSED
+        check1.message = "Passed"
+        check1.duration_ms = 50.0
+        check1.details = None
+        check1.suggestion = None
+        check1.error = None
+
+        check2 = Mock()
+        check2.name = "check2"
+        check2.status = CheckStatus.FAILED
+        check2.message = "Failed"
+        check2.duration_ms = 50.0
+        check2.details = None
+        check2.suggestion = None
+        check2.error = None
+
+        check3 = Mock()
+        check3.name = "check3"
+        check3.status = CheckStatus.SKIPPED
+        check3.message = "Skipped"
+        check3.duration_ms = 0.0
+        check3.details = None
+        check3.suggestion = None
+        check3.error = None
+
+        check4 = Mock()
+        check4.name = "check4"
+        check4.status = CheckStatus.WARNING
+        check4.message = "Warning"
+        check4.duration_ms = 50.0
+        check4.details = None
+        check4.suggestion = None
+        check4.error = None
+
+        result.checks = [check1, check2, check3, check4]
+
+        commands._output_json(result)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert output["summary"]["total_checks"] == 4
+        assert output["summary"]["passed"] == 1
+        assert output["summary"]["failed"] == 1
+        assert output["summary"]["skipped"] == 1
+        assert output["summary"]["warnings"] == 1

--- a/tests/test_config_coverage.py
+++ b/tests/test_config_coverage.py
@@ -4,6 +4,7 @@
 
 """Additional tests for config package to achieve 100% coverage."""
 
+import os
 import configparser
 import pytest
 
@@ -15,6 +16,14 @@ from itential_mcp.config import (
 )
 from itential_mcp.config.converters import auth_to_dict
 from itential_mcp.config.models import AuthConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache():
+    """Ensure config.get() doesn't cache between tests."""
+    config.get.cache_clear()
+    yield
+    config.get.cache_clear()
 
 
 class TestOptionsFunction:
@@ -209,3 +218,324 @@ class TestConfigFileWithAuthPrefix:
         assert cfg.auth.type == "jwt"
         assert cfg.auth.issuer == "https://auth.example.com"
         assert cfg.auth.audience == "my-api"
+
+
+class TestConverterEdgeCases:
+    """Tests for edge cases in converter functions."""
+
+    def test_split_comma_separated_with_empty_string(self):
+        """Test _split_comma_separated with empty string."""
+        from itential_mcp.config.converters import _split_comma_separated
+
+        result = _split_comma_separated("")
+        assert result == set()
+
+    def test_split_comma_separated_with_none(self):
+        """Test _split_comma_separated with None."""
+        from itential_mcp.config.converters import _split_comma_separated
+
+        result = _split_comma_separated(None)
+        assert result == set()
+
+    def test_split_to_list_with_none(self):
+        """Test _split_to_list with None."""
+        from itential_mcp.config.converters import _split_to_list
+
+        result = _split_to_list(None)
+        assert result == []
+
+    def test_split_to_list_with_empty_string(self):
+        """Test _split_to_list with empty string."""
+        from itential_mcp.config.converters import _split_to_list
+
+        result = _split_to_list("")
+        assert result == []
+
+    def test_auth_to_dict_with_dict_input(self):
+        """Test auth_to_dict with dict input (passthrough)."""
+        input_dict = {"type": "jwt", "issuer": "https://example.com"}
+        result = auth_to_dict(input_dict)
+        assert result == input_dict
+
+
+class TestLoaderFunctions:
+    """Tests for loader functions edge cases."""
+
+    def test_parse_tool_env_variables_invalid_format_no_underscore(self, monkeypatch):
+        """Test _parse_tool_env_variables with invalid format (no underscore)."""
+        from itential_mcp.config.loaders import _parse_tool_env_variables
+
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_INVALID", "value")
+
+        with pytest.raises(
+            ValueError, match="Invalid tool environment variable format"
+        ):
+            _parse_tool_env_variables()
+
+    def test_parse_tool_env_variables_empty_tool_name(self, monkeypatch):
+        """Test _parse_tool_env_variables with empty tool name."""
+        from itential_mcp.config.loaders import _parse_tool_env_variables
+
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL__TYPE", "endpoint")
+
+        with pytest.raises(
+            ValueError, match="Tool name and config key cannot be empty"
+        ):
+            _parse_tool_env_variables()
+
+    def test_parse_tool_env_variables_empty_config_key(self, monkeypatch):
+        """Test _parse_tool_env_variables with empty config key."""
+        from itential_mcp.config.loaders import _parse_tool_env_variables
+
+        # This would create ITENTIAL_MCP_TOOL_MYTOOL_ (trailing underscore, empty key)
+        # but we need to test the empty key path - let's use a different approach
+        # Actually, rsplit on last underscore means if we have "MYTOOL_" it becomes ("MYTOOL", "")
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_MYTOOL_", "value")
+
+        with pytest.raises(
+            ValueError, match="Tool name and config key cannot be empty"
+        ):
+            _parse_tool_env_variables()
+
+    def test_create_tool_from_dict_service_type(self):
+        """Test _create_tool_from_dict with service type."""
+        from itential_mcp.config.loaders import _create_tool_from_dict
+
+        tool_data = {
+            "name": "test-service",
+            "tool_name": "test_service_tool",
+            "type": "service",
+            "cluster": "default",
+        }
+        tool = _create_tool_from_dict(tool_data)
+
+        from itential_mcp.config.models import ServiceTool
+
+        assert isinstance(tool, ServiceTool)
+        assert tool.cluster == "default"
+
+    def test_create_tool_from_dict_default_tool_type(self):
+        """Test _create_tool_from_dict with endpoint type returns EndpointTool."""
+        from itential_mcp.config.loaders import _create_tool_from_dict
+
+        tool_data = {
+            "name": "test-tool",
+            "tool_name": "test_tool",
+            "type": "endpoint",
+            "automation": "Test Automation",
+        }
+        tool = _create_tool_from_dict(tool_data)
+
+        from itential_mcp.config.models import EndpointTool
+
+        assert isinstance(tool, EndpointTool)
+        assert tool.automation == "Test Automation"
+
+    def test_create_tool_from_dict_fallback_to_tool_base(self):
+        """Test _create_tool_from_dict fallback to Tool base class (covers line 113)."""
+        from itential_mcp.config.loaders import _create_tool_from_dict
+        from pydantic_core import ValidationError
+
+        # tool_data with type that's neither "endpoint" nor "service"
+        # This will reach line 113 but fail validation
+        tool_data = {
+            "name": "test-tool",
+            "tool_name": "test_tool",
+            "type": "invalid_type",
+        }
+
+        # This should raise ValidationError because Tool only accepts "endpoint" or "service"
+        with pytest.raises(ValidationError):
+            _create_tool_from_dict(tool_data)
+
+    def test_parse_config_file_with_tool_section(self, tmp_path, monkeypatch):
+        """Test _parse_config_file with tool sections."""
+        from itential_mcp.config.loaders import _parse_config_file
+
+        config_path = tmp_path / "test.ini"
+
+        cp = configparser.ConfigParser()
+        cp["server"] = {"transport": "stdio"}
+        cp["tool:my_workflow"] = {
+            "name": "deploy_config",
+            "type": "endpoint",
+            "automation": "Deploy Configuration",
+        }
+
+        with open(config_path, "w") as f:
+            cp.write(f)
+
+        # Clear environment tools
+        for key in list(os.environ.keys()):
+            if key.startswith("ITENTIAL_MCP_TOOL_"):
+                monkeypatch.delenv(key, raising=False)
+
+        config_data, tools = _parse_config_file(config_path)
+
+        assert len(tools) == 1
+        assert tools[0].tool_name == "my_workflow"
+        assert tools[0].type == "endpoint"
+
+    def test_parse_config_file_with_env_tool_override(self, tmp_path, monkeypatch):
+        """Test _parse_config_file with environment variable overriding config file."""
+        from itential_mcp.config.loaders import _parse_config_file
+
+        config_path = tmp_path / "test.ini"
+
+        # Clear all existing tool environment variables first
+        for key in list(os.environ.keys()):
+            if key.startswith("ITENTIAL_MCP_TOOL_"):
+                monkeypatch.delenv(key, raising=False)
+
+        cp = configparser.ConfigParser()
+        cp["tool:my_tool"] = {
+            "name": "original_name",
+            "type": "endpoint",
+            "automation": "Original Automation",
+        }
+
+        with open(config_path, "w") as f:
+            cp.write(f)
+
+        # Set environment variables that should override (matching the tool_name)
+        # The environment variable format uses uppercase and the tool name is "my_tool"
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_my_tool_NAME", "overridden_name")
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_my_tool_TYPE", "endpoint")
+        monkeypatch.setenv(
+            "ITENTIAL_MCP_TOOL_my_tool_AUTOMATION", "Override Automation"
+        )
+
+        config_data, tools = _parse_config_file(config_path)
+
+        # Should have only one tool (config file merged with env vars)
+        assert len(tools) == 1
+        assert tools[0].name == "overridden_name"
+        assert tools[0].automation == "Override Automation"
+
+    def test_parse_config_file_with_env_only_tool(self, tmp_path, monkeypatch):
+        """Test _parse_config_file includes environment-only tools."""
+        from itential_mcp.config.loaders import _parse_config_file
+
+        config_path = tmp_path / "test.ini"
+
+        cp = configparser.ConfigParser()
+        cp["server"] = {"transport": "stdio"}
+
+        with open(config_path, "w") as f:
+            cp.write(f)
+
+        # Set environment tool not in config file
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_ENV_ONLY_NAME", "env_tool")
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_ENV_ONLY_TYPE", "service")
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_ENV_ONLY_CLUSTER", "production")
+
+        config_data, tools = _parse_config_file(config_path)
+
+        assert len(tools) == 1
+        assert tools[0].tool_name == "ENV_ONLY"
+        assert tools[0].type == "service"
+
+    def test_split_comma_separated_in_loaders(self):
+        """Test _split_comma_separated function in loaders module."""
+        from itential_mcp.config.loaders import _split_comma_separated
+
+        # Test with None
+        result = _split_comma_separated(None)
+        assert result == []
+
+        # Test with empty string
+        result = _split_comma_separated("")
+        assert result == []
+
+        # Test with values
+        result = _split_comma_separated("a,b,c")
+        assert result == ["a", "b", "c"]
+
+    def test_split_space_or_comma_separated(self):
+        """Test _split_space_or_comma_separated function."""
+        from itential_mcp.config.loaders import _split_space_or_comma_separated
+
+        # Test with None
+        result = _split_space_or_comma_separated(None)
+        assert result == []
+
+        # Test with empty string
+        result = _split_space_or_comma_separated("")
+        assert result == []
+
+        # Test with space-separated values
+        result = _split_space_or_comma_separated("a b c")
+        assert result == ["a", "b", "c"]
+
+        # Test with comma-separated values
+        result = _split_space_or_comma_separated("a,b,c")
+        assert result == ["a", "b", "c"]
+
+        # Test with mixed separators
+        result = _split_space_or_comma_separated("a, b c,d")
+        assert result == ["a", "b", "c", "d"]
+
+    def test_load_config_without_file_with_env_tools(self, monkeypatch):
+        """Test load_config without config file but with environment tools."""
+        from itential_mcp.config.loaders import load_config
+
+        # Clear config file setting
+        monkeypatch.delenv("ITENTIAL_MCP_CONFIG", raising=False)
+
+        # Clear existing tools
+        for key in list(os.environ.keys()):
+            if key.startswith("ITENTIAL_MCP_TOOL_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Set environment tool
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_TEST_NAME", "test_asset")
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_TEST_TYPE", "endpoint")
+        monkeypatch.setenv("ITENTIAL_MCP_TOOL_TEST_AUTOMATION", "Test Automation")
+
+        config.get.cache_clear()
+        cfg = load_config()
+
+        assert len(cfg.tools) == 1
+        assert cfg.tools[0].tool_name == "TEST"
+        assert cfg.tools[0].type == "endpoint"
+
+
+class TestPlatformConfigValidators:
+    """Tests for PlatformConfig field validators."""
+
+    def test_platform_config_invalid_port_triggers_validation(self, monkeypatch):
+        """Test PlatformConfig with invalid port triggers validation."""
+        from itential_mcp.config.models import PlatformConfig
+
+        # Clear environment variables
+        for key in list(os.environ.keys()):
+            if key.startswith("ITENTIAL_MCP_PLATFORM_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Try to create with invalid port
+        with pytest.raises(
+            ValueError, match="Platform port must be between 1 and 65535"
+        ):
+            PlatformConfig(port=0)
+
+    def test_platform_config_invalid_host_triggers_validation(self, monkeypatch):
+        """Test PlatformConfig with invalid host triggers validation."""
+        from itential_mcp.config.models import PlatformConfig
+
+        # Clear environment variables
+        for key in list(os.environ.keys()):
+            if key.startswith("ITENTIAL_MCP_PLATFORM_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Try to create with invalid host (empty string)
+        with pytest.raises(ValueError, match="Platform host cannot be empty"):
+            PlatformConfig(host="")
+
+
+class TestValidateHostCompleteHostnamePath:
+    """Test validate_host to ensure all code paths are covered."""
+
+    def test_validate_host_with_valid_hostname(self):
+        """Test validate_host with valid hostname returns the hostname."""
+        result = validate_host("valid-hostname.example.com")
+        assert result == "valid-hostname.example.com"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -988,3 +988,415 @@ class TestServerClass:
         with patch("itential_mcp.server.server.FastMCP"):
             async with server_instance as srv:
                 assert srv == server_instance
+
+
+class TestServerInitialization:
+    """Test Server initialization methods"""
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.server.build_auth_provider")
+    @patch("itential_mcp.server.server.supports_transport")
+    async def test_init_server_auth_transport_incompatibility(
+        self, mock_supports_transport, mock_auth_builder
+    ):
+        """Test that __init_server__ raises ConfigurationException for incompatible auth/transport"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+        from itential_mcp.core.exceptions import ConfigurationException
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", log_level="INFO"),
+            auth=AuthConfig(type="oauth"),
+        )
+
+        # Mock auth provider that is NOT compatible with stdio transport
+        mock_auth_provider = MagicMock()
+        mock_auth_provider.__class__.__name__ = "OAuthProvider"
+        mock_auth_builder.return_value = mock_auth_provider
+        mock_supports_transport.return_value = False
+
+        server_instance = server_module.Server(mock_config)
+
+        # Should raise ConfigurationException
+        with pytest.raises(ConfigurationException) as exc_info:
+            await server_instance.__init_server__()
+
+        assert "not supported for transport" in str(exc_info.value)
+        assert "stdio" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    async def test_init_server_parse_tags_with_none(self, mock_auth_builder):
+        """Test __init_server__ with None tags returns None"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                include_tags=None,
+                exclude_tags=None,
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        server_instance = server_module.Server(mock_config)
+
+        with patch("itential_mcp.server.server.FastMCP") as mock_fastmcp:
+            await server_instance.__init_server__()
+
+            # Verify FastMCP was called with None for tags
+            call_kwargs = mock_fastmcp.call_args.kwargs
+            assert call_kwargs["include_tags"] is None
+            assert call_kwargs["exclude_tags"] is None
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.toolutils.itertools")
+    async def test_init_tools_with_custom_tools_path(
+        self, mock_itertools, mock_auth_builder
+    ):
+        """Test __init_tools__ includes custom tools_path"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                tools_path="/custom/path/to/tools",
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        def mock_func():
+            """Test tool"""
+            pass
+
+        mock_func.__name__ = "test_tool"
+        mock_itertools.return_value = [(mock_func, {"test"})]
+
+        server_instance = server_module.Server(mock_config)
+
+        with patch("itential_mcp.server.server.FastMCP"):
+            await server_instance.__init_server__()
+            await server_instance.__init_tools__()
+
+        # Verify itertools was called twice (once for builtin, once for custom path)
+        assert mock_itertools.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.toolutils.itertools")
+    @patch("itential_mcp.server.server.toolutils.get_json_schema")
+    async def test_init_tools_with_output_schema(
+        self, mock_get_schema, mock_itertools, mock_auth_builder
+    ):
+        """Test __init_tools__ adds output_schema when available"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", tools_path=None, log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        def mock_func():
+            """Test tool"""
+            pass
+
+        mock_func.__name__ = "test_tool"
+        mock_itertools.return_value = [(mock_func, {"test"})]
+
+        # Mock schema with object type
+        mock_get_schema.return_value = {"type": "object", "properties": {}}
+
+        server_instance = server_module.Server(mock_config)
+
+        with patch("itential_mcp.server.server.FastMCP"):
+            await server_instance.__init_server__()
+            await server_instance.__init_tools__()
+
+        # Verify get_json_schema was called
+        mock_get_schema.assert_called_with(mock_func)
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.toolutils.itertools")
+    @patch("itential_mcp.server.server.toolutils.get_json_schema")
+    async def test_init_tools_without_output_schema(
+        self, mock_get_schema, mock_itertools, mock_auth_builder
+    ):
+        """Test __init_tools__ handles tools without output_schema"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", tools_path=None, log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        def mock_func():
+            """Test tool"""
+            pass
+
+        mock_func.__name__ = "test_tool"
+        mock_itertools.return_value = [(mock_func, {"test"})]
+
+        # Mock get_json_schema to raise ValueError
+        mock_get_schema.side_effect = ValueError("No schema")
+
+        server_instance = server_module.Server(mock_config)
+
+        with patch("itential_mcp.server.server.FastMCP"):
+            await server_instance.__init_server__()
+            await server_instance.__init_tools__()
+
+        # Should not raise, just skip adding output_schema
+        mock_get_schema.assert_called_with(mock_func)
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.bindings.iterbindings")
+    async def test_init_bindings_with_tools(self, mock_iterbindings, mock_auth_builder):
+        """Test __init_bindings__ registers dynamic bindings"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        async def mock_bound_func():
+            """Bound tool"""
+            pass
+
+        # Setup async generator with bindings
+        async def mock_async_gen():
+            yield (mock_bound_func, {"name": "bound_tool", "tags": {"binding"}})
+
+        mock_iterbindings.return_value = mock_async_gen()
+
+        server_instance = server_module.Server(mock_config)
+
+        with patch("itential_mcp.server.server.FastMCP"):
+            await server_instance.__init_server__()
+            await server_instance.__init_bindings__()
+
+        # Verify iterbindings was called
+        mock_iterbindings.assert_called_once_with(mock_config)
+
+
+class TestConnectionTest:
+    """Test connection testing on startup"""
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.platform.connection_test.ConnectionTestService")
+    async def test_test_connection_on_startup_success(self, mock_service_class):
+        """Test _test_connection_on_startup with successful connection"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                test_connection_on_startup=True,
+                startup_test_timeout=30,
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        # Mock successful connection test result
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+
+        mock_service = MagicMock()
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+        mock_service_class.return_value = mock_service
+
+        server_instance = server_module.Server(mock_config)
+
+        # Should not raise
+        await server_instance._test_connection_on_startup()
+
+        mock_service.run_all_checks.assert_called_once_with(timeout=30)
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.platform.connection_test.ConnectionTestService")
+    async def test_test_connection_on_startup_failure(self, mock_service_class):
+        """Test _test_connection_on_startup with failed connection"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+        from itential_mcp.core.exceptions import ConnectionException
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                test_connection_on_startup=True,
+                startup_test_timeout=30,
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        # Mock failed connection test result
+        mock_check = MagicMock()
+        mock_check.status = CheckStatus.FAILED
+        mock_check.name = "dns_resolution"
+        mock_check.message = "DNS lookup failed"
+        mock_check.suggestion = "Check DNS configuration"
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error = "Connection failed"
+        mock_result.checks = [mock_check]
+
+        mock_service = MagicMock()
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+        mock_service_class.return_value = mock_service
+
+        server_instance = server_module.Server(mock_config)
+
+        # Should raise ConnectionException
+        with pytest.raises(ConnectionException) as exc_info:
+            await server_instance._test_connection_on_startup()
+
+        assert "Connection failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.platform.connection_test.ConnectionTestService")
+    async def test_test_connection_on_startup_exception(self, mock_service_class):
+        """Test _test_connection_on_startup with unexpected exception"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+        from itential_mcp.core.exceptions import ConnectionException
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                test_connection_on_startup=True,
+                startup_test_timeout=30,
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        # Mock service to raise exception
+        mock_service = MagicMock()
+        mock_service.run_all_checks = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+        mock_service_class.return_value = mock_service
+
+        server_instance = server_module.Server(mock_config)
+
+        # Should raise ConnectionException
+        with pytest.raises(ConnectionException) as exc_info:
+            await server_instance._test_connection_on_startup()
+
+        assert "Unexpected error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.platform.connection_test.ConnectionTestService")
+    async def test_server_run_with_connection_test_enabled(
+        self, mock_service_class, mock_auth_builder
+    ):
+        """Test Server.run() calls _test_connection_on_startup when enabled"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                test_connection_on_startup=True,
+                startup_test_timeout=30,
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        # Mock successful connection test
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.platform_version = "2024.1"
+        mock_result.authenticated_user = "admin"
+
+        mock_service = MagicMock()
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+        mock_service_class.return_value = mock_service
+
+        server_instance = server_module.Server(mock_config)
+
+        # Mock MCP instance
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        server_instance.mcp = mock_mcp
+
+        await server_instance.run()
+
+        # Verify connection test was called
+        mock_service.run_all_checks.assert_called_once_with(timeout=30)
+        # Verify server continued to run after successful test
+        mock_mcp.run_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.platform.connection_test.ConnectionTestService")
+    async def test_server_run_with_connection_test_failure_stops_startup(
+        self, mock_service_class, mock_auth_builder
+    ):
+        """Test Server.run() stops startup when connection test fails"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+        from itential_mcp.core.exceptions import ConnectionException
+        from itential_mcp.platform.connection_test import CheckStatus
+
+        mock_config = Config(
+            server=ServerConfig(
+                transport="stdio",
+                test_connection_on_startup=True,
+                startup_test_timeout=30,
+                log_level="INFO",
+            ),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        # Mock failed connection test
+        mock_check = MagicMock()
+        mock_check.status = CheckStatus.FAILED
+        mock_check.name = "connectivity"
+        mock_check.message = "Connection refused"
+        mock_check.suggestion = None
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error = "Cannot connect to platform"
+        mock_result.checks = [mock_check]
+
+        mock_service = MagicMock()
+        mock_service.run_all_checks = AsyncMock(return_value=mock_result)
+        mock_service_class.return_value = mock_service
+
+        server_instance = server_module.Server(mock_config)
+
+        # Mock MCP instance
+        mock_mcp = MagicMock()
+        mock_mcp.run_async = AsyncMock()
+        server_instance.mcp = mock_mcp
+
+        # Should raise ConnectionException and not call run_async
+        with pytest.raises(ConnectionException):
+            await server_instance.run()
+
+        # Verify server did NOT continue to run after failed test
+        mock_mcp.run_async.assert_not_called()

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -244,3 +244,113 @@ class TestTerminalIntegration:
 
         # Should complete 100 calls in less than 1 second
         assert (end_time - start_time) < 1.0
+
+
+class TestColors:
+    """Test cases for Colors class."""
+
+    def test_colors_class_exists(self):
+        """Test that Colors class exists."""
+        assert hasattr(terminal, "Colors")
+
+    def test_colors_constants_exist(self):
+        """Test that all color constants exist."""
+        assert hasattr(terminal.Colors, "RED")
+        assert hasattr(terminal.Colors, "GREEN")
+        assert hasattr(terminal.Colors, "YELLOW")
+        assert hasattr(terminal.Colors, "BLUE")
+        assert hasattr(terminal.Colors, "RESET")
+        assert hasattr(terminal.Colors, "BOLD")
+
+    def test_colors_are_strings(self):
+        """Test that all colors are strings."""
+        assert isinstance(terminal.Colors.RED, str)
+        assert isinstance(terminal.Colors.GREEN, str)
+        assert isinstance(terminal.Colors.YELLOW, str)
+        assert isinstance(terminal.Colors.BLUE, str)
+        assert isinstance(terminal.Colors.RESET, str)
+        assert isinstance(terminal.Colors.BOLD, str)
+
+
+class TestPrintFunctions:
+    """Test cases for terminal print functions."""
+
+    def test_print_success_function_exists(self):
+        """Test that print_success function exists."""
+        assert hasattr(terminal, "print_success")
+        assert callable(terminal.print_success)
+
+    def test_print_error_function_exists(self):
+        """Test that print_error function exists."""
+        assert hasattr(terminal, "print_error")
+        assert callable(terminal.print_error)
+
+    def test_print_warning_function_exists(self):
+        """Test that print_warning function exists."""
+        assert hasattr(terminal, "print_warning")
+        assert callable(terminal.print_warning)
+
+    def test_print_info_function_exists(self):
+        """Test that print_info function exists."""
+        assert hasattr(terminal, "print_info")
+        assert callable(terminal.print_info)
+
+    def test_print_success_outputs_message(self, capsys):
+        """Test that print_success outputs the message with color."""
+        terminal.print_success("Test success message")
+
+        captured = capsys.readouterr()
+        assert "Test success message" in captured.out
+        assert terminal.Colors.GREEN in captured.out
+        assert terminal.Colors.RESET in captured.out
+
+    def test_print_error_outputs_message(self, capsys):
+        """Test that print_error outputs the message with color."""
+        terminal.print_error("Test error message")
+
+        captured = capsys.readouterr()
+        assert "Test error message" in captured.out
+        assert terminal.Colors.RED in captured.out
+        assert terminal.Colors.RESET in captured.out
+
+    def test_print_warning_outputs_message(self, capsys):
+        """Test that print_warning outputs the message with color."""
+        terminal.print_warning("Test warning message")
+
+        captured = capsys.readouterr()
+        assert "Test warning message" in captured.out
+        assert terminal.Colors.YELLOW in captured.out
+        assert terminal.Colors.RESET in captured.out
+
+    def test_print_info_outputs_message(self, capsys):
+        """Test that print_info outputs the message with color."""
+        terminal.print_info("Test info message")
+
+        captured = capsys.readouterr()
+        assert "Test info message" in captured.out
+        assert terminal.Colors.BLUE in captured.out
+        assert terminal.Colors.RESET in captured.out
+
+    def test_print_functions_with_empty_string(self, capsys):
+        """Test print functions with empty string."""
+        terminal.print_success("")
+        terminal.print_error("")
+        terminal.print_warning("")
+        terminal.print_info("")
+
+        captured = capsys.readouterr()
+        # Should output color codes even with empty message
+        assert captured.out
+
+    def test_print_functions_with_special_characters(self, capsys):
+        """Test print functions with special characters."""
+        special_message = "Test: \n\t~!@#$%^&*()_+{}[]|\\:;\"'<>?,./`"
+
+        terminal.print_success(special_message)
+        terminal.print_error(special_message)
+        terminal.print_warning(special_message)
+        terminal.print_info(special_message)
+
+        captured = capsys.readouterr()
+        # Should output all instances of the message
+        assert captured.out.count(special_message) == 4


### PR DESCRIPTION
- Add comprehensive tests for config package achieving 100% coverage
- Add missing tests for runtime/commands.py (20% -> 100%)
- Add tests for cli/terminal.py print functions (89% -> 100%)
- Add tests for server/server.py initialization and lifecycle (78% -> 100%)
- Add tests for server/auth.py OAuth provider handling (85% -> 93%)
- Add connection testing on startup test scenarios
- Add server initialization with auth transport compatibility tests
- Add tool registration and binding tests