### PR TITLE
fix: expose variables field in describe_job response

### DIFF
--- a/src/itential_mcp/models/operations_manager.py
+++ b/src/itential_mcp/models/operations_manager.py
@@ -343,7 +343,7 @@ class DescribeJobResponse(BaseModel):
 
     This model represents detailed information about a specific job
     from the operations manager API, including comprehensive execution
-    details, status, tasks, and metrics.
+    details, status, tasks, metrics, and output variables.
 
     Attributes:
         object_id: Unique job identifier.
@@ -354,6 +354,7 @@ class DescribeJobResponse(BaseModel):
         status: Current job status (error, complete, running, canceled, incomplete, paused).
         metrics: Job execution metrics including start time, end time, and account.
         updated: Last update timestamp.
+        variables: Job variable outputs produced during workflow execution.
     """
 
     object_id: Annotated[
@@ -445,6 +446,18 @@ class DescribeJobResponse(BaseModel):
                 Last update timestamp
                 """
             )
+        ),
+    ]
+
+    variables: Annotated[
+        Mapping[str, Any] | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Job variable outputs produced during workflow execution
+                """
+            ),
+            default=None,
         ),
     ]
 

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -294,6 +294,7 @@ async def describe_job(
             - status: Current job status (error, complete, running, canceled, incomplete, paused)
             - metrics: Job execution metrics including start time, end time, and account
             - updated: Last update timestamp
+            - variables: Job variable outputs produced during workflow execution
     """
     await ctx.info("inside describe_job(...)")
 
@@ -311,6 +312,7 @@ async def describe_job(
             "status": data["status"],
             "metrics": data["metrics"],
             "updated": data["last_updated"],
+            "variables": data.get("variables"),
         }
     )
 

--- a/tests/test_models_operations_manager.py
+++ b/tests/test_models_operations_manager.py
@@ -359,3 +359,37 @@ class TestDescribeJobResponse:
         assert job_detail.job_type == "automation"
         assert job_detail.status == "complete"
         assert job_detail.updated == "2025-01-01T12:00:00Z"
+        assert job_detail.variables is None
+
+    def test_describe_job_response_with_variables(self):
+        """Test DescribeJobResponse with job variable outputs"""
+        job_detail = DescribeJobResponse(
+            _id="job-456",
+            name="Job With Variables",
+            description=None,
+            type="automation",
+            tasks={},
+            status="complete",
+            metrics={},
+            updated="2025-01-01T12:00:00Z",
+            variables={"output_ip": "192.168.1.1", "result_code": 0},
+        )
+
+        assert job_detail.object_id == "job-456"
+        assert job_detail.variables == {"output_ip": "192.168.1.1", "result_code": 0}
+
+    def test_describe_job_response_variables_none(self):
+        """Test DescribeJobResponse with explicitly None variables"""
+        job_detail = DescribeJobResponse(
+            _id="job-789",
+            name="No Variables Job",
+            description=None,
+            type="automation",
+            tasks={},
+            status="running",
+            metrics={},
+            updated="2025-01-01T12:00:00Z",
+            variables=None,
+        )
+
+        assert job_detail.variables is None

--- a/tests/test_tools_operations_manager.py
+++ b/tests/test_tools_operations_manager.py
@@ -1017,10 +1017,38 @@ class TestDescribeJobSuccess:
         assert result.job_type == "automation"
         assert result.status == "complete"
         assert result.updated == "2022-01-01T12:00:00Z"
+        assert result.variables is None
 
         # Verify service was called with correct parameter
         mock_context.request_context.lifespan_context.get.return_value.operations_manager.describe_job.assert_called_with(
             "job-123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_describe_job_with_variables(self, mock_context):
+        """Test describe_job returns variables when present in the API response"""
+        mock_data = {
+            "_id": "job-456",
+            "name": "Job With Variables",
+            "description": "A job that produces output variables",
+            "type": "automation",
+            "tasks": {"task1": {"type": "action", "status": "complete"}},
+            "status": "complete",
+            "metrics": {"start_time": 1640995200000, "end_time": 1640999200000},
+            "last_updated": "2022-01-01T12:00:00Z",
+            "variables": {"output_ip": "192.168.1.1", "result_code": 0},
+        }
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.describe_job.return_value = mock_data
+
+        result = await operations_manager.describe_job(mock_context, "job-456")
+
+        assert isinstance(result, DescribeJobResponse)
+        assert result.object_id == "job-456"
+        assert result.variables == {"output_ip": "192.168.1.1", "result_code": 0}
+
+        # Verify service was called with correct parameter
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.describe_job.assert_called_with(
+            "job-456"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Added `variables` as an optional `Mapping[str, Any]` field to `DescribeJobResponse` model to capture job variable outputs produced during workflow execution
- Updated `describe_job` tool handler to extract `variables` via `data.get("variables")` from the API response
- Added unit tests covering the new field: with variables present, explicitly `None`, and in the tool handler

## Test plan

- [x] `make ci` passes — 2386 tests, zero lint/security/header issues
- [x] CLI verified via `itential-mcp --config itential-mcp.conf tools` — `describe_job` listed correctly
- [x] Commit signed with RSA SSH key

🤖 Generated with [Claude Code](https://claude.com/claude-code)