### PR TITLE
docs: rewrite AGENTS.md as concise codebase reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1246 +1,378 @@
-# Itential MCP - Codebase Documentation
+# Itential MCP — Codebase Reference
 
-**Last Updated:** 2026-02-25
-**Version:** 0.12.0
-**Python Requirements:** 3.10 - 3.13
-**Code Base:** 20,727 lines of Python (94 source files)
-**Test Coverage:** 99% (73 test files)
-
-## What This Project Does
-
-Itential MCP is a production-grade Model Context Protocol (MCP) server that bridges AI agents (Claude, GPT, etc.) with the Itential Platform - a network automation and orchestration system. It exposes 56+ tools across 10 functional categories (health, device config, workflow execution, lifecycle management, etc.) allowing AI agents to manage network infrastructure, execute workflows, monitor systems, and perform advanced operations.
-
-**Key Value Proposition:** Instead of AI agents being limited to text generation, this server gives them operational capabilities - they can configure devices, run compliance checks, execute workflows, manage resources, and monitor platform health through a standardized MCP interface.
-
-## Architecture Deep Dive
-
-### 1. Server Initialization Flow
-
-```
-app.py:run()
-  → runtime/parser.py:parse_args()
-  → runtime/handlers.py:get_command_handler()
-  → server/server.py:run()
-    → Server.__init__(config)
-    → Server.__init_server__()    # Create FastMCP instance
-    → Server.__init_tools__()     # Discover and register tools
-    → Server.__init_bindings__()  # Register dynamic tool bindings
-    → Server.__init_routes__()    # Register health endpoints
-    → Server.run()                # Start transport (stdio/SSE/HTTP)
-```
-
-**Lifespan Management:**
-- `lifespan()` async context manager creates PlatformClient instance
-- Client is injected into FastMCP context for all tool requests
-- Keepalive task prevents session timeouts (configurable interval)
-- Proper cleanup on shutdown (cancel keepalive, close connections)
-
-### 2. Platform Client Architecture
-
-**src/itential_mcp/platform/client.py:PlatformClient**
-
-Key Design Decisions:
-- Wraps `ipsdk.AsyncPlatform` for Itential API communication
-- Dynamic service plugin loading from `platform/services/` directory
-- Each service is a class with `name` attribute (e.g., "health", "adapters")
-- Services are registered as PlatformClient attributes (e.g., `client.health`)
-- Async context manager for proper resource cleanup
-- Timeout protection on all HTTP requests (default 30s, configurable)
-
-**Service Plugin Pattern:**
-```python
-# platform/services/health.py
-class Service:
-    name = "health"
-
-    def __init__(self, client):
-        self.client = client
-
-    async def get_status_health(self):
-        return await self.client.get("/health")
-```
-
-Services are auto-discovered and loaded at client initialization. This pattern allows easy extension without modifying core client code.
-
-### 3. Configuration System (Recently Refactored - v0.11.0)
-
-**src/itential_mcp/config/** - Modular package with clean separation:
-
-**Design Philosophy:**
-- Immutable dataclasses (Pydantic) for type safety
-- Clear separation: models, loaders, validators, converters
-- Support for multiple config sources with precedence
-- Environment variables, CLI args, config files, defaults
-
-**Precedence Order (highest to lowest):**
-1. Environment variables (`ITENTIAL_MCP_SERVER_*`, `ITENTIAL_MCP_PLATFORM_*`)
-2. Command-line arguments
-3. Configuration file (--config)
-4. Default values (defaults.py)
-
-**Key Models:**
-- `Config` - Root config with nested sections
-- `ServerConfig` - Transport, host, port, logging, tool filtering
-- `PlatformConfig` - Platform connection settings (host, auth, TLS)
-- `AuthConfig` - Authentication configuration (JWT, OAuth)
-- `Tool`, `EndpointTool`, `ServiceTool` - Dynamic tool definitions
-
-**Cached Loading:**
-```python
-from itential_mcp import config
-
-cfg = config.get()  # Loads once, cached with @lru_cache
-cfg.server.transport  # Access nested attributes
-cfg.platform.host
-cfg.auth.type
-```
-
-### 4. Tool System
-
-**Static Tools (src/itential_mcp/tools/)**
-
-Each tool file exports async functions with:
-- `Context` parameter (FastMCP injection)
-- `__tags__` module attribute for filtering
-- Pydantic models for return types (type-safe responses)
-- Comprehensive docstrings (Args, Returns, Raises)
-
-**Tool Discovery:**
-```python
-# utilities/tool.py:itertools()
-for tool_file in tools_directory.glob("*.py"):
-    module = import_module(tool_file)
-    for func in get_async_functions(module):
-        yield func, get_tags(module)
-```
-
-Tools are automatically registered with FastMCP on server startup.
-
-**Dynamic Tool Bindings (src/itential_mcp/bindings/)**
-
-Powerful feature that creates MCP tools from:
-1. **Workflow Endpoints** - Expose Itential workflows as callable tools
-2. **Gateway Services** - Wrap external services (Ansible, Terraform, Python scripts)
-
-Configuration via environment variables:
-```bash
-ITENTIAL_MCP_TOOL_MY_WORKFLOW='{"type":"endpoint","name":"trigger_name","automation":"workflow_name"}'
-ITENTIAL_MCP_TOOL_RUN_ANSIBLE='{"type":"service","name":"ansible_service","cluster":"default"}'
-```
-
-**Binding Flow:**
-```
-bindings/__init__.py:iterbindings()
-  → For each tool in config.tools:
-    → bind_to_tool(tool, platform_client)
-      → Import binding module (endpoint.py or service.py)
-      → Call module.new(tool, client)
-      → Return (bound_function, registration_kwargs)
-  → FastMCP registers bound_function as MCP tool
-```
-
-This enables users to expose custom workflows without writing Python code.
-
-### 5. Middleware Stack
-
-FastMCP middleware (order matters - first added is outermost):
-
-1. **ErrorHandlingMiddleware** - Catch and format exceptions
-2. **DetailedTimingMiddleware** - Performance metrics per tool call
-3. **LoggingMiddleware** - Request/response logging with payload truncation
-4. **BindingsMiddleware** - O(1) tool name lookup (recent optimization)
-5. **SerializationMiddleware** - Response serialization with toon support
-
-**BindingsMiddleware Optimization:**
-Previously O(n) - iterated all bindings on every request. Now O(1) - uses dict lookup by tool name. Significant performance improvement for deployments with many dynamic tools.
-
-### 6. Authentication & Security
-
-**Supported Auth Methods:**
-- Basic Auth (username/password)
-- OAuth 2.0 (multiple providers: Auth0, Okta, Azure AD, custom)
-- JWT tokens (stateless, bearer token)
-- No auth (development only)
-
-**Transport Compatibility:**
-- stdio: No auth (local process communication)
-- SSE/HTTP: All auth methods supported
-
-**Security Features:**
-- TLS/HTTPS support with certificate configuration
-- Certificate verification (disable only in dev)
-- JWT token validation with issuer verification
-- OAuth token introspection
-- Sensitive data filtering in logs (passwords, tokens, secrets)
-- Request timeout protection (prevents hung requests)
-- Connection keepalive with session management
-
-**Security Warnings:**
-The logging system actively warns about insecure configurations:
-- TLS disabled
-- Certificate verification disabled
-- Sensitive data in environment variables
-
-### 7. Exception Hierarchy
-
-**src/itential_mcp/core/exceptions.py** - Comprehensive and well-designed (19 exception classes):
-
-```
-ItentialMcpException (base, http_status=500)
-├── ClientException (4xx)
-│   ├── ValidationException (400)
-│   ├── AuthenticationException (401)
-│   ├── AuthorizationException (403)
-│   ├── NotFoundError (404)
-│   ├── ConflictException (409)
-│   │   ├── AlreadyExistsError
-│   │   └── InvalidStateError
-│   └── RateLimitException (429)
-├── ServerException (5xx)
-│   ├── ConfigurationException (500)
-│   ├── ConnectionException (502)
-│   ├── TimeoutExceededError (504)
-│   └── ServiceUnavailableException (503)
-└── BusinessLogicException (422)
-    ├── WorkflowException
-    ├── DeviceException
-    └── ComplianceException
-```
-
-**Features:**
-- HTTP status code mapping for REST API contexts
-- Optional details dict for structured error info
-- Utility functions: `get_exception_for_http_status()`, `create_exception_from_response()`
-- Exception categories: `CLIENT_EXCEPTIONS`, `SERVER_EXCEPTIONS`, `BUSINESS_EXCEPTIONS`
-- Type-safe exception checking: `is_client_error()`, `is_server_error()`
-
-This is excellent design - proper exception hierarchy with HTTP semantics.
-
-## Code Quality Metrics
-
-**Quantitative Analysis (2026-02-25):**
-
-| Metric | Value | Assessment |
-|--------|-------|------------|
-| Total Lines of Code | 20,727 | Well-sized for scope |
-| Source Files | 94 | Good modularization |
-| Test Files | 73 (78% coverage) | Excellent |
-| Async Functions | 176 | Properly async throughout |
-| Parallel Async Calls | 4 instances | Room for more optimization |
-| Exception Classes | 19 | Comprehensive hierarchy |
-| Technical Debt Markers | 1 XXX, 0 TODO, 0 FIXME, 0 HACK | Exceptional |
-| Bare Except Clauses | 0 | Excellent error handling |
-| Pass Statements | 13 | Minimal placeholder code |
-| Try Blocks | 36 | Appropriate error handling |
-| Cached Functions | 2 | Using caching where it matters |
-| Type Hint Coverage | ~100% | Modern annotations throughout |
-| Largest File | 1,102 lines (models/health.py) | Acceptable for model definitions |
-
-**Code Cleanliness:**
-- Zero blocking I/O in async code (no `time.sleep`, no `requests.*`)
-- Zero old-style type hints (typing.Dict, typing.List, typing.Optional)
-- Consistent f-string usage (only exception: datetime.strftime - proper usage)
-- No empty Python files
-- All imports are explicit (no wildcard imports)
-
-## What's Well Done
-
-### Code Quality & Architecture
-
-1. **Test Coverage** - 99% with comprehensive unit tests
-   - 73 test files mirroring source structure (78% of source files)
-   - Extensive mocking and async testing
-   - Edge case coverage (error paths, timeouts, validation)
-   - Integration tests for CLI commands
-   - All tool modules have dedicated test coverage
-
-2. **Type Safety** - Modern Python type hints throughout
-   - `from __future__ import annotations` for forward references
-   - Pydantic dataclasses for validation
-   - Type hints on all function signatures
-   - Proper use of `Literal`, `Annotated`, `TypedDict`
-
-3. **Documentation** - Comprehensive Google-style docstrings
-   - Args, Returns, Raises consistently documented
-   - 12+ markdown docs for users (integration, auth, TLS, etc.)
-   - Example prompts for Claude and GPT integration
-   - Clear separation of user docs vs. developer docs
-
-4. **Configuration System** - Recently refactored (v0.11.0), bug fixes in v0.11.1
-   - Clean modular design (models, loaders, validators)
-   - Immutable dataclasses prevent accidental mutations
-   - Clear precedence rules (env > CLI > file > defaults)
-   - Cached loading with `@lru_cache`
-   - Fixed AuthConfig attribute access (v0.11.1)
-
-5. **Error Handling** - Proper exception hierarchy
-   - HTTP status codes mapped to exception types
-   - Structured error details (dict)
-   - Category-based filtering
-   - Clear error messages
-
-6. **Security Awareness** - Production-ready security features
-   - TLS/HTTPS support
-   - Multiple auth methods (OAuth, JWT, Basic)
-   - Sensitive data filtering in logs
-   - Security warnings for misconfigurations
-   - Timeout protection on all HTTP requests
-
-7. **Performance Optimizations**
-   - O(1) bindings middleware lookup (v0.11.0)
-   - Parallel async API calls (`asyncio.gather`)
-   - Connection pooling via ipsdk
-   - Keepalive to prevent reconnections
-   - Generator-based tool discovery
-
-8. **Developer Experience**
-   - Comprehensive Makefile with clear targets
-   - Tox support for multi-version testing (3.10-3.13)
-   - Pre-merge pipeline automation
-   - Ruff for fast linting and formatting
-   - Copyright header checking script
-
-9. **Production Readiness**
-   - Kubernetes health endpoints (/status/healthz, /readyz, /livez)
-   - Container support (Dockerfile → Containerfile)
-   - Multi-architecture builds (amd64, arm64)
-   - Proper logging with levels
-   - Graceful shutdown handling
-
-10. **Code Organization**
-    - Clear package boundaries
-    - Single responsibility principle
-    - Minimal coupling between modules
-    - Consistent naming conventions
-    - Logical grouping (core, platform, runtime, tools)
-
-### Specific Highlights
-
-**server/server.py:lifespan()** - Excellent async context manager pattern:
-```python
-@asynccontextmanager
-async def lifespan(mcp: FastMCP) -> AsyncGenerator[dict[str | Any], None]:
-    async with PlatformClient() as client_instance:
-        keepalive_task = None
-        try:
-            if keepalive_interval > 0:
-                keepalive_task = start_keepalive(client_instance, keepalive_interval)
-            yield {"client": client_instance}
-        finally:
-            if keepalive_task and not keepalive_task.done():
-                keepalive_task.cancel()
-                try:
-                    await keepalive_task
-                except asyncio.CancelledError:
-                    pass
-```
-This ensures proper resource cleanup even on errors.
-
-**platform/client.py:_init_plugins()** - Robust service plugin loading:
-- Graceful handling of import errors
-- Validation of service name attributes
-- Debug logging for troubleshooting
-- Continues on single plugin failure (doesn't crash entire client)
-
-**middleware/bindings.py** - O(1) optimization is excellent:
-```python
-# Old: O(n) - iterate all bindings
-for binding in all_bindings:
-    if binding.name == tool_name:
-        return binding
-
-# New: O(1) - dict lookup
-return bindings_dict.get(tool_name)
-```
-
-## Patterns & Conventions
-
-### Python Style
-
-**Follows Python best practices consistently:**
-
-1. **Type Hints** - Modern annotation style
-   ```python
-   # Good - modern style
-   def func(data: dict[str, Any]) -> list[str]:
-       ...
-
-   # Avoid - old style
-   from typing import Dict, List
-   def func(data: Dict[str, Any]) -> List[str]:
-       ...
-   ```
-
-2. **String Formatting** - F-strings everywhere
-   ```python
-   # Used consistently
-   f"Error: {error_msg} (code: {status_code})"
-
-   # Not used: .format() or % formatting
-   ```
-
-3. **Async/Await** - Proper async patterns
-   - Async context managers (`async with`)
-   - Parallel execution with `asyncio.gather()`
-   - Timeout protection with `asyncio.wait_for()`
-   - Proper cancellation handling
-
-4. **Error Handling** - EAFP (Easier to Ask Forgiveness than Permission)
-   ```python
-   # Used: Try and handle exceptions
-   try:
-       result = await client.get("/path")
-   except ConnectionException:
-       # Handle error
-
-   # Not used: Check before access
-   if client.is_connected():
-       result = await client.get("/path")
-   ```
-
-5. **Context Managers** - Resource cleanup
-   - PlatformClient as async context manager
-   - Proper cleanup in finally blocks
-   - No resource leaks
-
-6. **Immutability** - Where appropriate
-   - Pydantic dataclasses with `frozen=True`
-   - Config objects are immutable
-   - Prevents accidental state mutations
-
-7. **Function Parameters** - Explicit keyword arguments over mappings
-   - Always prefer explicit keyword arguments over `Mapping` parameters
-   - Provides better type safety, IDE autocomplete, and API clarity
-   - Build request bodies programmatically from explicit parameters
-   - Especially important when converting OpenAPI specifications to Python
-
-   ```python
-   # Good - explicit keyword arguments
-   async def create_resource(
-       self,
-       name: str,
-       description: str,
-       enabled: bool,
-       tags: list[str] | None = None,
-       metadata: dict[str, Any] | None = None,
-   ) -> dict[str, Any]:
-       body = {
-           "name": name,
-           "description": description,
-           "enabled": enabled,
-       }
-       if tags is not None:
-           body["tags"] = tags
-       if metadata is not None:
-           body["metadata"] = metadata
-
-       return await self.client.post("/resources", json=body)
-
-   # Avoid - mapping parameter
-   async def create_resource(
-       self, resource_data: Mapping[str, Any]
-   ) -> dict[str, Any]:
-       return await self.client.post("/resources", json=resource_data)
-
-   # Also avoid - **kwargs without explicit parameters
-   async def create_resource(self, **kwargs: Any) -> dict[str, Any]:
-       return await self.client.post("/resources", json=kwargs)
-   ```
-
-   **Benefits:**
-   - Type checkers can validate parameter types at call sites
-   - IDEs provide accurate autocomplete with parameter names and types
-   - Function signature documents expected parameters without reading docs
-   - Required vs optional parameters are explicit
-   - Easier to refactor - renaming parameters updates all call sites
-   - Better runtime validation with type hints
-
-   **OpenAPI Conversion:**
-   When converting OpenAPI specs to Python service methods:
-   - Map each schema property to an explicit function parameter
-   - Use `| None` for optional properties (not `Optional`)
-   - Set default to `None` for optional parameters
-   - Build request body dict conditionally (only include non-None values)
-   - Preserve property names from OpenAPI schema in request body
-
-   **Keyword-Only Arguments:**
-   Always use the `*` marker to require keyword-only arguments for optional parameters.
-   This prevents accidental positional argument bugs and makes code more explicit.
-
-   ```python
-   # Good - keyword-only optional arguments
-   async def create_resource(
-       self,
-       name: str,
-       description: str,
-       enabled: bool,
-       *,  # Everything after this must be passed as keyword argument
-       tags: list[str] | None = None,
-       metadata: dict[str, Any] | None = None,
-   ) -> dict[str, Any]:
-       ...
-
-   # Good - all optional parameters are keyword-only
-   async def update_resource(
-       self,
-       resource_id: str,
-       *,  # All update fields are keyword-only
-       name: str | None = None,
-       description: str | None = None,
-       enabled: bool | None = None,
-   ) -> dict[str, Any]:
-       ...
-
-   # Avoid - optional parameters without keyword-only marker
-   async def create_resource(
-       self,
-       name: str,
-       description: str,
-       enabled: bool,
-       tags: list[str] | None = None,  # Can be passed positionally (error-prone)
-       metadata: dict[str, Any] | None = None,
-   ) -> dict[str, Any]:
-       ...
-   ```
-
-   **Benefits of keyword-only arguments:**
-   - Prevents accidental argument ordering mistakes
-   - Makes function calls more readable and self-documenting
-   - Easier to add new optional parameters without breaking existing code
-   - Forces callers to be explicit about what they're setting
-   - Consistent with Python standard library best practices
-
-### Code Organization Patterns
-
-1. **Package Structure** - Clear boundaries
-   ```
-   core/        - Fundamental utilities (logging, exceptions, env)
-   platform/    - API client and service wrappers
-   runtime/     - Application lifecycle (CLI, commands, runner)
-   server/      - MCP server implementation
-   tools/       - MCP tool implementations
-   models/      - Data models (Pydantic)
-   bindings/    - Dynamic tool bindings
-   middleware/  - FastMCP middleware
-   config/      - Configuration system
-   utilities/   - Shared helpers
-   ```
-
-2. **Module Organization** - Consistent ordering
-   ```python
-   # 1. Copyright header
-   # 2. Module docstring
-   # 3. Imports (stdlib, third-party, local)
-   # 4. Constants
-   # 5. Private functions (_func)
-   # 6. Public functions
-   # 7. Classes
-   ```
-
-3. **Import Style**
-   ```python
-   # Standard library
-   import asyncio
-   import pathlib
-
-   # Third-party
-   from fastmcp import Context
-   from pydantic import Field
-
-   # Local (relative imports within package)
-   from .. import config
-   from ..core import logging
-   ```
-
-4. **Naming Conventions**
-   - Modules: lowercase_with_underscores
-   - Classes: PascalCase
-   - Functions: lowercase_with_underscores
-   - Constants: UPPERCASE_WITH_UNDERSCORES
-   - Private: _leading_underscore
-   - Dunder: __double_leading__ (for class internals)
-
-### Testing Patterns
-
-1. **Test Organization** - Mirrors source structure
-   ```
-   src/itential_mcp/platform/client.py
-   tests/test_client.py
-   ```
-
-2. **Test Naming** - Descriptive and consistent
-   ```python
-   def test_function_name_when_condition_then_expected_result():
-       ...
-
-   # Examples:
-   def test_get_health_when_platform_available_returns_health_data():
-   def test_bind_to_tool_when_invalid_type_raises_import_error():
-   ```
-
-3. **Test Structure** - AAA (Arrange, Act, Assert)
-   ```python
-   async def test_example():
-       # Arrange
-       mock_client = Mock()
-       mock_response = Mock(json=lambda: {"status": "ok"})
-       mock_client.get.return_value = mock_response
-
-       # Act
-       result = await get_health(mock_client)
-
-       # Assert
-       assert result.status == "ok"
-       mock_client.get.assert_called_once()
-   ```
-
-4. **Mocking Strategy**
-   - Mock external dependencies (HTTP calls, file I/O)
-   - Don't mock the code under test
-   - Use `AsyncMock` for async functions
-   - Verify mock calls with assertions
-
-5. **Fixture Usage**
-   - Minimal fixtures (only when needed)
-   - Prefer explicit setup in tests for clarity
-   - Use fixtures for complex shared setup
-
-### Documentation Patterns
-
-1. **Docstrings** - Google style, comprehensive
-   ```python
-   def function(arg1: str, arg2: int | None = None) -> dict:
-       """Short description on first line.
-
-       Longer description with more details about what the function
-       does, how it works, and any important notes.
-
-       Args:
-           arg1: Description of arg1.
-           arg2: Description of arg2. Defaults to None.
-
-       Returns:
-           dict: Description of return value with structure details.
-
-       Raises:
-           ValueError: When input validation fails.
-           ConnectionException: When API communication fails.
-       """
-   ```
-
-2. **Module Docstrings** - Purpose and contents
-   ```python
-   """Module description.
-
-   Detailed explanation of what this module provides and how it
-   fits into the overall architecture.
-   """
-   ```
-
-3. **Inline Comments** - Explain "why" not "what"
-   ```python
-   # Good: Explains reasoning
-   # Use timeout to prevent hung requests blocking the server
-   result = await asyncio.wait_for(request, timeout=30)
-
-   # Avoid: Restates code
-   # Call asyncio.wait_for with timeout parameter
-   result = await asyncio.wait_for(request, timeout=30)
-   ```
-
-### Configuration Patterns
-
-1. **Environment Variables** - Consistent naming
-   ```bash
-   ITENTIAL_MCP_SERVER_*    # Server configuration
-   ITENTIAL_MCP_PLATFORM_*  # Platform connection
-   ITENTIAL_MCP_TOOL_*      # Dynamic tool definitions
-   ```
-
-2. **Defaults** - Centralized in defaults.py
-   ```python
-   # All defaults in one place
-   ITENTIAL_MCP_SERVER_TRANSPORT = "stdio"
-   ITENTIAL_MCP_SERVER_HOST = "127.0.0.1"
-   ITENTIAL_MCP_SERVER_PORT = 8000
-   ```
-
-3. **Validation** - Separate validators module
-   ```python
-   # config/validators.py
-   def validate_port(port: int) -> int:
-       if not 1 <= port <= 65535:
-           raise ValueError(f"Invalid port: {port}")
-       return port
-   ```
-
-## Development Workflow
-
-### Daily Development Commands
-
-```bash
-# Setup
-make build              # Create venv, install dependencies
-
-# Development cycle
-make format             # Format code with ruff
-make check              # Lint code
-make test               # Run tests
-make coverage           # Generate coverage report
-
-# Before committing
-make premerge           # Full pipeline: clean, format, check, test
-
-# Security
-make security           # Run bandit security scanner
-
-# Headers
-make check-headers      # Verify copyright headers
-make fix-headers        # Add missing headers
-```
-
-### Testing Workflow
-
-```bash
-# Quick test run
-uv run pytest tests -v -s
-
-# With coverage
-uv run pytest --cov=itential_mcp --cov-report=term --cov-report=html tests/
-
-# Specific test file
-uv run pytest tests/test_client.py -v
-
-# Specific test
-uv run pytest tests/test_client.py::test_function_name -v
-
-# Multi-version testing
-make tox                # Test against Python 3.10, 3.11, 3.12, 3.13
-make tox-py310          # Test specific version
-```
-
-### Running the Server
-
-```bash
-# Development (stdio)
-uv run itential-mcp run
-
-# Development (SSE)
-uv run itential-mcp run --transport sse --host 0.0.0.0 --port 8000
-
-# With custom config
-uv run itential-mcp run --config config.conf
-
-# Debug logging
-ITENTIAL_MCP_SERVER_LOG_LEVEL=DEBUG uv run itential-mcp run
-
-# Container
-make container
-docker run -p 8000:8000 \
-  -e ITENTIAL_MCP_SERVER_TRANSPORT=sse \
-  -e ITENTIAL_MCP_PLATFORM_HOST=platform.example.com \
-  itential-mcp:devel
-```
-
-## Adding New Features
-
-### Adding a New Tool
-
-1. **Create tool file** - `src/itential_mcp/tools/my_feature.py`
-
-```python
-from typing import Annotated
-from pydantic import Field
-from fastmcp import Context
-from itential_mcp.models.my_feature import MyFeatureResponse
-
-__tags__ = ("my_category",)
-
-async def my_feature_tool(
-    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
-    param1: Annotated[str, Field(description="Parameter description")],
-) -> MyFeatureResponse:
-    """Short description.
-
-    Longer description with details about what this tool does,
-    when to use it, and any important notes.
-
-    Args:
-        ctx: The FastMCP Context object.
-        param1: Description of param1.
-
-    Returns:
-        MyFeatureResponse: Description of return value.
-
-    Raises:
-        ValidationException: When param1 is invalid.
-        ConnectionException: When platform communication fails.
-    """
-    await ctx.info(f"Executing my_feature_tool with param1={param1}")
-
-    client = ctx.request_context.lifespan_context.get("client")
-
-    res = await client.get(f"/api/my-feature/{param1}")
-
-    return MyFeatureResponse(**res.json())
-```
-
-2. **Create data model** - `src/itential_mcp/models/my_feature.py`
-
-```python
-from pydantic import BaseModel, Field
-
-class MyFeatureResponse(BaseModel):
-    """Response from my_feature tool.
-
-    Attributes:
-        status: Current status.
-        data: Feature data.
-    """
-    status: str = Field(description="Current status")
-    data: dict = Field(description="Feature data")
-```
-
-3. **Add service wrapper** (if needed) - `src/itential_mcp/platform/services/my_feature.py`
-
-```python
-class Service:
-    name = "my_feature"
-
-    def __init__(self, client):
-        self.client = client
-
-    async def get_feature(self, feature_id: str):
-        """Get feature by ID.
-
-        Args:
-            feature_id: The feature identifier.
-
-        Returns:
-            dict: Feature data from platform.
-
-        Raises:
-            NotFoundError: When feature doesn't exist.
-        """
-        res = await self.client.get(f"/api/my-feature/{feature_id}")
-        return res.json()
-```
-
-4. **Write tests** - `tests/test_tools_my_feature.py`
-
-```python
-import pytest
-from unittest.mock import Mock, AsyncMock
-from itential_mcp.tools.my_feature import my_feature_tool
-
-@pytest.mark.asyncio
-async def test_my_feature_tool_returns_expected_data():
-    # Arrange
-    mock_ctx = Mock()
-    mock_ctx.info = AsyncMock()
-    mock_client = Mock()
-    mock_response = Mock(json=lambda: {"status": "ok", "data": {}})
-    mock_client.get = AsyncMock(return_value=mock_response)
-    mock_ctx.request_context.lifespan_context.get = Mock(return_value=mock_client)
-
-    # Act
-    result = await my_feature_tool(mock_ctx, param1="test")
-
-    # Assert
-    assert result.status == "ok"
-    mock_client.get.assert_called_once_with("/api/my-feature/test")
-```
-
-5. **Run premerge** - `make premerge`
-
-The tool is automatically discovered and registered on server startup.
-
-### Adding a New Service
-
-Services are auto-discovered from `platform/services/`. Follow the pattern:
-
-```python
-# src/itential_mcp/platform/services/my_service.py
-
-class Service:
-    """My service description.
-
-    Provides API wrappers for my service endpoints.
-    """
-
-    name = "my_service"  # Attribute name on PlatformClient
-
-    def __init__(self, client):
-        """Initialize service with platform client.
-
-        Args:
-            client: The AsyncPlatform client instance.
-        """
-        self.client = client
-
-    async def get_resource(self, resource_id: str) -> dict:
-        """Get resource by ID.
-
-        Args:
-            resource_id: Resource identifier.
-
-        Returns:
-            dict: Resource data.
-
-        Raises:
-            NotFoundError: When resource doesn't exist.
-        """
-        res = await self.client.get(f"/my-service/resources/{resource_id}")
-        return res.json()
-```
-
-Service is automatically loaded and available as `client.my_service`.
-
-### Adding a Dynamic Binding
-
-Create environment variable or config file entry:
-
-```bash
-# Workflow endpoint binding
-ITENTIAL_MCP_TOOL_DEPLOY_CONFIG='{"type":"endpoint","name":"deploy_trigger","automation":"Deploy Configuration","description":"Deploy configuration to devices"}'
-
-# Gateway service binding
-ITENTIAL_MCP_TOOL_RUN_ANSIBLE='{"type":"service","name":"ansible_playbook","cluster":"default","description":"Run Ansible playbook"}'
-```
-
-Or in config file:
-
-```toml
-[[tools]]
-type = "endpoint"
-name = "deploy_trigger"
-tool_name = "deploy_config"
-automation = "Deploy Configuration"
-description = "Deploy configuration to devices"
-tags = "network,deployment"
-
-[[tools]]
-type = "service"
-name = "ansible_playbook"
-tool_name = "run_ansible"
-cluster = "default"
-description = "Run Ansible playbook"
-tags = "automation,ansible"
-```
-
-## Common Pitfalls & How to Avoid
-
-1. **Forgetting `PYTHONDONTWRITEBYTECODE=1`**
-   - Bytecode can cause stale import issues
-   - Always set when running Python commands
-   - Makefile targets do this automatically
-
-2. **Not using async context managers**
-   ```python
-   # Good
-   async with PlatformClient() as client:
-       result = await client.get("/path")
-
-   # Bad - connection leak
-   client = PlatformClient()
-   result = await client.get("/path")
-   ```
-
-3. **Missing tool return type annotation**
-   ```python
-   # Good - FastMCP generates proper schema
-   async def my_tool(ctx: Context) -> MyModel:
-       ...
-
-   # Bad - No schema information for MCP clients
-   async def my_tool(ctx: Context):
-       ...
-   ```
-
-4. **Not handling exceptions in tools**
-   ```python
-   # Good - Let specific exceptions propagate
-   async def my_tool(ctx: Context) -> dict:
-       client = ctx.request_context.lifespan_context.get("client")
-       res = await client.get("/path")  # May raise ConnectionException
-       return res.json()
-
-   # Bad - Swallow all exceptions
-   async def my_tool(ctx: Context) -> dict:
-       try:
-           client = ctx.request_context.lifespan_context.get("client")
-           res = await client.get("/path")
-           return res.json()
-       except Exception:
-           return {}  # Error silently ignored
-   ```
-
-5. **Modifying config after load**
-   ```python
-   # Bad - Config is frozen (immutable)
-   cfg = config.get()
-   cfg.server.port = 9000  # Raises FrozenInstanceError
-
-   # Good - Set before loading
-   os.environ["ITENTIAL_MCP_SERVER_PORT"] = "9000"
-   cfg = config.get()
-   ```
-
-## Performance Considerations
-
-1. **Parallel API Calls** - Use `asyncio.gather()` when possible
-   ```python
-   # Sequential (slow)
-   status = await client.health.get_status()
-   system = await client.health.get_system()
-
-   # Parallel (fast)
-   status, system = await asyncio.gather(
-       client.health.get_status(),
-       client.health.get_system(),
-   )
-   ```
-
-2. **Connection Reuse** - PlatformClient is shared across requests
-   - Single client instance in lifespan context
-   - Connection pooling handled by ipsdk
-   - Keepalive prevents connection timeouts
-
-3. **Tool Discovery** - Uses generators for efficiency
-   ```python
-   # Good - yields as it finds
-   for tool, tags in itertools(path):
-       yield tool, tags
-
-   # Bad - loads all into memory first
-   tools = list(find_all_tools(path))
-   for tool in tools:
-       yield tool
-   ```
-
-4. **Config Caching** - `@lru_cache` on config.get()
-   - Config loaded once on first call
-   - Subsequent calls return cached instance
-   - Restart required for config changes
-
-## Quick Reference
-
-### Environment Variables
-
-```bash
-# Server
-ITENTIAL_MCP_SERVER_TRANSPORT=stdio|sse|http
-ITENTIAL_MCP_SERVER_HOST=0.0.0.0
-ITENTIAL_MCP_SERVER_PORT=8000
-ITENTIAL_MCP_SERVER_LOG_LEVEL=INFO|DEBUG|ERROR|NONE
-ITENTIAL_MCP_SERVER_INCLUDE_TAGS=tag1,tag2
-ITENTIAL_MCP_SERVER_EXCLUDE_TAGS=experimental,beta
-
-# Platform
-ITENTIAL_MCP_PLATFORM_HOST=platform.example.com
-ITENTIAL_MCP_PLATFORM_PORT=3000
-ITENTIAL_MCP_PLATFORM_USER=admin
-ITENTIAL_MCP_PLATFORM_PASSWORD=secret
-ITENTIAL_MCP_PLATFORM_DISABLE_TLS=false
-ITENTIAL_MCP_PLATFORM_DISABLE_VERIFY=false
-ITENTIAL_MCP_PLATFORM_TIMEOUT=30
-
-# Auth (OAuth)
-ITENTIAL_MCP_AUTH_TYPE=oauth
-ITENTIAL_MCP_AUTH_ISSUER=https://auth.example.com
-ITENTIAL_MCP_AUTH_AUDIENCE=https://api.example.com
-
-# Dynamic Tools
-ITENTIAL_MCP_TOOL_<NAME>='{"type":"endpoint","name":"...","automation":"..."}'
-```
-
-### Makefile Targets
-
-```bash
-make help       # Show all targets
-make build      # Setup development environment
-make test       # Run test suite
-make coverage   # Generate coverage report
-make check      # Lint code
-make format     # Format code
-make fix        # Auto-fix issues
-make security   # Security scan
-make premerge   # Full pipeline
-make clean      # Remove artifacts
-make container  # Build container
-```
-
-### CLI Commands
-
-```bash
-itential-mcp --help                 # Show help
-itential-mcp run                    # Start server
-itential-mcp version                # Show version
-itential-mcp tools                  # List tools
-itential-mcp tags                   # List tags
-itential-mcp call <tool> [--params] # Call tool
-```
-
-### Key Files
-
-```bash
-src/itential_mcp/app.py              # Application entry point
-src/itential_mcp/server/server.py    # MCP server implementation
-src/itential_mcp/platform/client.py  # Platform API client
-src/itential_mcp/config/__init__.py  # Configuration loader
-src/itential_mcp/core/exceptions.py  # Exception hierarchy
-pyproject.toml                       # Project metadata
-Makefile                             # Development commands
-CHANGELOG.md                         # Version history
-```
-
-## Getting Help
-
-- **Documentation:** `docs/` directory (15 comprehensive guides)
-- **Troubleshooting:** `docs/troubleshooting.md` - Diagnostic procedures and health checks (NEW in v0.11.1+)
-- **Issues:** GitHub Issues for bug reports and feature requests
-- **Tests:** `tests/` directory mirrors source structure (73 test files)
-- **Examples:** `docs/mcp.conf.example`, example prompts for Claude and GPT integration
-
-## Summary
-
-This is a **high-quality, production-ready codebase** with:
-- Excellent test coverage (99%, 73 test files covering 94 source files)
-- Comprehensive documentation (15 guides + API docs)
-- Modern Python practices (type hints, async/await, Pydantic)
-- Clean architecture (clear separation of concerns)
-- Security awareness (multiple auth methods, TLS, input validation)
-- Performance optimizations (O(1) lookups, connection pooling, async parallelism)
-- Minimal technical debt (only 1 XXX comment in 20,727 lines)
-- No anti-patterns: zero bare except clauses, no blocking I/O in async code
-
-**Main strengths:**
-- Well-organized package structure with clear boundaries
-- Type-safe with Pydantic models (100% of tools return Pydantic models)
-- Comprehensive exception hierarchy (19 exception classes with HTTP semantics)
-- Good separation of concerns (core, platform, runtime, server, tools)
-- Extensive user documentation with troubleshooting guide
-
-**Recent improvements (v0.12.0):**
-- Added connection test command for platform connectivity validation
-- Added comprehensive troubleshooting guide
-- Added additional gateway_manager services
-- Improved test coverage to 99%
-- Improved platform services code quality and test coverage
-- Fixed input_params handling in run_service tool
-- Fixed JSON deserialization with plain text fallback
-- Fixed toon package import compatibility
-- Fixed HTTP method enum compatibility with ipsdk
-
-**Areas to watch:**
-- No retry logic for transient failures (consider exponential backoff)
-- Connection pooling delegated to ipsdk (limited visibility)
-- Limited logging configuration flexibility (no per-module levels)
-- Service plugin system could be more explicit (implicit contract)
-- core/errors.py is unused and should be deprecated
-
-**For immediate productivity:**
-1. Read README.md for user perspective
-2. Review `src/itential_mcp/tools/` for tool examples
-3. Check `docs/troubleshooting.md` for diagnostic procedures
-4. Use `make premerge` before committing (formats, lints, tests)
-5. Follow existing patterns for consistency (see Patterns & Conventions section)
+**Version:** 0.12.1 | **Python:** 3.10–3.13 | **Updated:** 2026-03-08
 
 ---
 
-## Audit History
+## Purpose & Architecture
 
-### 2026-02-25 Release 0.12.0 Update
+Itential MCP is a production-grade Model Context Protocol (MCP) server that bridges AI agents with the Itential Platform — a network automation and orchestration system. It exposes 56+ tools across 10 functional categories (health, device config, workflow execution, lifecycle management, adapters, applications, compliance, projects, gateway, operations), allowing AI agents to configure devices, execute workflows, run compliance checks, and monitor platform health through a standardized MCP interface.
 
-**Auditor:** Release preparation for version 0.12.0
-**Changes:**
-- Updated version from 0.11.1 to 0.12.0
-- Updated last updated date from 2026-01-28 to 2026-02-25
-- Updated line count: 18,532 → 20,727 lines (11.8% increase)
-- Updated source file count: 92 → 94 files
-- Updated test file count: 70 → 73 files
-- Updated test coverage: 95%+ → 99%
-- Updated file coverage ratio: 76% → 78%
-- Added v0.12.0 feature documentation:
-  - Connection test command for platform connectivity validation
-  - Comprehensive troubleshooting guide
-  - Additional gateway_manager services
-  - CLI restructuring for --config as true global option
-  - Platform services code quality improvements
-  - Multiple bug fixes for compatibility and reliability
+**Primary data flow:**
 
-**Key Metrics:**
-- 11 commits since v0.11.1 (2026-01-16)
-- ~2,195 lines of new code added
-- 3 new test files
-- Test coverage improved from 95%+ to 99%
+```
+AI Agent → MCP Transport (stdio|sse|http)
+  → Middleware Stack (error → timing → logging → bindings → serialization)
+    → FastMCP tool dispatch
+      → Tool function (tools/*.py)
+        → PlatformClient (platform/client.py)
+          → Service plugin (platform/services/*.py)
+            → ipsdk.AsyncPlatform → Itential REST API
+```
 
-**Key Insight:** Significant stability and quality improvements with focus on connectivity validation, troubleshooting capabilities, and test coverage enhancement.
+**Key modules and responsibilities:**
 
-### 2026-01-28 Verification Audit (Second Pass)
+| Module | Responsibility |
+|--------|----------------|
+| `app.py` | Entry point, exit code handling, debug tracebacks |
+| `server/server.py` | Server initialization, transport startup, lifespan management |
+| `platform/client.py` | Wraps ipsdk, service plugin loading, timeout/TLS enforcement |
+| `platform/services/` | Per-feature API wrappers auto-loaded as `client.<name>` |
+| `config/` | Immutable config models, precedence resolution, cached loading |
+| `tools/` | MCP tool implementations, auto-discovered at startup |
+| `models/` | Pydantic return types for all tools |
+| `bindings/` | Dynamic tool creation from config (endpoint and service types) |
+| `middleware/` | FastMCP middleware stack (bindings injection, serialization) |
+| `runtime/` | CLI argument parsing, command handlers, tool runner |
+| `utilities/tool.py` | Tool discovery generator, tag system, schema extraction |
+| `core/exceptions.py` | 19-class exception hierarchy with HTTP status mapping |
 
-**Auditor:** Comprehensive codebase analysis with quantitative metrics
-**Corrections Made:**
-- Test file count: 71 → 70 (corrected via `find` command)
-- Service file count: 13 → 12 (verified all service files)
-- Removed note about missing tool tests (all tools have test coverage)
-- Updated test coverage note: removed claim about gaps, confirmed 76% file coverage
+**Non-obvious design decisions:**
 
-**New Additions:**
-- Added Code Quality Metrics section with quantitative analysis
-- Documented 176 async functions across codebase
-- Verified zero anti-patterns (no bare except, no blocking I/O)
-- Confirmed 100% modern type hint coverage
-- Added file size analysis (largest: 1,102 lines in models/health.py)
-- Documented async excellence: 4 parallel gather operations, proper await usage
-- Added technical debt metrics: 1 XXX, 0 TODO, 0 FIXME, 0 HACK
-- Verified string formatting: consistent f-strings (only exception: datetime.strftime)
+- **Lifespan context for client injection**: `PlatformClient` is created once in `server.py:lifespan()` and injected into FastMCP's lifespan context. Tools access it via `ctx.request_context.lifespan_context.get("client")`. This is a single shared instance across all requests — connection pooling is delegated to ipsdk.
+- **Service plugins as client attributes**: `platform/services/*.py` modules are auto-discovered and registered as attributes on `PlatformClient` (e.g., `client.health`, `client.workflow_engine`). A single plugin failure does not crash initialization.
+- **Dynamic bindings via environment**: Tools can be created at runtime without writing Python by setting `ITENTIAL_MCP_TOOL_<NAME>` env vars with JSON config. This enables exposing workflows as MCP tools without code changes.
+- **Tag system for tool filtering**: Each tool module declares `__tags__` and individual functions can use `@tags()`. Tool name is always auto-tagged. `include_tags`/`exclude_tags` in server config controls what tools are exposed to clients.
+- **Config immutability**: All config dataclasses use `frozen=True`. You cannot mutate config after load — set env vars before startup.
+- **BindingsMiddleware uses O(1) dict lookup**: Previously iterated all bindings on every request. Now uses `tool_name → Tool config` dict. Critical for deployments with many dynamic tools.
 
-**Verification Methods:**
-- File counts: `find`, `ls`, `wc -l`
-- Code patterns: `grep -r` with regex patterns
-- Quality metrics: ruff, grep-based pattern detection
-- Manual inspection of critical files
+---
 
-**Key Insight:** This codebase has exceptionally low technical debt (0.000054% of lines have debt markers) and follows Python best practices consistently. Zero anti-patterns detected.
+## Tech Stack
 
-### 2026-01-28 Comprehensive Audit
+**Language:** Python 3.10–3.13 (all versions tested via tox)
 
-**Auditor:** Automated codebase analysis
-**Changes:**
-- Updated version from 0.11.0+ to 0.11.1 (current release)
-- Updated last updated date from 2026-01-10 to 2026-01-28
-- Corrected line count: ~18,500 → 18,532 (verified with wc)
-- Corrected test coverage: 98% → 95%+ (more accurate, based on file ratio)
-- Added source file count: 92 Python files
-- Updated test file count: 69 → 71 files
-- Updated model file count: 18 → 16 files (verified)
-- Updated tool file count: 18 → 17 files (verified)
-- Updated service file count: "10+" → 13 files (verified)
-- Updated documentation file count: "12+" → 15 files (verified)
-- Added troubleshooting.md to documentation list (new in v0.11.1+)
-- Corrected "Inconsistent Return Types" claim - verified ALL tools return Pydantic models
-- Added specific finding: templates.py:get_templates is the only outlier (returns list instead of RootModel)
-- Confirmed core/errors.py is UNUSED (only imported by tests/test_errors.py)
-- Added v0.11.1 bug fix notes (AuthConfig attribute access, tool discovery)
-- Documented single XXX comment location (gateway_manager.py:90) with explanation
-- Updated test coverage note to mention gaps in tool module test files
-- Enhanced summary with recent improvements and accurate metrics
+**Core dependencies and why:**
 
-**Key Findings:**
-1. **Exceptional Code Quality:** Only 1 XXX comment in 18,532 lines of code (99.9995% clean)
-2. **Unused Module:** core/errors.py has zero production usage - safe to deprecate
-3. **Test Coverage:** 70 test files covering 92 source files (76% file coverage ratio, 95%+ line coverage)
-4. **Zero Anti-Patterns:** No bare except clauses, no blocking I/O, no old-style types
-5. **Recent Activity:** 5 commits since last update, including bug fixes and troubleshooting guide
-6. **Async Excellence:** 176 async functions, all properly awaited, no blocking calls
-7. **Type Safety:** 100% modern type hint coverage with Pydantic validation
+| Dependency | Role |
+|------------|------|
+| `fastmcp` | MCP server framework — handles protocol, tool registration, middleware, transports |
+| `ipsdk>=0.7.0` | Itential Platform SDK — async HTTP client with auth and connection pooling |
+| `pydantic` | Config models (frozen dataclasses), tool return types, validation |
+| `uvicorn` | ASGI server for SSE and HTTP transports |
+| `python-toon` | Alternative response serialization format (configured via `ITENTIAL_MCP_SERVER_RESPONSE_FORMAT=toon`) |
+| `wsproto` | WebSocket protocol support |
 
-**File Count Corrections (2026-01-28 Audit):**
-- Test files: 71 → 70 (verified with find command)
-- Service files: 13 → 12 (verified count)
-- Model files: Confirmed 16 files
-- Tool files: Confirmed 17 files
-- Documentation: Confirmed 15 markdown files
+**Build toolchain:**
 
-**Documentation Accuracy:** All file counts, version numbers, metrics, and technical claims have been independently verified against the actual codebase.
+| Tool | Role |
+|------|------|
+| `uv` | Package manager and venv management (replaces pip/venv) |
+| `hatchling` + `uv-dynamic-versioning` | Build backend with git-tag-based semver |
+| `ruff` | Linter and formatter (single tool, replaces flake8/black/isort) |
+| `bandit` | Security scanner |
+| `tox` + `tox-uv` | Multi-version test matrix |
+| `pytest` + `pytest-asyncio` | Async-capable test framework |
+
+**What's intentionally absent:**
+
+- No `requests` — all HTTP is async via ipsdk
+- No `typing.Dict`, `typing.List`, `typing.Optional` — modern union syntax (`X | Y`) used throughout
+- No `time.sleep` or blocking I/O in async code
+- No wildcard imports
+- No bare `except:` clauses
+
+---
+
+## Development Workflow
+
+**Initial setup:**
+
+```bash
+make build          # Creates .venv, installs all dependencies via uv
+```
+
+**Daily commands:**
+
+```bash
+make test           # Run test suite
+make format         # Format with ruff
+make check          # Lint with ruff check
+make coverage       # HTML + terminal coverage report
+make security       # bandit security scan
+make premerge       # Full pipeline: clean → format → check → security → test
+```
+
+**Before every commit:** `make premerge` — this is what CI runs.
+
+**Running the server locally:**
+
+```bash
+uv run itential-mcp run                                         # stdio (direct process)
+uv run itential-mcp run --transport sse --host 0.0.0.0 --port 8000   # SSE
+uv run itential-mcp run --config config.conf                    # from config file
+ITENTIAL_MCP_SERVER_LOG_LEVEL=DEBUG uv run itential-mcp run    # verbose logging
+```
+
+**CLI reference:**
+
+```
+itential-mcp [--config FILE]
+  run       - Start the server
+  tools     - List available tools
+  tags      - List available tags
+  call      - Call a specific tool
+  version   - Show version
+```
+
+**Multi-version testing:**
+
+```bash
+make tox            # Test against Python 3.10, 3.11, 3.12, 3.13
+make tox-py312      # Single version
+make tox-premerge   # Full premerge pipeline via tox
+```
+
+**Environment variables for local dev:**
+
+```bash
+ITENTIAL_MCP_PLATFORM_HOST=platform.example.com
+ITENTIAL_MCP_PLATFORM_USER=admin
+ITENTIAL_MCP_PLATFORM_PASSWORD=secret
+ITENTIAL_MCP_PLATFORM_DISABLE_TLS=true       # Dev only
+ITENTIAL_MCP_PLATFORM_DISABLE_VERIFY=true    # Dev only
+ITENTIAL_MCP_SERVER_LOG_LEVEL=DEBUG
+ITENTIAL_MCP_SERVER_TRANSPORT=sse
+ITENTIAL_MCP_SERVER_PORT=8000
+ITENTIAL_MCP_DEBUG=true                       # Enables full tracebacks on error
+```
+
+**Dynamic tool binding (no code required):**
+
+```bash
+ITENTIAL_MCP_TOOL_DEPLOY='{"type":"endpoint","name":"deploy_trigger","automation":"Deploy Configuration"}'
+ITENTIAL_MCP_TOOL_ANSIBLE='{"type":"service","name":"ansible_playbook","cluster":"default"}'
+```
+
+**Container:**
+
+```bash
+make container      # Builds amd64 + arm64 container
+```
+
+**Copyright headers:** All `.py` files must have SPDX copyright headers.
+
+```bash
+make check-headers  # Verify
+make fix-headers    # Add missing
+```
+
+**TLS certs for dev:**
+
+```bash
+make certs          # Generate self-signed development certificates
+```
+
+---
+
+## Code Standards
+
+These are enforced by CI — violations block merge.
+
+### Type Hints
+
+Modern syntax only, no `typing` module generics:
+
+- `dict[str, Any]` not `Dict[str, Any]`
+- `list[str]` not `List[str]`
+- `str | None` not `Optional[str]`
+- `from __future__ import annotations` at top of all files
+
+### Async
+
+- All I/O must be async — no `time.sleep`, no `requests.*`
+- Parallel calls use `asyncio.gather()` — never sequential awaits when calls are independent
+- Timeout protection via `asyncio.wait_for()` on all external calls
+- Always use async context managers for resource cleanup
+
+### Function Signatures
+
+- Explicit keyword parameters over `**kwargs` or `Mapping` — this is a hard rule
+- Optional parameters after `*` marker (keyword-only enforcement)
+- Pydantic models for structured return types — no raw `dict` returns from tools
+
+### Error Handling
+
+- EAFP style: try/except, not check-before-access
+- Use the exception hierarchy in `core/exceptions.py` — don't raise `ValueError` directly
+- Never swallow exceptions with `except Exception: pass`
+- Let specific exceptions propagate from tools — `ErrorHandlingMiddleware` handles formatting
+
+### Documentation
+
+Google-style docstrings on all public functions: Args, Returns, Raises sections. Module docstrings explaining purpose and contents. Inline comments explain *why*, not *what*.
+
+### Imports
+
+Order: stdlib → third-party → local (relative). No wildcard imports. Relative imports within the package.
+
+### Immutability
+
+Config objects are frozen Pydantic dataclasses — attempting to set attributes raises `FrozenInstanceError`. Design code around this.
+
+### Naming
+
+- Modules: `lowercase_with_underscores`
+- Classes: `PascalCase`
+- Functions: `lowercase_with_underscores`
+- Constants: `UPPERCASE_WITH_UNDERSCORES`
+- Private: `_leading_underscore`
+
+---
+
+## Adding Tools, Services, and Bindings
+
+### New Static Tool
+
+1. Create `src/itential_mcp/tools/my_feature.py` with `__tags__` and async functions returning Pydantic models
+2. Create `src/itential_mcp/models/my_feature.py` with response models
+3. If the tool needs API calls, add `src/itential_mcp/platform/services/my_feature.py` with a `Service` class having `name = "my_feature"`
+4. Write tests in `tests/test_tools_my_feature.py`
+5. Run `make premerge`
+
+Tools are discovered automatically — no registration code needed.
+
+### New Service Plugin
+
+Create `src/itential_mcp/platform/services/my_service.py` with:
+
+```python
+class Service:
+    name = "my_service"   # Available as client.my_service
+
+    def __init__(self, client): ...
+    async def get_resource(self, id: str) -> dict: ...
+```
+
+Auto-loaded at client initialization.
+
+### Dynamic Binding
+
+Set `ITENTIAL_MCP_TOOL_<NAME>` env var or add `[[tools]]` section to config file. No Python required.
+
+---
+
+## Configuration Reference
+
+**Precedence (highest → lowest):** env vars → CLI args → config file → defaults
+
+**Key environment variable prefixes:**
+
+- `ITENTIAL_MCP_SERVER_*` — server settings (transport, host, port, logging, tags)
+- `ITENTIAL_MCP_PLATFORM_*` — platform connection (host, auth, TLS, timeout)
+- `ITENTIAL_MCP_AUTH_*` — authentication (jwt, oauth, oauth_proxy)
+- `ITENTIAL_MCP_TOOL_*` — dynamic tool definitions (JSON blobs)
+
+**Config loading:**
+
+```python
+from itential_mcp import config
+cfg = config.get()   # Cached with @lru_cache — loads once, immutable
+```
+
+Config example: `docs/mcp.conf.example`
+
+---
+
+## Current State & Known Debt
+
+### Active Tech Debt (ranked by impact)
+
+1. **`core/errors.py` is dead code** — this module contains simple error message functions and is imported only by `tests/test_errors.py`. It has zero production usage. Safe to delete, but exists in test assertions that would need updating.
+
+2. **No retry logic** — transient failures (network hiccups, platform restarts) propagate directly to the caller. No exponential backoff anywhere. For production deployments with unreliable networks this matters.
+
+3. **Connection pooling opacity** — pooling is fully delegated to ipsdk. There's no visibility into pool state, no metrics, no configuration for pool size. This is a blackbox.
+
+4. **Limited logging configuration** — log level is global. No per-module log levels. `ITENTIAL_MCP_SERVER_LOG_LEVEL=DEBUG` makes everything verbose.
+
+5. **Service plugin implicit contract** — plugins must have a `Service` class with a `name` attribute, but this is undocumented at the call site. Failed plugin loads are logged at DEBUG and silently skipped, which can cause confusing "method not found" errors at runtime.
+
+6. **`templates.py:get_templates`** returns `list` instead of a `RootModel` — only tool that doesn't return a Pydantic model. Not enforced by the type system.
+
+### Areas in Flux
+
+- FastMCP API compatibility: v0.12.1 fixed a breaking change where `include_tags`/`exclude_tags` kwargs were removed in FastMCP 3.x in favor of `enable()`/`disable()` API. Watch for further FastMCP API changes.
+- `ITENTIAL_MCP_SERVER_RESPONSE_FORMAT=toon` — TOON serialization support is relatively new (v0.10.0). Less battle-tested than JSON mode.
+
+### Testing Gaps
+
+- 99% line coverage, but integration tests are limited — most tests mock the platform client. Real platform connectivity is only tested via the `connection test` command.
+- `core/errors.py` is only tested in isolation with no production callers — these tests provide false coverage confidence for a dead module.
+
+---
+
+## New Developer Entry Points
+
+### Understand the system
+
+1. Read `README.md` for user perspective and use cases
+2. Read `server/server.py` — this is the hub that wires everything together
+3. Read one tool implementation in `tools/health.py` — it's the simplest and shows the full pattern
+4. Read `platform/client.py` to understand how the platform connection works
+
+### Verify your setup works
+
+```bash
+make build
+make test
+uv run itential-mcp version
+uv run itential-mcp tools
+```
+
+### What will trip you up
+
+- **Config is immutable** — set env vars before the process starts, not in test code after `config.get()` is called. Use `importlib.reload` or mock `config.get` in tests that need custom config.
+- **`config.get()` is cached** — if you call it in a test, the cache persists across tests unless you mock it. Tests in this repo handle this with `patch("itential_mcp.config.get")`.
+- **Service plugins fail silently** — if a service plugin fails to load, its methods won't exist on the client. The error is logged at DEBUG level only. Check debug logs first when `AttributeError: 'PlatformClient' object has no attribute '...'` appears.
+- **Tool return types must be Pydantic models** — FastMCP generates the MCP schema from the return annotation. Functions returning bare dicts produce no schema and break MCP clients.
+- **Middleware order matters** — middleware registered first is applied last (outermost). The current order in `server.py:__init_server__` is intentional.
+- **`PYTHONDONTWRITEBYTECODE=1`** — always set when running Python commands. The Makefile targets do this automatically. Bytecode can cause stale import issues during development.
+- **The `_tool_config` key** — bindings middleware injects this into tool kwargs and removes it after execution. If you see this parameter in a tool signature, that's why.
+
+### Key files at a glance
+
+```
+app.py                          Entry point and exit codes
+server/server.py                Server init, lifespan, transport startup
+platform/client.py              Platform API client, plugin loading
+platform/services/health.py     Simplest service plugin example
+tools/health.py                 Simplest tool implementation example
+config/__init__.py              Config loading API
+config/models.py                All config dataclasses
+config/defaults.py              All default values in one place
+core/exceptions.py              Exception hierarchy
+utilities/tool.py               Tool discovery and tag system
+bindings/__init__.py            Dynamic binding orchestration
+middleware/bindings.py          O(1) bindings injection
+runtime/parser.py               CLI argument handling
+pyproject.toml                  Project metadata, dependencies, test config
+Makefile                        All development commands
+CHANGELOG.md                    Full release history
+docs/troubleshooting.md         Diagnostic procedures
+docs/mcp.conf.example           Config file reference
+```
+
+---
+
+## CI/CD Reference
+
+**Pipelines:** `.github/workflows/`
+
+- `premerge.yaml` — format → lint → check-headers → security → test. Runs on every PR.
+- `container.yaml` — builds amd64 + arm64 images on merge to main branches.
+- `release.yaml` — publishes to PyPI via OIDC trusted publisher on GitHub release creation.
+
+**Dependabot** is configured for Python dependencies.
+
+**Release process:** Tag → GitHub release → `release.yaml` publishes to PyPI. Changelog generated via `release-drafter.yml`.


### PR DESCRIPTION
- Replace 1246-line verbose audit document with focused 378-line reference
- Update version header to 0.12.1 and correct last-updated date
- Remove LOC counts, code snippets, and audit history sections
- Add current tech debt rankings and known breaking changes (FastMCP 3.x)
- Add new developer gotchas section covering config caching, silent plugin failures, and tool return type requirements
- Restructure into actionable sections: architecture, workflow, standards, debt, entry points