### PR TITLE
fix: correct Annotated type for optional str parameters in lifecycle_manager

### DIFF
--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -244,7 +244,9 @@ async def describe_instance(
     resource_name: Annotated[
         str, Field(description="The Lifecycle Manager resource name")
     ],
-    instance_name: Annotated[str, Field(description="The instance name", default=None)],
+    instance_name: Annotated[
+        str | None, Field(description="The instance name", default=None)
+    ],
 ) -> models.DescribeInstanceResponse:
     """
     Get details about an instance of a Lifecycle Manager resource
@@ -294,9 +296,11 @@ async def run_action(
         str, Field(description="The Lifecycle Manager resource name")
     ],
     action_name: Annotated[str, Field(description="The action to run")],
-    instance_name: Annotated[str, Field(description="The instance name", default=None)],
+    instance_name: Annotated[
+        str | None, Field(description="The instance name", default=None)
+    ],
     instance_description: Annotated[
-        str, Field(description="The instance description", default=None)
+        str | None, Field(description="The instance description", default=None)
     ],
     input_params: Annotated[
         dict | str | None,

--- a/tests/test_tools_lifecycle_manager.py
+++ b/tests/test_tools_lifecycle_manager.py
@@ -1333,3 +1333,67 @@ class TestIntegration:
         RunActionResponse(
             start_time="2024-01-01T00:00:00Z", job_id="test", status="running"
         )
+
+
+class TestDescribeInstanceTypeAnnotations:
+    """Regression tests for Warning 2 — describe_instance and run_action parameter annotations.
+
+    instance_name and instance_description were declared as `str` with default=None,
+    a type annotation mismatch.  They are now correctly declared as `str | None`.
+
+    Note: With FastMCP's Annotated[..., Field(default=None)] pattern the Python
+    default lives inside the Field metadata, not as param.default on the signature.
+    We verify the inner type hint includes NoneType.
+    """
+
+    def _get_inner_type(self, annotation):
+        """Unwrap Annotated[X, ...] to return X."""
+        import typing
+
+        args = typing.get_args(annotation)
+        return args[0] if args else annotation
+
+    def test_describe_instance_instance_name_is_optional(self):
+        """describe_instance must declare instance_name as str | None."""
+        import inspect
+        import typing
+        from itential_mcp.tools.lifecycle_manager import describe_instance
+
+        sig = inspect.signature(describe_instance)
+        param = sig.parameters["instance_name"]
+
+        inner_type = self._get_inner_type(param.annotation)
+        type_args = typing.get_args(inner_type)
+        assert type(None) in type_args, (
+            f"instance_name annotation should be str | None, got: {inner_type}"
+        )
+
+    def test_run_action_instance_name_is_optional(self):
+        """run_action must declare instance_name as str | None."""
+        import inspect
+        import typing
+        from itential_mcp.tools.lifecycle_manager import run_action
+
+        sig = inspect.signature(run_action)
+        param = sig.parameters["instance_name"]
+
+        inner_type = self._get_inner_type(param.annotation)
+        type_args = typing.get_args(inner_type)
+        assert type(None) in type_args, (
+            f"run_action instance_name annotation should be str | None, got: {inner_type}"
+        )
+
+    def test_run_action_instance_description_is_optional(self):
+        """run_action must declare instance_description as str | None."""
+        import inspect
+        import typing
+        from itential_mcp.tools.lifecycle_manager import run_action
+
+        sig = inspect.signature(run_action)
+        param = sig.parameters["instance_description"]
+
+        inner_type = self._get_inner_type(param.annotation)
+        type_args = typing.get_args(inner_type)
+        assert type(None) in type_args, (
+            f"run_action instance_description annotation should be str | None, got: {inner_type}"
+        )


### PR DESCRIPTION
## Summary

- `instance_name` and `instance_description` in `describe_instance()` were declared as `Annotated[str, Field(..., default=None)]`
- This creates a type mismatch: the annotation says `str` (non-nullable) but the default is `None`, producing a Pydantic v2 schema warning and allowing `None` where `str` is expected
- Changed to `Annotated[str | None, Field(..., default=None)]` to align the type with the default and added 3 regression tests

## Test plan

- [ ] `make ci` passes on the branch (no Pydantic schema warnings)
- [ ] New tests in `tests/test_tools_lifecycle_manager.py` verify correct type annotation behavior
- [ ] `describe_instance` accepts `None` for optional parameters as documented

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)