### PR TITLE
feat: add agent automation support to operations manager

### DIFF
--- a/src/itential_mcp/models/operations_manager.py
+++ b/src/itential_mcp/models/operations_manager.py
@@ -462,6 +462,261 @@ class DescribeJobResponse(BaseModel):
     ]
 
 
+class StartAgentResponse(BaseModel):
+    """Response returned when an agent endpoint trigger fires successfully.
+
+    Agent triggers return a session object rather than a job object. Use
+    session_id with describe_session to poll for completion and read the output.
+
+    Attributes:
+        session_id: Unique session identifier for this agent run.
+        status: Initial session status (RUNNING or COMPLETE).
+    """
+
+    session_id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique session identifier; use with describe_session to poll
+                for completion and retrieve the agent output
+                """
+            )
+        ),
+    ]
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Initial session status (RUNNING or COMPLETE)
+                """
+            )
+        ),
+    ]
+
+
+class SessionMessage(BaseModel):
+    """A single message/event from an agent session.
+
+    Attributes:
+        event_type: Type of event (inference-succeeded, agent-session-completed, etc.).
+        category: Broad category (AGENT_REASONING, AGENT_STATUS, etc.).
+        text: Agent output text, present on inference-succeeded events.
+        timestamp: ISO 8601 event timestamp.
+    """
+
+    event_type: Annotated[
+        str,
+        Field(alias="type", description="Event type identifier"),
+    ]
+
+    category: Annotated[
+        str | None,
+        Field(description="Broad event category", default=None),
+    ]
+
+    text: Annotated[
+        str | None,
+        Field(
+            description="Agent output text (present on inference-succeeded events)",
+            default=None,
+        ),
+    ]
+
+    timestamp: Annotated[
+        str | None,
+        Field(description="ISO 8601 event timestamp", default=None),
+    ]
+
+
+class DescribeSessionResponse(BaseModel):
+    """Full details of a completed or running agent session.
+
+    Attributes:
+        session_id: Unique session identifier.
+        agent_name: Name of the agent that ran.
+        status: Session status (RUNNING, COMPLETE, FAILED).
+        output: Final text output from the agent (None while still running).
+        started_at: ISO 8601 start timestamp.
+        end_time: ISO 8601 end timestamp (None if still running).
+        duration_ms: Total session duration in milliseconds.
+        messages: All session events in order.
+    """
+
+    session_id: Annotated[
+        str,
+        Field(description="Unique session identifier"),
+    ]
+
+    agent_name: Annotated[
+        str | None,
+        Field(description="Name of the agent that ran", default=None),
+    ]
+
+    status: Annotated[
+        str,
+        Field(description="Session status (RUNNING, COMPLETE, FAILED)"),
+    ]
+
+    output: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Final text output from the agent; None while still RUNNING
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    started_at: Annotated[
+        str | None,
+        Field(description="ISO 8601 start timestamp", default=None),
+    ]
+
+    end_time: Annotated[
+        str | None,
+        Field(
+            description="ISO 8601 end timestamp (None if still running)", default=None
+        ),
+    ]
+
+    duration_ms: Annotated[
+        int | None,
+        Field(description="Total session duration in milliseconds", default=None),
+    ]
+
+    messages: Annotated[
+        list[SessionMessage],
+        Field(
+            description="All session events in chronological order",
+            default_factory=list,
+        ),
+    ]
+
+
+class AgentElement(BaseModel):
+    """
+    Represents a single agent automation from the operations manager.
+
+    Agents are AI-driven automation components that can be exposed as API
+    endpoints and triggered similarly to workflows. This model surfaces the
+    fields most useful to an LLM caller: the agent's identity, its input
+    contract, and the route name needed to start it.
+
+    Attributes:
+        name: Human-readable automation name wrapping the agent.
+        description: Optional description of the agent automation.
+        agent_id: UUID of the underlying agent component (componentId).
+        route_name: API route name for triggering via start_workflow (None if no
+            endpoint trigger has been created for this agent).
+        input_schema: JSON Schema for the endpoint trigger's input (None if no
+            endpoint trigger exists).
+        last_executed: ISO 8601 timestamp of the last trigger execution (None if
+            the agent has never been triggered via its endpoint).
+    """
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Human-readable name of the automation wrapping the agent
+                """
+            )
+        ),
+    ]
+
+    description: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Description of the agent automation
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    agent_id: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                UUID of the underlying agent component; use this to identify the agent
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    route_name: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                API route name for triggering this agent (use with start_workflow);
+                None means no endpoint trigger has been created yet — use expose_agent
+                to create one
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    input_schema: Annotated[
+        Mapping[str, Any] | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                JSON Schema describing the input the agent endpoint accepts
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    last_executed: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 timestamp of last endpoint trigger execution (null if never executed)
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+
+class GetAgentsResponse(RootModel):
+    """
+    Response model for agent automation collection endpoints.
+
+    Wraps a list of AgentElement objects returned from the operations manager
+    when querying for agent-type automations.
+
+    Attributes:
+        root: List of AgentElement objects with agent metadata and trigger info.
+    """
+
+    root: Annotated[
+        list[AgentElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of agent automation objects with identity and trigger metadata
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+
 class ExposeWorkflowResponse(BaseModel):
     """Response model for workflow exposure endpoints.
 

--- a/src/itential_mcp/platform/services/operations_manager.py
+++ b/src/itential_mcp/platform/services/operations_manager.py
@@ -130,7 +130,48 @@ class Service(ServiceBase):
             json=data,
         )
 
-        return res.json().get("data")
+        body = res.json()
+        # Workflow jobs return under "data"; agent sessions return the session
+        # object directly at the top level alongside message/metadata keys.
+        if "data" in body and body["data"] is not None:
+            return body["data"]
+        # Agent session response: {"message": "OK", "data": {"sessionId": ..., "status": ...}}
+        # already handled above, but guard for unexpected shapes
+        return body
+
+    async def get_session(self, session_id: str) -> dict:
+        """Retrieve details for a specific agent session.
+
+        Args:
+            session_id: The session UUID returned by start_workflow for agent triggers.
+
+        Returns:
+            dict: Session detail object from AgentSessionManager.
+
+        Raises:
+            Exception: If the session is not found or the API call fails.
+        """
+        res = await self.client.get(f"/agent-session-manager/sessions/{session_id}")
+        return res.json()
+
+    async def get_session_messages(self, session_id: str) -> list[dict]:
+        """Retrieve all messages/events for an agent session.
+
+        Args:
+            session_id: The session UUID returned by start_workflow for agent triggers.
+
+        Returns:
+            list[dict]: Ordered list of session event objects. The inference-succeeded
+                event carries the agent's text output in its ``text`` field.
+
+        Raises:
+            Exception: If the session is not found or the API call fails.
+        """
+        res = await self.client.get(
+            f"/agent-session-manager/sessions/{session_id}/messages"
+        )
+        body = res.json()
+        return body if isinstance(body, list) else body.get("data", [])
 
     async def get_jobs(self, name: str, project: str | None = None) -> list[dict]:
         """
@@ -332,10 +373,94 @@ class Service(ServiceBase):
 
         return res.json()
 
+    async def get_agents(self) -> list[dict]:
+        """Retrieve all agent automations and join their endpoint triggers.
+
+        Fetches automations where componentType is "agents", then fetches all
+        endpoint triggers and joins them by actionId so callers can surface the
+        route_name and input_schema for each agent in a single response.
+
+        Returns:
+            list[dict]: Each dict contains automation fields plus optional
+                ``route_name``, ``input_schema``, and ``last_executed`` from the
+                matching endpoint trigger (all None when no endpoint trigger exists).
+
+        Raises:
+            Exception: If either API call fails.
+        """
+        limit = 100
+        skip = 0
+        automations = []
+
+        while True:
+            res = await self.client.get(
+                "/operations-manager/automations",
+                params={
+                    "limit": limit,
+                    "skip": skip,
+                    "equalsField": "componentType",
+                    "equals": "agents",
+                },
+            )
+            data = res.json()
+            page = data.get("data", [])
+            automations.extend(page)
+
+            if len(automations) >= data.get("metadata", {}).get("total", 0):
+                break
+
+            skip += limit
+
+        # Build a lookup of endpoint triggers keyed by actionId
+        skip = 0
+        endpoint_triggers: dict[str, dict] = {}
+
+        while True:
+            res = await self.client.get(
+                "/operations-manager/triggers",
+                params={
+                    "limit": limit,
+                    "skip": skip,
+                    "equalsField": "type",
+                    "equals": "endpoint",
+                },
+            )
+            data = res.json()
+            page = data.get("data", [])
+
+            for trigger in page:
+                action_id = trigger.get("actionId")
+                if action_id and action_id not in endpoint_triggers:
+                    endpoint_triggers[action_id] = trigger
+
+            total = data.get("metadata", {}).get("total", 0)
+            skip += limit
+            if skip >= total:
+                break
+
+        results = []
+        for auto in automations:
+            # Skip automations with no linked agent component
+            if not auto.get("componentId"):
+                continue
+            trigger = endpoint_triggers.get(auto["_id"])
+            results.append(
+                {
+                    "name": auto.get("name"),
+                    "description": auto.get("description"),
+                    "agent_id": auto.get("componentId"),
+                    "route_name": trigger.get("routeName") if trigger else None,
+                    "input_schema": trigger.get("schema") if trigger else None,
+                    "last_executed": trigger.get("lastExecuted") if trigger else None,
+                }
+            )
+
+        return results
+
     async def create_automation(
         self,
         name: str,
-        component_type: Literal["workflows", "ucm_compliance_plan"],
+        component_type: Literal["workflows", "ucm_compliance_plan", "agents"],
         component_name: str | None = None,
         description: str | None = None,
     ) -> Mapping[str, Any]:
@@ -352,9 +477,10 @@ class Service(ServiceBase):
         Args:
             name (str): The name of the automation to create. This name will be
                 used to identify the automation in the Operations Manager.
-            component_type (Literal["workflows", "ucm_compliance_plan"]): The type
+            component_type (Literal["workflows", "ucm_compliance_plan", "agents"]): The type
                 of component this automation will execute. "workflows" for Automation
-                Studio workflows, "ucm_compliance_plan" for compliance plans.
+                Studio workflows, "ucm_compliance_plan" for compliance plans,
+                "agents" for FlowAgent agents.
             component_name (str | None): The name of the specific component to
                 associate with this automation. If provided, the method will look up
                 the component ID. Defaults to None.
@@ -390,6 +516,12 @@ class Service(ServiceBase):
                     )
 
                 body["componentId"] = json_data["items"][0]["_id"]
+
+            elif component_type == "agents":
+                # Agents are identified by UUID (componentId). The caller may pass
+                # either the UUID directly or the automation name — accept either.
+                body["componentId"] = component_name
+                body["componentName"] = component_name
 
             elif component_type == "ucm_compliance_plan":
                 pass

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -170,6 +170,61 @@ async def get_workflows(
     return models.GetWorkflowsResponse(root=workflow_elements)
 
 
+async def get_agents(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+) -> models.GetAgentsResponse:
+    """
+    Get all agent automations from Itential Platform.
+
+    Agents are AI-driven automation components managed by the Operations Manager.
+    Each agent automation may optionally have an endpoint trigger that exposes it
+    for programmatic invocation via the same mechanism as workflows.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+    Returns:
+        models.GetAgentsResponse: List of agent objects with the following fields:
+            - name: Human-readable name of the automation wrapping the agent
+            - description: Description of the agent automation
+            - agent_id: UUID of the underlying agent component
+            - route_name: API route name for triggering (use with start_workflow);
+              None means no endpoint trigger exists yet — use expose_agent to create one
+            - input_schema: JSON Schema for the endpoint input (None if no endpoint trigger)
+            - last_executed: ISO 8601 timestamp of last endpoint trigger execution
+
+    Notes:
+        - Use agent_id when creating a new automation via create_automation
+        - Use route_name with start_workflow to trigger an agent that has an endpoint
+        - Agents without a route_name must be exposed first via expose_agent
+    """
+    await ctx.info("inside get_agents(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    data = await client.operations_manager.get_agents()
+
+    agent_elements = []
+
+    for item in data:
+        last_executed = None
+        if item.get("last_executed") is not None:
+            last_executed = timeutils.epoch_to_timestamp(item["last_executed"])
+
+        agent_elements.append(
+            models.AgentElement(
+                name=item["name"],
+                description=item.get("description"),
+                agent_id=item["agent_id"],
+                route_name=item.get("route_name"),
+                input_schema=item.get("input_schema"),
+                last_executed=last_executed,
+            )
+        )
+
+    return models.GetAgentsResponse(root=agent_elements)
+
+
 async def start_workflow(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     route_name: Annotated[
@@ -183,38 +238,37 @@ async def start_workflow(
             default=None,
         ),
     ],
-) -> models.StartWorkflowResponse:
+) -> models.StartWorkflowResponse | models.StartAgentResponse:
     """
-    Execute a workflow by triggering its API endpoint.
+    Execute a workflow or agent by triggering its API endpoint.
 
-    Workflows are the core automation processes in Itential Platform. This function
-    initiates workflow execution and returns a job object that can be monitored
-    for progress and results.
+    Works for both workflow triggers (returns a job object) and agent triggers
+    (returns a session object). Check whether the response has an object_id
+    (workflow job) or session_id (agent session) to determine the type and
+    use the appropriate follow-up tool.
 
     Args:
         ctx (Context): The FastMCP Context object
 
-        route_name (str): API route name for the workflow. Use the 'route_name'
-            field from `get_workflows`.
+        route_name (str): API route name. Use the 'route_name' field from
+            `get_workflows` for workflows or `get_agents` for agents.
 
-        data (dict | None): Input data for workflow execution. Structure must
-            match the workflow's input schema (available in the 'schema'
-            field from `get_workflows`).
+        data (dict | None): Input data matching the trigger's input schema.
 
     Returns:
-        models.StartWorkflowResponse: Job execution details with the following fields:
-            - object_id: Unique job identifier (use with `describe_job` for monitoring)
-            - name: Workflow name that was executed
-            - description: Workflow description
-            - tasks: Complete set of tasks to be executed in the workflow
-            - status: Current job status (error, complete, running, canceled, incomplete, paused)
-            - metrics: Job execution metrics including start_time, end_time, and user
+        models.StartWorkflowResponse: For workflow triggers — job details with:
+            - object_id: Job identifier (use with describe_job for monitoring)
+            - name: Workflow name
+            - status: Job status (error, complete, running, canceled, incomplete, paused)
+            - metrics: Execution metrics
+
+        models.StartAgentResponse: For agent triggers — session details with:
+            - session_id: Session identifier (use with describe_session for output)
+            - status: Initial session status (RUNNING or COMPLETE)
 
     Notes:
-        - Use the returned 'object_id' field with `describe_job` to monitor workflow progress
-        - The 'data' parameter must conform to the workflow's input schema
-        - Job status can be monitored using the `get_jobs` or `describe_job` functions
-        - Workflow schemas are available via the `get_workflows` function
+        - For agents: use describe_session with the returned session_id to get output
+        - For workflows: use describe_job with the returned object_id to monitor progress
     """
     await ctx.info("inside start_workflow(...)")
 
@@ -247,6 +301,14 @@ async def start_workflow(
             )
 
     res = await client.operations_manager.start_workflow(route_name, data)
+
+    # Agent endpoint triggers return a session object: {"sessionId": ..., "status": ...}
+    # Workflow endpoint triggers return a job object:   {"_id": ..., "name": ..., "tasks": ...}
+    if "sessionId" in res:
+        return models.StartAgentResponse(
+            session_id=res["sessionId"],
+            status=res.get("status", "RUNNING"),
+        )
 
     metrics_data = res.get("metrics") or {}
 
@@ -490,4 +552,175 @@ async def expose_workflow(
 
     return models.ExposeWorkflowResponse(
         message=f"Successfully exposed workflow `{name}` with route `{route_name}`"
+    )
+
+
+async def expose_agent(
+    ctx: Annotated[
+        Context,
+        Field(description="The FastMCP Context object"),
+    ],
+    agent_id: Annotated[
+        str,
+        Field(description="UUID of the agent to expose (agent_id from get_agents)"),
+    ],
+    automation_name: Annotated[
+        str,
+        Field(description="Name for the automation wrapping the agent"),
+    ],
+    route_name: Annotated[
+        str | None,
+        Field(
+            description="API route name for the endpoint trigger; defaults to automation_name with spaces replaced by underscores",
+            default=None,
+        ),
+    ],
+    endpoint_name: Annotated[
+        str | None,
+        Field(
+            description="Name for the trigger endpoint; defaults to 'API Route for {automation_name}'",
+            default=None,
+        ),
+    ],
+    endpoint_description: Annotated[
+        str | None,
+        Field(description="Description for the endpoint trigger", default=None),
+    ],
+    endpoint_schema: Annotated[
+        dict | None,
+        Field(
+            description="JSON Schema for the endpoint input; defaults to an open schema if not provided",
+            default=None,
+        ),
+    ],
+) -> models.ExposeWorkflowResponse:
+    """Expose an agent as an API endpoint trigger.
+
+    Creates an automation wrapping the specified agent and an endpoint trigger
+    so the agent can be started via start_workflow using the assigned route_name.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        agent_id (str): UUID of the agent component to expose. Use get_agents to
+            retrieve available agent UUIDs.
+        automation_name (str): Name for the automation that wraps this agent in
+            the Operations Manager.
+        route_name (str | None): API route name for the endpoint. Defaults to
+            automation_name with spaces replaced by underscores.
+        endpoint_name (str | None): Display name for the trigger. Defaults to
+            "API Route for {automation_name}".
+        endpoint_description (str | None): Description for the trigger. Defaults
+            to "auto-created by itential-mcp".
+        endpoint_schema (dict | None): JSON Schema for trigger input validation.
+            Defaults to an open schema that accepts any object.
+
+    Returns:
+        models.ExposeWorkflowResponse: Status message confirming the operation.
+
+    Raises:
+        exceptions.ConfigurationException: If the endpoint trigger cannot be created.
+        Exception: If the automation cannot be created.
+    """
+    await ctx.info("inside expose_agent(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    res = await client.operations_manager.create_automation(
+        name=automation_name,
+        component_type="agents",
+        component_name=agent_id,
+        description="auto-created by itential-mcp",
+    )
+
+    automation_id = res["_id"]
+    resolved_route = route_name or automation_name.replace(" ", "_")
+
+    try:
+        await client.operations_manager.create_endpoint_trigger(
+            name=endpoint_name or f"API Route for {automation_name}",
+            automation_id=automation_id,
+            description=endpoint_description or "auto-created by itential-mcp",
+            route_name=resolved_route,
+            schema=endpoint_schema,
+        )
+
+    except Exception as exc:
+        await client.operations_manager.delete_automation(automation_id)
+        raise exceptions.ConfigurationException(f"failed to expose agent: {exc}")
+
+    return models.ExposeWorkflowResponse(
+        message=f"Successfully exposed agent `{agent_id}` as automation `{automation_name}` with route `{resolved_route}`"
+    )
+
+
+async def describe_session(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    session_id: Annotated[
+        str,
+        Field(description="Session ID returned by start_workflow for an agent trigger"),
+    ],
+) -> models.DescribeSessionResponse:
+    """
+    Get the status and output of an agent session.
+
+    Use this after start_workflow returns a StartAgentResponse to poll for
+    completion and retrieve the agent's text output. Sessions complete quickly
+    (typically under 30 seconds); if status is RUNNING, call this again.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+        session_id (str): Session identifier from start_workflow's session_id field
+
+    Returns:
+        models.DescribeSessionResponse: Session details with the following fields:
+            - session_id: The session identifier
+            - agent_name: Name of the agent that ran
+            - status: Session status (RUNNING, COMPLETE, FAILED)
+            - output: Final text output from the agent (None while RUNNING)
+            - started_at: ISO 8601 start timestamp
+            - end_time: ISO 8601 end timestamp (None if still RUNNING)
+            - duration_ms: Total duration in milliseconds
+            - messages: All session events in chronological order
+
+    Notes:
+        - The agent output is in the 'output' field once status is COMPLETE
+        - Poll every few seconds if status is RUNNING
+    """
+    await ctx.info("inside describe_session(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    session = await client.operations_manager.get_session(session_id)
+    raw_messages = await client.operations_manager.get_session_messages(session_id)
+
+    # Extract final text output from the inference-succeeded event
+    output = None
+    for msg in raw_messages:
+        if msg.get("type") == "inference-succeeded" and msg.get("text"):
+            output = msg["text"]
+
+    messages = []
+    for msg in raw_messages:
+        ts_epoch = msg.get("timestamp")
+        ts = timeutils.epoch_to_timestamp(ts_epoch) if ts_epoch else None
+        messages.append(
+            models.SessionMessage(
+                type=msg.get("type", ""),
+                category=msg.get("category"),
+                text=msg.get("text"),
+                timestamp=ts,
+            )
+        )
+
+    snap = session.get("agentSnapshot") or {}
+
+    return models.DescribeSessionResponse(
+        session_id=session_id,
+        agent_name=snap.get("name"),
+        status=session.get("status", "UNKNOWN"),
+        output=output,
+        started_at=session.get("startedAt"),
+        end_time=session.get("endTime"),
+        duration_ms=session.get("durationMs"),
+        messages=messages,
     )

--- a/tests/test_models_operations_manager.py
+++ b/tests/test_models_operations_manager.py
@@ -13,6 +13,11 @@ from itential_mcp.models.operations_manager import (
     JobElement,
     GetJobsResponse,
     DescribeJobResponse,
+    StartAgentResponse,
+    SessionMessage,
+    DescribeSessionResponse,
+    AgentElement,
+    GetAgentsResponse,
 )
 
 
@@ -393,3 +398,218 @@ class TestDescribeJobResponse:
         )
 
         assert job_detail.variables is None
+
+
+class TestStartAgentResponse:
+    """Test the StartAgentResponse model"""
+
+    def test_start_agent_response_basic(self):
+        """Test basic StartAgentResponse creation"""
+        response = StartAgentResponse(
+            session_id="abc-123",
+            status="RUNNING",
+        )
+
+        assert response.session_id == "abc-123"
+        assert response.status == "RUNNING"
+
+    def test_start_agent_response_complete_status(self):
+        """Test StartAgentResponse with COMPLETE status"""
+        response = StartAgentResponse(session_id="xyz-789", status="COMPLETE")
+
+        assert response.status == "COMPLETE"
+
+    def test_start_agent_response_missing_session_id(self):
+        """Test StartAgentResponse validation fails without session_id"""
+        with pytest.raises(ValidationError) as exc_info:
+            StartAgentResponse(status="RUNNING")
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("session_id",) for e in errors)
+
+    def test_start_agent_response_missing_status(self):
+        """Test StartAgentResponse validation fails without status"""
+        with pytest.raises(ValidationError) as exc_info:
+            StartAgentResponse(session_id="abc-123")
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("status",) for e in errors)
+
+
+class TestSessionMessage:
+    """Test the SessionMessage model"""
+
+    def test_session_message_basic(self):
+        """Test basic SessionMessage creation via alias"""
+        msg = SessionMessage(
+            type="inference-succeeded",
+            category="AGENT_REASONING",
+            text="Hello world",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+
+        assert msg.event_type == "inference-succeeded"
+        assert msg.category == "AGENT_REASONING"
+        assert msg.text == "Hello world"
+        assert msg.timestamp == "2025-01-01T00:00:00Z"
+
+    def test_session_message_optional_fields(self):
+        """Test SessionMessage with only required type field"""
+        msg = SessionMessage(type="agent-session-completed")
+
+        assert msg.event_type == "agent-session-completed"
+        assert msg.category is None
+        assert msg.text is None
+        assert msg.timestamp is None
+
+    def test_session_message_missing_type(self):
+        """Test SessionMessage validation fails without type"""
+        with pytest.raises(ValidationError) as exc_info:
+            SessionMessage()
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] in (("type",), ("event_type",)) for e in errors)
+
+
+class TestDescribeSessionResponse:
+    """Test the DescribeSessionResponse model"""
+
+    def test_describe_session_response_basic(self):
+        """Test basic DescribeSessionResponse creation"""
+        response = DescribeSessionResponse(
+            session_id="sess-001",
+            agent_name="JF Agent",
+            status="COMPLETE",
+            output="Here is your one liner.",
+            started_at="2025-01-01T00:00:00Z",
+            end_time="2025-01-01T00:00:05Z",
+            duration_ms=5000,
+            messages=[],
+        )
+
+        assert response.session_id == "sess-001"
+        assert response.agent_name == "JF Agent"
+        assert response.status == "COMPLETE"
+        assert response.output == "Here is your one liner."
+        assert response.duration_ms == 5000
+        assert response.messages == []
+
+    def test_describe_session_response_running(self):
+        """Test DescribeSessionResponse for a still-running session"""
+        response = DescribeSessionResponse(
+            session_id="sess-002",
+            status="RUNNING",
+        )
+
+        assert response.status == "RUNNING"
+        assert response.output is None
+        assert response.end_time is None
+        assert response.duration_ms is None
+        assert response.messages == []
+
+    def test_describe_session_response_with_messages(self):
+        """Test DescribeSessionResponse with message list"""
+        msg = SessionMessage(
+            type="inference-succeeded",
+            category="AGENT_REASONING",
+            text="output text",
+        )
+        response = DescribeSessionResponse(
+            session_id="sess-003",
+            status="COMPLETE",
+            messages=[msg],
+        )
+
+        assert len(response.messages) == 1
+        assert response.messages[0].event_type == "inference-succeeded"
+        assert response.messages[0].text == "output text"
+
+    def test_describe_session_response_missing_required(self):
+        """Test DescribeSessionResponse validation fails without required fields"""
+        with pytest.raises(ValidationError) as exc_info:
+            DescribeSessionResponse()
+
+        errors = exc_info.value.errors()
+        required_locs = {e["loc"][0] for e in errors}
+        assert "session_id" in required_locs
+        assert "status" in required_locs
+
+
+class TestAgentElement:
+    """Test the AgentElement model"""
+
+    def test_agent_element_basic(self):
+        """Test basic AgentElement creation"""
+        element = AgentElement(
+            name="My Agent",
+            description="Does things",
+            agent_id="efaf23d0-4d10-482b-abde-a76180a95d5e",
+            route_name="my-agent",
+            input_schema={
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+            },
+            last_executed="2025-01-01T00:00:00Z",
+        )
+
+        assert element.name == "My Agent"
+        assert element.agent_id == "efaf23d0-4d10-482b-abde-a76180a95d5e"
+        assert element.route_name == "my-agent"
+
+    def test_agent_element_required_only(self):
+        """Test AgentElement with only required name field"""
+        element = AgentElement(name="Minimal Agent")
+
+        assert element.name == "Minimal Agent"
+        assert element.agent_id is None
+        assert element.route_name is None
+        assert element.input_schema is None
+        assert element.last_executed is None
+
+    def test_agent_element_no_endpoint_trigger(self):
+        """Test AgentElement with no endpoint trigger configured"""
+        element = AgentElement(
+            name="Unexposed Agent",
+            agent_id="some-uuid",
+            route_name=None,
+            input_schema=None,
+            last_executed=None,
+        )
+
+        assert element.route_name is None
+        assert element.input_schema is None
+
+    def test_agent_element_missing_required_name(self):
+        """Test AgentElement validation fails without name"""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentElement()
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("name",) for e in errors)
+
+
+class TestGetAgentsResponse:
+    """Test the GetAgentsResponse model"""
+
+    def test_get_agents_response_empty(self):
+        """Test empty GetAgentsResponse"""
+        response = GetAgentsResponse(root=[])
+
+        assert response.root == []
+
+    def test_get_agents_response_default_factory(self):
+        """Test GetAgentsResponse default creates empty list"""
+        response = GetAgentsResponse()
+
+        assert response.root == []
+
+    def test_get_agents_response_with_elements(self):
+        """Test GetAgentsResponse with agent elements"""
+        agent1 = AgentElement(name="Agent A", agent_id="uuid-a", route_name="agent-a")
+        agent2 = AgentElement(name="Agent B", agent_id="uuid-b")
+        response = GetAgentsResponse(root=[agent1, agent2])
+
+        assert len(response.root) == 2
+        assert response.root[0].name == "Agent A"
+        assert response.root[0].route_name == "agent-a"
+        assert response.root[1].route_name is None

--- a/tests/test_services_operations_manager.py
+++ b/tests/test_services_operations_manager.py
@@ -1675,3 +1675,230 @@ class TestDeleteAutomation:
         service.client.delete.assert_called_once_with(
             "/operations-manager/automations/"
         )
+
+
+class TestGetAgents:
+    """Test the get_agents method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        return Service(mock_client)
+
+    @pytest.fixture
+    def mock_automations_response(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "auto-001",
+                    "name": "My Agent",
+                    "description": "An agent",
+                    "componentType": "agents",
+                    "componentId": "uuid-001",
+                },
+                {
+                    "_id": "auto-002",
+                    "name": "No ID Agent",
+                    "description": "",
+                    "componentType": "agents",
+                    "componentId": None,
+                },
+            ],
+            "metadata": {"total": 2},
+        }
+        return mock_response
+
+    @pytest.fixture
+    def mock_triggers_response(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "trig-001",
+                    "type": "endpoint",
+                    "actionId": "auto-001",
+                    "routeName": "my-agent",
+                    "schema": {"type": "object"},
+                    "lastExecuted": None,
+                },
+            ],
+            "metadata": {"total": 1},
+        }
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_get_agents_joins_triggers(
+        self, service, mock_automations_response, mock_triggers_response
+    ):
+        """Test get_agents joins automations with their endpoint triggers"""
+        service.client.get = AsyncMock(
+            side_effect=[mock_automations_response, mock_triggers_response]
+        )
+
+        result = await service.get_agents()
+
+        # auto-002 skipped (no componentId); auto-001 joined with trigger
+        assert len(result) == 1
+        assert result[0]["name"] == "My Agent"
+        assert result[0]["agent_id"] == "uuid-001"
+        assert result[0]["route_name"] == "my-agent"
+        assert result[0]["input_schema"] == {"type": "object"}
+
+    @pytest.mark.asyncio
+    async def test_get_agents_skips_no_component_id(
+        self, service, mock_automations_response, mock_triggers_response
+    ):
+        """Test get_agents skips automations without a componentId"""
+        service.client.get = AsyncMock(
+            side_effect=[mock_automations_response, mock_triggers_response]
+        )
+
+        result = await service.get_agents()
+
+        names = [r["name"] for r in result]
+        assert "No ID Agent" not in names
+
+    @pytest.mark.asyncio
+    async def test_get_agents_no_endpoint_trigger(self, service):
+        """Test get_agents returns None for route_name when no endpoint trigger exists"""
+        auto_response = MagicMock()
+        auto_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "auto-003",
+                    "name": "Agent No Trigger",
+                    "description": "",
+                    "componentType": "agents",
+                    "componentId": "uuid-003",
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+        trigger_response = MagicMock()
+        trigger_response.json.return_value = {"data": [], "metadata": {"total": 0}}
+
+        service.client.get = AsyncMock(side_effect=[auto_response, trigger_response])
+
+        result = await service.get_agents()
+
+        assert len(result) == 1
+        assert result[0]["route_name"] is None
+        assert result[0]["input_schema"] is None
+        assert result[0]["last_executed"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_agents_empty(self, service):
+        """Test get_agents with no agent automations"""
+        empty_auto = MagicMock()
+        empty_auto.json.return_value = {"data": [], "metadata": {"total": 0}}
+        empty_trigger = MagicMock()
+        empty_trigger.json.return_value = {"data": [], "metadata": {"total": 0}}
+
+        service.client.get = AsyncMock(side_effect=[empty_auto, empty_trigger])
+
+        result = await service.get_agents()
+
+        assert result == []
+
+
+class TestGetSession:
+    """Test the get_session method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_get_session_returns_session_data(self, service):
+        """Test get_session returns session detail dict"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "sessionId": "sess-abc",
+            "status": "COMPLETE",
+            "agentDefinitionId": "uuid-001",
+        }
+        service.client.get = AsyncMock(return_value=mock_response)
+
+        result = await service.get_session("sess-abc")
+
+        assert result["sessionId"] == "sess-abc"
+        assert result["status"] == "COMPLETE"
+        service.client.get.assert_called_once_with(
+            "/agent-session-manager/sessions/sess-abc"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_session_client_error(self, service):
+        """Test get_session raises on client error"""
+        service.client.get = AsyncMock(side_effect=Exception("Not found"))
+
+        with pytest.raises(Exception, match="Not found"):
+            await service.get_session("missing-id")
+
+
+class TestGetSessionMessages:
+    """Test the get_session_messages method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_list_response(self, service):
+        """Test get_session_messages handles a direct list response"""
+        messages = [
+            {
+                "type": "inference-succeeded",
+                "text": "Hello",
+                "category": "AGENT_REASONING",
+            },
+            {"type": "agent-session-completed", "category": "AGENT_STATUS"},
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = messages
+        service.client.get = AsyncMock(return_value=mock_response)
+
+        result = await service.get_session_messages("sess-abc")
+
+        assert len(result) == 2
+        assert result[0]["type"] == "inference-succeeded"
+        service.client.get.assert_called_once_with(
+            "/agent-session-manager/sessions/sess-abc/messages"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_dict_response(self, service):
+        """Test get_session_messages handles a dict-wrapped response"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [{"type": "inference-succeeded", "text": "output"}]
+        }
+        service.client.get = AsyncMock(return_value=mock_response)
+
+        result = await service.get_session_messages("sess-abc")
+
+        assert len(result) == 1
+        assert result[0]["text"] == "output"
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_empty(self, service):
+        """Test get_session_messages with no messages"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        service.client.get = AsyncMock(return_value=mock_response)
+
+        result = await service.get_session_messages("sess-abc")
+
+        assert result == []

--- a/tests/test_tools_operations_manager.py
+++ b/tests/test_tools_operations_manager.py
@@ -30,10 +30,13 @@ class TestModule:
         """Test all expected functions exist in the module"""
         expected_functions = [
             "get_workflows",
+            "get_agents",
             "start_workflow",
             "get_jobs",
             "describe_job",
+            "describe_session",
             "expose_workflow",
+            "expose_agent",
             "_account_id_to_username",
         ]
 
@@ -48,10 +51,13 @@ class TestModule:
         functions_to_test = [
             operations_manager._account_id_to_username,
             operations_manager.get_workflows,
+            operations_manager.get_agents,
             operations_manager.start_workflow,
             operations_manager.get_jobs,
             operations_manager.describe_job,
+            operations_manager.describe_session,
             operations_manager.expose_workflow,
+            operations_manager.expose_agent,
         ]
 
         for func in functions_to_test:
@@ -1408,3 +1414,242 @@ class TestErrorHandling:
 
         with pytest.raises(Exception, match="Authorization API Error"):
             await operations_manager._account_id_to_username(mock_context, "user-123")
+
+
+class TestGetAgentsTool:
+    """Test the get_agents tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        ctx = MagicMock(spec=Context)
+        ctx.info = AsyncMock()
+        ctx.debug = AsyncMock()
+        ctx.warning = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.operations_manager = AsyncMock()
+        ctx.request_context.lifespan_context.get.return_value = mock_client
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_get_agents_returns_response(self, mock_context):
+        """Test get_agents returns GetAgentsResponse"""
+        from itential_mcp.models.operations_manager import GetAgentsResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_agents = AsyncMock(
+            return_value=[
+                {
+                    "name": "My Agent",
+                    "description": "does stuff",
+                    "agent_id": "uuid-001",
+                    "route_name": "my-agent",
+                    "input_schema": {"type": "object"},
+                    "last_executed": None,
+                }
+            ]
+        )
+
+        result = await operations_manager.get_agents(mock_context)
+
+        assert isinstance(result, GetAgentsResponse)
+        assert len(result.root) == 1
+        assert result.root[0].name == "My Agent"
+        assert result.root[0].route_name == "my-agent"
+
+    @pytest.mark.asyncio
+    async def test_get_agents_empty(self, mock_context):
+        """Test get_agents with empty result"""
+        from itential_mcp.models.operations_manager import GetAgentsResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_agents = AsyncMock(
+            return_value=[]
+        )
+
+        result = await operations_manager.get_agents(mock_context)
+
+        assert isinstance(result, GetAgentsResponse)
+        assert result.root == []
+
+    @pytest.mark.asyncio
+    async def test_get_agents_converts_epoch_timestamp(self, mock_context):
+        """Test get_agents converts epoch last_executed to ISO string"""
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_agents = AsyncMock(
+            return_value=[
+                {
+                    "name": "Timed Agent",
+                    "description": "",
+                    "agent_id": "uuid-002",
+                    "route_name": "timed",
+                    "input_schema": None,
+                    "last_executed": 1640995200000,
+                }
+            ]
+        )
+
+        result = await operations_manager.get_agents(mock_context)
+
+        assert result.root[0].last_executed is not None
+        assert "2022" in result.root[0].last_executed
+
+
+class TestStartWorkflowAgentBranch:
+    """Test start_workflow when triggered against an agent endpoint"""
+
+    @pytest.fixture
+    def mock_context(self):
+        ctx = MagicMock(spec=Context)
+        ctx.info = AsyncMock()
+        ctx.debug = AsyncMock()
+        ctx.warning = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.operations_manager = AsyncMock()
+        ctx.request_context.lifespan_context.get.return_value = mock_client
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_agent_returns_session(self, mock_context):
+        """Test start_workflow returns StartAgentResponse when platform returns sessionId"""
+        from itential_mcp.models.operations_manager import StartAgentResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.start_workflow = AsyncMock(
+            return_value={"sessionId": "sess-xyz", "status": "RUNNING"}
+        )
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_workflows = AsyncMock(
+            return_value=[]
+        )
+
+        result = await operations_manager.start_workflow(
+            mock_context, "jfagent", {"input": "hello"}
+        )
+
+        assert isinstance(result, StartAgentResponse)
+        assert result.session_id == "sess-xyz"
+        assert result.status == "RUNNING"
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_agent_complete_status(self, mock_context):
+        """Test start_workflow handles COMPLETE status from agent session"""
+        from itential_mcp.models.operations_manager import StartAgentResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.start_workflow = AsyncMock(
+            return_value={"sessionId": "sess-done", "status": "COMPLETE"}
+        )
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_workflows = AsyncMock(
+            return_value=[]
+        )
+
+        result = await operations_manager.start_workflow(
+            mock_context, "some-agent-route", None
+        )
+
+        assert isinstance(result, StartAgentResponse)
+        assert result.status == "COMPLETE"
+
+
+class TestDescribeSessionTool:
+    """Test the describe_session tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        ctx = MagicMock(spec=Context)
+        ctx.info = AsyncMock()
+        ctx.debug = AsyncMock()
+        ctx.warning = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.operations_manager = AsyncMock()
+        ctx.request_context.lifespan_context.get.return_value = mock_client
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_describe_session_complete(self, mock_context):
+        """Test describe_session returns output for a completed session"""
+        from itential_mcp.models.operations_manager import DescribeSessionResponse
+
+        mock_ops = mock_context.request_context.lifespan_context.get.return_value.operations_manager
+        mock_ops.get_session = AsyncMock(
+            return_value={
+                "sessionId": "sess-001",
+                "status": "COMPLETE",
+                "startedAt": "2025-01-01T00:00:00Z",
+                "endTime": "2025-01-01T00:00:05Z",
+                "durationMs": 5000,
+                "agentSnapshot": {"_id": "uuid-001", "name": "JF Agent"},
+            }
+        )
+        mock_ops.get_session_messages = AsyncMock(
+            return_value=[
+                {
+                    "type": "inference-succeeded",
+                    "category": "AGENT_REASONING",
+                    "text": "Your one liner here.",
+                    "timestamp": 1640995200000,
+                },
+                {
+                    "type": "agent-session-completed",
+                    "category": "AGENT_STATUS",
+                    "timestamp": 1640995200100,
+                },
+            ]
+        )
+
+        result = await operations_manager.describe_session(mock_context, "sess-001")
+
+        assert isinstance(result, DescribeSessionResponse)
+        assert result.session_id == "sess-001"
+        assert result.status == "COMPLETE"
+        assert result.agent_name == "JF Agent"
+        assert result.output == "Your one liner here."
+        assert result.duration_ms == 5000
+        assert len(result.messages) == 2
+
+    @pytest.mark.asyncio
+    async def test_describe_session_running_no_output(self, mock_context):
+        """Test describe_session returns None output while session is RUNNING"""
+        from itential_mcp.models.operations_manager import DescribeSessionResponse
+
+        mock_ops = mock_context.request_context.lifespan_context.get.return_value.operations_manager
+        mock_ops.get_session = AsyncMock(
+            return_value={
+                "sessionId": "sess-002",
+                "status": "RUNNING",
+                "agentSnapshot": {"name": "Some Agent"},
+            }
+        )
+        mock_ops.get_session_messages = AsyncMock(return_value=[])
+
+        result = await operations_manager.describe_session(mock_context, "sess-002")
+
+        assert isinstance(result, DescribeSessionResponse)
+        assert result.status == "RUNNING"
+        assert result.output is None
+        assert result.messages == []
+
+    @pytest.mark.asyncio
+    async def test_describe_session_client_error(self, mock_context):
+        """Test describe_session propagates client errors"""
+        mock_ops = mock_context.request_context.lifespan_context.get.return_value.operations_manager
+        mock_ops.get_session = AsyncMock(side_effect=Exception("Session not found"))
+
+        with pytest.raises(Exception, match="Session not found"):
+            await operations_manager.describe_session(mock_context, "bad-id")
+
+    @pytest.mark.asyncio
+    async def test_describe_session_no_output_message(self, mock_context):
+        """Test describe_session with messages but no inference-succeeded event"""
+        mock_ops = mock_context.request_context.lifespan_context.get.return_value.operations_manager
+        mock_ops.get_session = AsyncMock(
+            return_value={
+                "sessionId": "sess-003",
+                "status": "FAILED",
+                "agentSnapshot": {"name": "Failing Agent"},
+            }
+        )
+        mock_ops.get_session_messages = AsyncMock(
+            return_value=[
+                {"type": "agent-session-completed", "category": "AGENT_STATUS"},
+            ]
+        )
+
+        result = await operations_manager.describe_session(mock_context, "sess-003")
+
+        assert result.output is None
+        assert result.status == "FAILED"


### PR DESCRIPTION
## Summary

- **`get_agents`** — lists all agent automations joined with their endpoint triggers, surfacing `name`, `agent_id` (UUID), `route_name`, `input_schema`, and `last_executed` in one call. Join is required because `componentType` only lives on the automation, not the trigger.
- **`expose_agent`** — creates an automation wrapping an agent UUID + endpoint trigger so the agent is callable via `start_workflow`. Rolls back on trigger creation failure.
- **`describe_session`** — polls AgentSessionManager for session status and messages, extracts text output from the `inference-succeeded` event. Returns `output`, `status`, `duration_ms`, and full event log.
- **`start_workflow` fix** — handles both response shapes: workflow triggers return a job object (`_id`); agent triggers return a session object (`sessionId`). Previously crashed with `KeyError: '_id'` on agent triggers. Returns `StartAgentResponse` for agents, `StartWorkflowResponse` for workflows unchanged.
- **`create_automation`** — accepts `agents` as a valid `componentType` alongside `workflows` and `ucm_compliance_plan`.

## Test plan

- [x] 36 new tests added across model, service, and tool test files
- [x] All 2435 tests pass (`make ci` clean: format, lint, headers, security, pytest)
- [x] Validated end-to-end against UAT (`flowai.uat.itential.io`) — `get_agents` returns 12 agents, `start_workflow("jfagent", {"input": "..."})\ returns `StartAgentResponse`, `describe_session` retrieves agent output

Generated with [Claude Code](https://claude.com/claude-code)