### PR TITLE
fix: pass input_params as keyword argument in run_service tool

### DIFF
--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -156,7 +156,9 @@ async def run_service(
     if isinstance(input_params, str):
         input_params = jsonutils.loads(input_params)
 
-    res = await client.gateway_manager.run_service(name, cluster, input_params)
+    res = await client.gateway_manager.run_service(
+        name, cluster, input_params=input_params
+    )
 
     if "error" in res:
         raise ValueError(res["error"]["data"])

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -459,7 +459,7 @@ class TestRunService(TestGatewayManagerTools):
 
         # Verify client method was called with correct parameters
         self.mock_client.gateway_manager.run_service.assert_called_once_with(
-            "test-service", "test-cluster", {"param1": "value1"}
+            "test-service", "test-cluster", input_params={"param1": "value1"}
         )
 
         # Verify result type and content
@@ -489,7 +489,7 @@ class TestRunService(TestGatewayManagerTools):
 
         # Verify client method was called with None for input_params
         self.mock_client.gateway_manager.run_service.assert_called_once_with(
-            "no-param-service", "test-cluster", None
+            "no-param-service", "test-cluster", input_params=None
         )
 
         assert isinstance(result, RunServiceResponse)
@@ -513,7 +513,7 @@ class TestRunService(TestGatewayManagerTools):
 
         # Verify client method was called
         self.mock_client.gateway_manager.run_service.assert_called_once_with(
-            "json-service", "json-cluster", {"format": "json"}
+            "json-service", "json-cluster", input_params={"format": "json"}
         )
 
         # Verify result
@@ -574,7 +574,7 @@ class TestRunService(TestGatewayManagerTools):
 
         # Verify client method was still called
         self.mock_client.gateway_manager.run_service.assert_called_once_with(
-            "failing-service", "test-cluster", {"timeout": 30}
+            "failing-service", "test-cluster", input_params={"timeout": 30}
         )
 
     @pytest.mark.asyncio
@@ -632,7 +632,7 @@ class TestRunService(TestGatewayManagerTools):
 
         # Verify client was called with complex parameters
         self.mock_client.gateway_manager.run_service.assert_called_once_with(
-            "complex-service", "production-cluster", complex_params
+            "complex-service", "production-cluster", input_params=complex_params
         )
 
         assert isinstance(result, RunServiceResponse)


### PR DESCRIPTION
- Fix incorrect positional argument usage for input_params parameter
- Service method requires keyword-only argument per function signature