### PR TITLE
feat: add agent_session_manager service, tools, and models

### DIFF
--- a/src/itential_mcp/models/agent_session_manager.py
+++ b/src/itential_mcp/models/agent_session_manager.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import inspect
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field, RootModel
+
+
+class SessionMessage(BaseModel):
+    """
+    Represents a single event message from an agent session.
+
+    Session messages capture the discrete events emitted during agent execution,
+    including model inference steps, tool calls, and final outputs. Each message
+    has a type that classifies the event and an optional text payload.
+
+    Attributes:
+        event_type: The event classification (e.g., "inference-succeeded",
+            "tool-call", "agent-error").
+        category: Optional grouping category for the event.
+        text: The text content of the event (e.g., model output, error message).
+        timestamp: ISO 8601 timestamp when the event was emitted.
+    """
+
+    event_type: Annotated[
+        str,
+        Field(
+            alias="type",
+            description=inspect.cleandoc(
+                """
+                Event classification for this message (e.g., inference-succeeded,
+                tool-call, agent-error)
+                """
+            ),
+        ),
+    ]
+
+    category: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Optional grouping category for the event
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    text: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Text content of the event such as model output or error message
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    timestamp: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 timestamp when this event was emitted
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    model_config = {"populate_by_name": True}
+
+
+class SessionElement(BaseModel):
+    """
+    Represents a single agent session from the AgentSessionManager.
+
+    Sessions are created when an agent automation is triggered via an endpoint
+    trigger. This lightweight list-view model surfaces the fields most useful
+    for scanning recent sessions; use describe_session for the full event log
+    and output text.
+
+    Attributes:
+        session_id: Unique session identifier (use with describe_session).
+        agent_name: Name of the agent that ran.
+        status: Session status (RUNNING, COMPLETE, FAILED).
+        started_at: ISO 8601 start timestamp.
+        end_time: ISO 8601 end timestamp (None if still running).
+        duration_ms: Total session duration in milliseconds.
+    """
+
+    session_id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique session identifier; use with describe_session to get the
+                full event log and agent output
+                """
+            )
+        ),
+    ]
+
+    agent_name: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Name of the agent that ran
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Session status (RUNNING, COMPLETE, FAILED)
+                """
+            )
+        ),
+    ]
+
+    started_at: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 start timestamp
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    end_time: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 end timestamp; None if the session is still RUNNING
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    duration_ms: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total session duration in milliseconds
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+
+class GetSessionsResponse(RootModel):
+    """
+    Response model for agent session collection endpoints.
+
+    Wraps a list of SessionElement objects returned from the AgentSessionManager
+    when listing sessions, optionally filtered by agent name.
+
+    Attributes:
+        root: List of SessionElement objects with session metadata and status.
+    """
+
+    root: Annotated[
+        list[SessionElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of agent session objects with status and timing metadata
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+
+class DescribeSessionResponse(BaseModel):
+    """
+    Response model for agent session detail endpoints.
+
+    Provides the full detail of an agent session including the complete event
+    log and the final output text produced by the agent. Use this model to
+    inspect what the agent did and what it returned.
+
+    Attributes:
+        session_id: Unique session identifier.
+        agent_name: Name of the agent that ran.
+        status: Session status (RUNNING, COMPLETE, FAILED).
+        output: Final text output produced by the agent (from the
+            inference-succeeded event). None if the session has not yet
+            completed or produced no output.
+        started_at: ISO 8601 start timestamp.
+        end_time: ISO 8601 end timestamp (None if still running).
+        duration_ms: Total session duration in milliseconds.
+        messages: Ordered list of session event messages.
+    """
+
+    session_id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique session identifier
+                """
+            )
+        ),
+    ]
+
+    agent_name: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Name of the agent that ran
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Session status (RUNNING, COMPLETE, FAILED)
+                """
+            )
+        ),
+    ]
+
+    output: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Final text output produced by the agent; extracted from the
+                inference-succeeded event. None if the session has not completed
+                or produced no text output.
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    started_at: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 start timestamp
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    end_time: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 end timestamp; None if the session is still RUNNING
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    duration_ms: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total session duration in milliseconds
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    messages: Annotated[
+        list[SessionMessage],
+        Field(
+            description=inspect.cleandoc(
+                """
+                Ordered list of session event messages captured during agent execution
+                """
+            ),
+            default_factory=list,
+        ),
+    ]

--- a/src/itential_mcp/platform/services/agent_session_manager.py
+++ b/src/itential_mcp/platform/services/agent_session_manager.py
@@ -46,17 +46,11 @@ class Service(ServiceBase):
                 Platform API or if the API returns an unexpected response format.
         """
         limit = 100
-        skip = 0
+        offset = 0
         results = []
 
-        params: dict = {}
-        if agent_name is not None:
-            params["equalsField"] = "agentSnapshot.name"
-            params["equals"] = agent_name
-
         while True:
-            params["limit"] = limit
-            params["skip"] = skip
+            params: dict = {"limit": limit, "offset": offset}
 
             res = await self.client.get(
                 "/agent-session-manager/sessions",
@@ -65,6 +59,9 @@ class Service(ServiceBase):
 
             data = res.json()
             items = data.get("data", [])
+
+            if not items:
+                break
 
             for item in items:
                 results.append(
@@ -78,11 +75,13 @@ class Service(ServiceBase):
                     }
                 )
 
-            total = data.get("metadata", {}).get("total", 0)
-            if len(results) >= total:
+            total = data.get("total", 0)
+            offset += limit
+            if offset >= total:
                 break
 
-            skip += limit
+        if agent_name is not None:
+            results = [r for r in results if r["agent_name"] == agent_name]
 
         return results
 

--- a/src/itential_mcp/platform/services/agent_session_manager.py
+++ b/src/itential_mcp/platform/services/agent_session_manager.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from itential_mcp.platform.services import ServiceBase
+
+
+class Service(ServiceBase):
+    """AgentSessionManager service for Itential Platform agent session access.
+
+    This service provides methods for interacting with the Itential Platform's
+    AgentSessionManager component, which manages agent execution sessions.
+    Sessions are created when an agent automation is triggered via an endpoint
+    trigger and record the full event log and final output produced by the agent.
+
+    Attributes:
+        name (str): The service identifier used for registration and routing.
+            Set to "agent_session_manager".
+
+    Inherits:
+        ServiceBase: Base service class providing common functionality including
+            client initialization and configuration management.
+    """
+
+    name: str = "agent_session_manager"
+
+    async def get_sessions(self, agent_name: str | None = None) -> list[dict]:
+        """Retrieve agent sessions from Itential Platform.
+
+        Queries the AgentSessionManager to fetch agent execution sessions,
+        implementing pagination to handle large result sets. Optionally filters
+        results to a specific agent by name.
+
+        Args:
+            agent_name (str | None): Optional agent name to filter sessions.
+                When provided, only sessions where the agent snapshot name
+                matches this value are returned. Defaults to None.
+
+        Returns:
+            list[dict]: A list of dictionaries containing session data with
+                normalized field names: session_id, agent_name, status,
+                started_at, end_time, duration_ms.
+
+        Raises:
+            Exception: If there is an error communicating with the Itential
+                Platform API or if the API returns an unexpected response format.
+        """
+        limit = 100
+        skip = 0
+        results = []
+
+        params: dict = {}
+        if agent_name is not None:
+            params["equalsField"] = "agentSnapshot.name"
+            params["equals"] = agent_name
+
+        while True:
+            params["limit"] = limit
+            params["skip"] = skip
+
+            res = await self.client.get(
+                "/agent-session-manager/sessions",
+                params=params,
+            )
+
+            data = res.json()
+            items = data.get("data", [])
+
+            for item in items:
+                results.append(
+                    {
+                        "session_id": item["sessionId"],
+                        "agent_name": item.get("agentSnapshot", {}).get("name"),
+                        "status": item["status"],
+                        "started_at": item.get("startedAt"),
+                        "end_time": item.get("endTime"),
+                        "duration_ms": item.get("durationMs"),
+                    }
+                )
+
+            total = data.get("metadata", {}).get("total", 0)
+            if len(results) >= total:
+                break
+
+            skip += limit
+
+        return results
+
+    async def get_session(self, session_id: str) -> dict:
+        """Retrieve detailed information about a specific agent session.
+
+        Fetches the full session record from the AgentSessionManager for the
+        given session identifier.
+
+        Args:
+            session_id (str): Unique session identifier to retrieve.
+
+        Returns:
+            dict: Session details as returned by the platform API.
+
+        Raises:
+            Exception: If there is an error communicating with the Itential
+                Platform API or if the session is not found.
+        """
+        res = await self.client.get(f"/agent-session-manager/sessions/{session_id}")
+        return res.json()
+
+    async def get_session_messages(self, session_id: str) -> list[dict]:
+        """Retrieve the event messages for a specific agent session.
+
+        Fetches the ordered list of event messages emitted during agent
+        execution. Handles both list responses and dict responses that wrap
+        the data under a "data" key.
+
+        Args:
+            session_id (str): Unique session identifier whose messages to retrieve.
+
+        Returns:
+            list[dict]: Ordered list of session event message dictionaries.
+
+        Raises:
+            Exception: If there is an error communicating with the Itential
+                Platform API or if the session is not found.
+        """
+        res = await self.client.get(
+            f"/agent-session-manager/sessions/{session_id}/messages"
+        )
+        data = res.json()
+
+        if isinstance(data, list):
+            return data
+
+        return data.get("data", [])

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+from fastmcp import Context
+
+from itential_mcp.utilities import time as timeutils
+from itential_mcp.models import agent_session_manager as models
+
+
+__tags__ = ("agent_session_manager",)
+
+
+async def get_sessions(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    agent_name: Annotated[
+        str | None,
+        Field(
+            description="Optional agent name used to filter sessions",
+            default=None,
+        ),
+    ],
+) -> models.GetSessionsResponse:
+    """
+    List agent sessions from Itential Platform.
+
+    Agent sessions are created when an agent automation is triggered via an
+    endpoint trigger. Each session records the agent that ran, its execution
+    status, and timing information.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        agent_name (str | None): Filter sessions to a specific agent by name.
+            When omitted, all sessions are returned.
+
+    Returns:
+        models.GetSessionsResponse: List of session objects with the following fields:
+            - session_id: Unique session identifier (use with describe_session)
+            - agent_name: Name of the agent that ran
+            - status: Session status (RUNNING, COMPLETE, FAILED)
+            - started_at: ISO 8601 start timestamp
+            - end_time: ISO 8601 end timestamp (None if still running)
+            - duration_ms: Total session duration in milliseconds
+
+    Notes:
+        - Use describe_session with a session_id to get the full event log and output
+        - Timestamps are converted from epoch milliseconds to ISO 8601 format
+    """
+    await ctx.info("inside get_sessions(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    data = await client.agent_session_manager.get_sessions(agent_name)
+
+    session_elements = []
+
+    for item in data:
+        started_at = item.get("started_at")
+        if isinstance(started_at, int):
+            started_at = timeutils.epoch_to_timestamp(started_at)
+
+        end_time = item.get("end_time")
+        if isinstance(end_time, int):
+            end_time = timeutils.epoch_to_timestamp(end_time)
+
+        session_element = models.SessionElement(
+            session_id=item["session_id"],
+            agent_name=item.get("agent_name"),
+            status=item["status"],
+            started_at=started_at,
+            end_time=end_time,
+            duration_ms=item.get("duration_ms"),
+        )
+        session_elements.append(session_element)
+
+    return models.GetSessionsResponse(root=session_elements)
+
+
+async def describe_session(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    session_id: Annotated[
+        str,
+        Field(description="The session ID to retrieve full details for"),
+    ],
+) -> models.DescribeSessionResponse:
+    """
+    Get detailed information about a specific agent session.
+
+    Returns the full session record including all event messages emitted
+    during agent execution and the final text output produced by the agent.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        session_id (str): Unique session identifier. Session IDs are returned
+            by get_sessions.
+
+    Returns:
+        models.DescribeSessionResponse: Full session details with the following fields:
+            - session_id: Unique session identifier
+            - agent_name: Name of the agent that ran
+            - status: Session status (RUNNING, COMPLETE, FAILED)
+            - output: Final text produced by the agent (None if not yet complete)
+            - started_at: ISO 8601 start timestamp
+            - end_time: ISO 8601 end timestamp (None if still running)
+            - duration_ms: Total session duration in milliseconds
+            - messages: Ordered list of session event messages
+
+    Notes:
+        - The output field is extracted from the inference-succeeded event message
+        - Message timestamps are converted from epoch milliseconds to ISO 8601 format
+    """
+    await ctx.info("inside describe_session(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    session = await client.agent_session_manager.get_session(session_id)
+    raw_messages = await client.agent_session_manager.get_session_messages(session_id)
+
+    agent_snapshot = session.get("agentSnapshot") or {}
+    agent_name = agent_snapshot.get("name")
+
+    started_at = session.get("startedAt")
+    if isinstance(started_at, int):
+        started_at = timeutils.epoch_to_timestamp(started_at)
+
+    end_time = session.get("endTime")
+    if isinstance(end_time, int):
+        end_time = timeutils.epoch_to_timestamp(end_time)
+
+    messages = []
+    output = None
+
+    for raw in raw_messages:
+        msg_timestamp = raw.get("timestamp")
+        if isinstance(msg_timestamp, int):
+            msg_timestamp = timeutils.epoch_to_timestamp(msg_timestamp)
+
+        msg = models.SessionMessage(
+            type=raw.get("type", ""),
+            category=raw.get("category"),
+            text=raw.get("text"),
+            timestamp=msg_timestamp,
+        )
+        messages.append(msg)
+
+        if raw.get("type") == "inference-succeeded" and raw.get("text") is not None:
+            output = raw["text"]
+
+    return models.DescribeSessionResponse(
+        session_id=session.get("sessionId", session_id),
+        agent_name=agent_name,
+        status=session.get("status", ""),
+        output=output,
+        started_at=started_at,
+        end_time=end_time,
+        duration_ms=session.get("durationMs"),
+        messages=messages,
+    )

--- a/tests/test_models_agent_session_manager.py
+++ b/tests/test_models_agent_session_manager.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+from pydantic import ValidationError
+
+from itential_mcp.models.agent_session_manager import (
+    SessionMessage,
+    SessionElement,
+    GetSessionsResponse,
+    DescribeSessionResponse,
+)
+
+
+class TestSessionMessage:
+    """Test the SessionMessage model"""
+
+    def test_session_message_required_fields(self):
+        """Test SessionMessage creation with the required event_type field"""
+        msg = SessionMessage(type="inference-succeeded")
+
+        assert msg.event_type == "inference-succeeded"
+        assert msg.category is None
+        assert msg.text is None
+        assert msg.timestamp is None
+
+    def test_session_message_all_fields(self):
+        """Test SessionMessage creation with all fields"""
+        msg = SessionMessage(
+            type="inference-succeeded",
+            category="output",
+            text="The device has been configured.",
+            timestamp="2025-06-01T12:00:00Z",
+        )
+
+        assert msg.event_type == "inference-succeeded"
+        assert msg.category == "output"
+        assert msg.text == "The device has been configured."
+        assert msg.timestamp == "2025-06-01T12:00:00Z"
+
+    def test_session_message_alias_type_works(self):
+        """Test that the 'type' alias is accepted as the field name"""
+        msg = SessionMessage(**{"type": "tool-call", "text": "calling get_device"})
+
+        assert msg.event_type == "tool-call"
+        assert msg.text == "calling get_device"
+
+    def test_session_message_populate_by_name(self):
+        """Test that event_type field name is also accepted via model_config"""
+        msg = SessionMessage(event_type="agent-error")
+
+        assert msg.event_type == "agent-error"
+
+    def test_session_message_missing_type_raises(self):
+        """Test SessionMessage validation fails when type is missing"""
+        with pytest.raises(ValidationError) as exc_info:
+            SessionMessage()
+
+        errors = exc_info.value.errors()
+        assert any(e["type"] == "missing" for e in errors)
+
+    def test_session_message_optional_fields_default_none(self):
+        """Test that optional fields default to None"""
+        msg = SessionMessage(type="tool-result")
+
+        assert msg.category is None
+        assert msg.text is None
+        assert msg.timestamp is None
+
+
+class TestSessionElement:
+    """Test the SessionElement model"""
+
+    def test_session_element_required_fields(self):
+        """Test SessionElement creation with only required fields"""
+        element = SessionElement(session_id="sess-001", status="COMPLETE")
+
+        assert element.session_id == "sess-001"
+        assert element.status == "COMPLETE"
+        assert element.agent_name is None
+        assert element.started_at is None
+        assert element.end_time is None
+        assert element.duration_ms is None
+
+    def test_session_element_all_fields(self):
+        """Test SessionElement creation with all fields"""
+        element = SessionElement(
+            session_id="sess-002",
+            agent_name="network-config-agent",
+            status="COMPLETE",
+            started_at="2025-06-01T10:00:00Z",
+            end_time="2025-06-01T10:01:30Z",
+            duration_ms=90000,
+        )
+
+        assert element.session_id == "sess-002"
+        assert element.agent_name == "network-config-agent"
+        assert element.status == "COMPLETE"
+        assert element.started_at == "2025-06-01T10:00:00Z"
+        assert element.end_time == "2025-06-01T10:01:30Z"
+        assert element.duration_ms == 90000
+
+    def test_session_element_running_no_end_time(self):
+        """Test SessionElement for a running session with no end time"""
+        element = SessionElement(
+            session_id="sess-003",
+            agent_name="my-agent",
+            status="RUNNING",
+        )
+
+        assert element.status == "RUNNING"
+        assert element.end_time is None
+        assert element.duration_ms is None
+
+    def test_session_element_missing_required_raises(self):
+        """Test SessionElement validation fails when required fields are missing"""
+        with pytest.raises(ValidationError) as exc_info:
+            SessionElement()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "session_id" in error_locs
+        assert "status" in error_locs
+
+    def test_session_element_optionals_explicit_none(self):
+        """Test SessionElement with explicit None for optional fields"""
+        element = SessionElement(
+            session_id="sess-004",
+            status="FAILED",
+            agent_name=None,
+            started_at=None,
+            end_time=None,
+            duration_ms=None,
+        )
+
+        assert element.agent_name is None
+        assert element.started_at is None
+        assert element.end_time is None
+        assert element.duration_ms is None
+
+
+class TestGetSessionsResponse:
+    """Test the GetSessionsResponse model"""
+
+    def test_get_sessions_response_empty_default(self):
+        """Test GetSessionsResponse default factory produces empty list"""
+        response = GetSessionsResponse()
+
+        assert response.root == []
+        assert len(response.root) == 0
+
+    def test_get_sessions_response_empty_explicit(self):
+        """Test GetSessionsResponse with an explicitly empty list"""
+        response = GetSessionsResponse(root=[])
+
+        assert response.root == []
+
+    def test_get_sessions_response_with_elements(self):
+        """Test GetSessionsResponse with multiple session elements"""
+        elem1 = SessionElement(session_id="sess-001", status="COMPLETE")
+        elem2 = SessionElement(
+            session_id="sess-002",
+            agent_name="my-agent",
+            status="RUNNING",
+        )
+
+        response = GetSessionsResponse(root=[elem1, elem2])
+
+        assert len(response.root) == 2
+        assert response.root[0].session_id == "sess-001"
+        assert response.root[1].session_id == "sess-002"
+        assert response.root[1].agent_name == "my-agent"
+
+    def test_get_sessions_response_is_iterable(self):
+        """Test GetSessionsResponse root list is iterable"""
+        elem = SessionElement(session_id="sess-001", status="COMPLETE")
+        response = GetSessionsResponse(root=[elem])
+
+        sessions = list(response.root)
+        assert len(sessions) == 1
+        assert sessions[0].session_id == "sess-001"
+
+
+class TestDescribeSessionResponse:
+    """Test the DescribeSessionResponse model"""
+
+    def test_describe_session_response_full_fields(self):
+        """Test DescribeSessionResponse with all fields populated"""
+        msg = SessionMessage(type="inference-succeeded", text="Done.")
+
+        response = DescribeSessionResponse(
+            session_id="sess-001",
+            agent_name="network-agent",
+            status="COMPLETE",
+            output="Done.",
+            started_at="2025-06-01T10:00:00Z",
+            end_time="2025-06-01T10:01:00Z",
+            duration_ms=60000,
+            messages=[msg],
+        )
+
+        assert response.session_id == "sess-001"
+        assert response.agent_name == "network-agent"
+        assert response.status == "COMPLETE"
+        assert response.output == "Done."
+        assert response.started_at == "2025-06-01T10:00:00Z"
+        assert response.end_time == "2025-06-01T10:01:00Z"
+        assert response.duration_ms == 60000
+        assert len(response.messages) == 1
+        assert response.messages[0].event_type == "inference-succeeded"
+
+    def test_describe_session_response_output_none_when_running(self):
+        """Test DescribeSessionResponse output is None for running sessions"""
+        response = DescribeSessionResponse(
+            session_id="sess-002",
+            status="RUNNING",
+            output=None,
+        )
+
+        assert response.output is None
+        assert response.agent_name is None
+        assert response.messages == []
+
+    def test_describe_session_response_no_inference_succeeded(self):
+        """Test DescribeSessionResponse with messages but no inference-succeeded"""
+        msgs = [
+            SessionMessage(type="tool-call", text="calling list_devices"),
+            SessionMessage(type="tool-result", text="[router1, router2]"),
+        ]
+
+        response = DescribeSessionResponse(
+            session_id="sess-003",
+            status="FAILED",
+            output=None,
+            messages=msgs,
+        )
+
+        assert response.output is None
+        assert len(response.messages) == 2
+
+    def test_describe_session_response_missing_required_raises(self):
+        """Test DescribeSessionResponse validation fails when required fields are absent"""
+        with pytest.raises(ValidationError) as exc_info:
+            DescribeSessionResponse()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "session_id" in error_locs
+        assert "status" in error_locs
+
+    def test_describe_session_response_default_messages_empty(self):
+        """Test DescribeSessionResponse messages defaults to empty list"""
+        response = DescribeSessionResponse(session_id="sess-004", status="COMPLETE")
+
+        assert response.messages == []
+
+    def test_describe_session_response_optional_fields_default_none(self):
+        """Test DescribeSessionResponse optional fields default to None"""
+        response = DescribeSessionResponse(session_id="sess-005", status="COMPLETE")
+
+        assert response.agent_name is None
+        assert response.output is None
+        assert response.started_at is None
+        assert response.end_time is None
+        assert response.duration_ms is None

--- a/tests/test_services_agent_session_manager.py
+++ b/tests/test_services_agent_session_manager.py
@@ -73,7 +73,7 @@ class TestGetSessions:
                     "startedAt": "2025-06-01T11:00:00Z",
                 },
             ],
-            "metadata": {"total": 2},
+            "total": 2,
         }
         mock_client.get.return_value = mock_response
 
@@ -88,10 +88,10 @@ class TestGetSessions:
         assert result[1]["end_time"] is None
 
     @pytest.mark.asyncio
-    async def test_get_sessions_agent_name_filter_passes_correct_params(
+    async def test_get_sessions_agent_name_filter_client_side(
         self, service, mock_client
     ):
-        """Test get_sessions passes equalsField and equals params when agent_name given"""
+        """Test get_sessions filters by agent_name client-side after fetching all pages"""
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "data": [
@@ -99,44 +99,50 @@ class TestGetSessions:
                     "sessionId": "sess-001",
                     "status": "COMPLETE",
                     "agentSnapshot": {"name": "my-agent"},
-                }
+                },
+                {
+                    "sessionId": "sess-002",
+                    "status": "COMPLETE",
+                    "agentSnapshot": {"name": "other-agent"},
+                },
             ],
-            "metadata": {"total": 1},
+            "total": 2,
         }
         mock_client.get.return_value = mock_response
 
         result = await service.get_sessions(agent_name="my-agent")
 
+        # Server-side filter params must NOT be sent (API ignores them)
         call_kwargs = mock_client.get.call_args
-        params = (
-            call_kwargs[1]["params"]
-            if "params" in call_kwargs[1]
-            else call_kwargs[0][1]
-        )
-        assert params.get("equalsField") == "agentSnapshot.name"
-        assert params.get("equals") == "my-agent"
+        params = call_kwargs[1].get("params", {})
+        assert "equalsField" not in params
+        assert "equals" not in params
+
+        # Only the matching session returned
         assert len(result) == 1
         assert result[0]["agent_name"] == "my-agent"
 
     @pytest.mark.asyncio
-    async def test_get_sessions_pagination(self, service, mock_client):
-        """Test get_sessions paginates until all results are retrieved"""
+    async def test_get_sessions_pagination_uses_offset(self, service, mock_client):
+        """Test get_sessions paginates using offset (not skip) and top-level total"""
+        page1_items = [
+            {"sessionId": f"sess-{i:03}", "status": "COMPLETE"} for i in range(100)
+        ]
+        page2_items = [{"sessionId": "sess-100", "status": "COMPLETE"}]
         page1 = MagicMock()
-        page1.json.return_value = {
-            "data": [{"sessionId": "sess-001", "status": "COMPLETE"}],
-            "metadata": {"total": 2},
-        }
+        page1.json.return_value = {"data": page1_items, "total": 101}
         page2 = MagicMock()
-        page2.json.return_value = {
-            "data": [{"sessionId": "sess-002", "status": "FAILED"}],
-            "metadata": {"total": 2},
-        }
+        page2.json.return_value = {"data": page2_items, "total": 101}
         mock_client.get.side_effect = [page1, page2]
 
         result = await service.get_sessions()
 
-        assert len(result) == 2
+        assert len(result) == 101
         assert mock_client.get.call_count == 2
+        # Second call should use offset=100, not skip=100
+        second_call_params = mock_client.get.call_args_list[1][1]["params"]
+        assert second_call_params.get("offset") == 100
+        assert "skip" not in second_call_params
 
     @pytest.mark.asyncio
     async def test_get_sessions_empty_result(self, service, mock_client):
@@ -144,7 +150,7 @@ class TestGetSessions:
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "data": [],
-            "metadata": {"total": 0},
+            "total": 0,
         }
         mock_client.get.return_value = mock_response
 
@@ -163,7 +169,7 @@ class TestGetSessions:
                     "status": "COMPLETE",
                 }
             ],
-            "metadata": {"total": 1},
+            "total": 1,
         }
         mock_client.get.return_value = mock_response
 

--- a/tests/test_services_agent_session_manager.py
+++ b/tests/test_services_agent_session_manager.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from ipsdk.platform import AsyncPlatform
+
+from itential_mcp.platform.services import ServiceBase
+from itential_mcp.platform.services.agent_session_manager import Service
+
+
+class TestService:
+    """Test the agent_session_manager Service class"""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock AsyncPlatform client"""
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create a Service instance with mock client"""
+        return Service(mock_client)
+
+    def test_service_initialization(self, mock_client):
+        """Test Service initialization"""
+        service = Service(mock_client)
+
+        assert service.client == mock_client
+        assert service.name == "agent_session_manager"
+
+    def test_service_inherits_service_base(self, service):
+        """Test Service inherits from ServiceBase"""
+        assert isinstance(service, ServiceBase)
+        assert hasattr(service, "client")
+
+    def test_service_name_attribute(self, service):
+        """Test Service has correct name attribute"""
+        assert service.name == "agent_session_manager"
+
+
+class TestGetSessions:
+    """Test the get_sessions method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_no_filter_returns_all(self, service, mock_client):
+        """Test get_sessions with no agent_name filter returns all sessions"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "sessionId": "sess-001",
+                    "status": "COMPLETE",
+                    "agentSnapshot": {"name": "agent-a"},
+                    "startedAt": "2025-06-01T10:00:00Z",
+                    "endTime": "2025-06-01T10:01:00Z",
+                    "durationMs": 60000,
+                },
+                {
+                    "sessionId": "sess-002",
+                    "status": "RUNNING",
+                    "agentSnapshot": {"name": "agent-b"},
+                    "startedAt": "2025-06-01T11:00:00Z",
+                },
+            ],
+            "metadata": {"total": 2},
+        }
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_sessions()
+
+        assert len(result) == 2
+        assert result[0]["session_id"] == "sess-001"
+        assert result[0]["agent_name"] == "agent-a"
+        assert result[0]["status"] == "COMPLETE"
+        assert result[0]["duration_ms"] == 60000
+        assert result[1]["session_id"] == "sess-002"
+        assert result[1]["end_time"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_agent_name_filter_passes_correct_params(
+        self, service, mock_client
+    ):
+        """Test get_sessions passes equalsField and equals params when agent_name given"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "sessionId": "sess-001",
+                    "status": "COMPLETE",
+                    "agentSnapshot": {"name": "my-agent"},
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_sessions(agent_name="my-agent")
+
+        call_kwargs = mock_client.get.call_args
+        params = (
+            call_kwargs[1]["params"]
+            if "params" in call_kwargs[1]
+            else call_kwargs[0][1]
+        )
+        assert params.get("equalsField") == "agentSnapshot.name"
+        assert params.get("equals") == "my-agent"
+        assert len(result) == 1
+        assert result[0]["agent_name"] == "my-agent"
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_pagination(self, service, mock_client):
+        """Test get_sessions paginates until all results are retrieved"""
+        page1 = MagicMock()
+        page1.json.return_value = {
+            "data": [{"sessionId": "sess-001", "status": "COMPLETE"}],
+            "metadata": {"total": 2},
+        }
+        page2 = MagicMock()
+        page2.json.return_value = {
+            "data": [{"sessionId": "sess-002", "status": "FAILED"}],
+            "metadata": {"total": 2},
+        }
+        mock_client.get.side_effect = [page1, page2]
+
+        result = await service.get_sessions()
+
+        assert len(result) == 2
+        assert mock_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_empty_result(self, service, mock_client):
+        """Test get_sessions returns empty list when no sessions exist"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [],
+            "metadata": {"total": 0},
+        }
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_sessions()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_missing_agent_snapshot(self, service, mock_client):
+        """Test get_sessions handles sessions with no agentSnapshot gracefully"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "sessionId": "sess-001",
+                    "status": "COMPLETE",
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_sessions()
+
+        assert result[0]["agent_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_client_error_propagates(self, service, mock_client):
+        """Test get_sessions propagates client errors"""
+        mock_client.get.side_effect = Exception("connection refused")
+
+        with pytest.raises(Exception, match="connection refused"):
+            await service.get_sessions()
+
+
+class TestGetSession:
+    """Test the get_session method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_get_session_returns_data(self, service, mock_client):
+        """Test get_session returns the parsed JSON response"""
+        session_data = {
+            "sessionId": "sess-001",
+            "status": "COMPLETE",
+            "agentSnapshot": {"name": "my-agent"},
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = session_data
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_session("sess-001")
+
+        assert result == session_data
+        mock_client.get.assert_called_once_with(
+            "/agent-session-manager/sessions/sess-001"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_session_client_error_propagates(self, service, mock_client):
+        """Test get_session propagates client errors"""
+        mock_client.get.side_effect = Exception("not found")
+
+        with pytest.raises(Exception, match="not found"):
+            await service.get_session("sess-missing")
+
+
+class TestGetSessionMessages:
+    """Test the get_session_messages method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_list_response(self, service, mock_client):
+        """Test get_session_messages handles a bare list response"""
+        messages = [
+            {"type": "tool-call", "text": "calling list_devices"},
+            {"type": "inference-succeeded", "text": "Done."},
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = messages
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_session_messages("sess-001")
+
+        assert result == messages
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_dict_response(self, service, mock_client):
+        """Test get_session_messages handles a dict-wrapped response"""
+        messages = [{"type": "inference-succeeded", "text": "Output text."}]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": messages}
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_session_messages("sess-001")
+
+        assert result == messages
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_empty_dict_response(self, service, mock_client):
+        """Test get_session_messages returns empty list when data key is absent"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_session_messages("sess-001")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_uses_correct_endpoint(
+        self, service, mock_client
+    ):
+        """Test get_session_messages calls the correct API endpoint"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_client.get.return_value = mock_response
+
+        await service.get_session_messages("sess-xyz")
+
+        mock_client.get.assert_called_once_with(
+            "/agent-session-manager/sessions/sess-xyz/messages"
+        )

--- a/tests/test_tools_agent_session_manager.py
+++ b/tests/test_tools_agent_session_manager.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import inspect
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastmcp import Context
+
+from itential_mcp.tools import agent_session_manager
+from itential_mcp.models.agent_session_manager import (
+    GetSessionsResponse,
+    DescribeSessionResponse,
+)
+
+
+def _make_context(agent_session_manager_mock=None):
+    """Build a mock Context wired up with a client holding the given service mock."""
+    context = AsyncMock(spec=Context)
+    context.info = AsyncMock()
+    context.warning = AsyncMock()
+
+    mock_client = MagicMock()
+    if agent_session_manager_mock is not None:
+        mock_client.agent_session_manager = agent_session_manager_mock
+
+    context.request_context = MagicMock()
+    context.request_context.lifespan_context = MagicMock()
+    context.request_context.lifespan_context.get.return_value = mock_client
+
+    return context
+
+
+class TestModule:
+    """Test the agent_session_manager tools module"""
+
+    def test_module_has_tags(self):
+        """Test module has __tags__ attribute"""
+        assert hasattr(agent_session_manager, "__tags__")
+
+    def test_module_tags_value(self):
+        """Test module __tags__ has correct value"""
+        assert agent_session_manager.__tags__ == ("agent_session_manager",)
+
+    def test_module_functions_exist(self):
+        """Test all expected public functions are present in the module"""
+        expected = ["get_sessions", "describe_session"]
+        for func_name in expected:
+            assert hasattr(agent_session_manager, func_name), (
+                f"missing function: {func_name}"
+            )
+            assert callable(getattr(agent_session_manager, func_name))
+
+    def test_functions_are_async(self):
+        """Test that all public tool functions are async coroutines"""
+        functions = [
+            agent_session_manager.get_sessions,
+            agent_session_manager.describe_session,
+        ]
+        for func in functions:
+            assert inspect.iscoroutinefunction(func), (
+                f"{func.__name__} must be an async def"
+            )
+
+
+class TestGetSessionsTool:
+    """Test the get_sessions tool function"""
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_returns_response_with_elements(self):
+        """Test get_sessions returns a populated GetSessionsResponse"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            {
+                "session_id": "sess-001",
+                "agent_name": "network-agent",
+                "status": "COMPLETE",
+                "started_at": "2025-06-01T10:00:00Z",
+                "end_time": "2025-06-01T10:01:00Z",
+                "duration_ms": 60000,
+            }
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_sessions(ctx, None)
+
+        assert isinstance(result, GetSessionsResponse)
+        assert len(result.root) == 1
+        assert result.root[0].session_id == "sess-001"
+        assert result.root[0].agent_name == "network-agent"
+        assert result.root[0].status == "COMPLETE"
+        assert result.root[0].duration_ms == 60000
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_empty_returns_empty_response(self):
+        """Test get_sessions with no sessions returns an empty response"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = []
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_sessions(ctx, None)
+
+        assert isinstance(result, GetSessionsResponse)
+        assert len(result.root) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_passes_agent_name_filter(self):
+        """Test get_sessions passes agent_name through to the service"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = []
+        ctx = _make_context(mock_service)
+
+        await agent_session_manager.get_sessions(ctx, agent_name="my-agent")
+
+        mock_service.get_sessions.assert_called_once_with("my-agent")
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_epoch_started_at_converted(self):
+        """Test get_sessions converts epoch integer started_at to ISO 8601"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            {
+                "session_id": "sess-001",
+                "agent_name": None,
+                "status": "COMPLETE",
+                "started_at": 1748779200000,
+                "end_time": None,
+                "duration_ms": None,
+            }
+        ]
+        ctx = _make_context(mock_service)
+
+        with patch(
+            "itential_mcp.tools.agent_session_manager.timeutils.epoch_to_timestamp"
+        ) as mock_ts:
+            mock_ts.return_value = "2025-06-01T12:00:00Z"
+
+            result = await agent_session_manager.get_sessions(ctx, None)
+
+        mock_ts.assert_called_with(1748779200000)
+        assert result.root[0].started_at == "2025-06-01T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_epoch_end_time_converted(self):
+        """Test get_sessions converts epoch integer end_time to ISO 8601"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            {
+                "session_id": "sess-001",
+                "agent_name": None,
+                "status": "COMPLETE",
+                "started_at": None,
+                "end_time": 1748779260000,
+                "duration_ms": None,
+            }
+        ]
+        ctx = _make_context(mock_service)
+
+        with patch(
+            "itential_mcp.tools.agent_session_manager.timeutils.epoch_to_timestamp"
+        ) as mock_ts:
+            mock_ts.return_value = "2025-06-01T12:01:00Z"
+
+            result = await agent_session_manager.get_sessions(ctx, None)
+
+        mock_ts.assert_called_with(1748779260000)
+        assert result.root[0].end_time == "2025-06-01T12:01:00Z"
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_string_timestamps_not_converted(self):
+        """Test get_sessions leaves string timestamps untouched"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            {
+                "session_id": "sess-001",
+                "agent_name": None,
+                "status": "COMPLETE",
+                "started_at": "2025-06-01T10:00:00Z",
+                "end_time": "2025-06-01T10:01:00Z",
+                "duration_ms": 60000,
+            }
+        ]
+        ctx = _make_context(mock_service)
+
+        with patch(
+            "itential_mcp.tools.agent_session_manager.timeutils.epoch_to_timestamp"
+        ) as mock_ts:
+            result = await agent_session_manager.get_sessions(ctx, None)
+
+        mock_ts.assert_not_called()
+        assert result.root[0].started_at == "2025-06-01T10:00:00Z"
+        assert result.root[0].end_time == "2025-06-01T10:01:00Z"
+
+
+class TestDescribeSessionTool:
+    """Test the describe_session tool function"""
+
+    @pytest.mark.asyncio
+    async def test_describe_session_complete_with_output(self):
+        """Test describe_session returns full detail including agent output"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-001",
+            "status": "COMPLETE",
+            "agentSnapshot": {"name": "network-agent"},
+            "startedAt": "2025-06-01T10:00:00Z",
+            "endTime": "2025-06-01T10:01:00Z",
+            "durationMs": 60000,
+        }
+        mock_service.get_session_messages.return_value = [
+            {
+                "type": "tool-call",
+                "text": "calling get_device",
+                "category": None,
+                "timestamp": None,
+            },
+            {
+                "type": "inference-succeeded",
+                "text": "Device configured.",
+                "category": "output",
+                "timestamp": None,
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session(ctx, "sess-001")
+
+        assert isinstance(result, DescribeSessionResponse)
+        assert result.session_id == "sess-001"
+        assert result.agent_name == "network-agent"
+        assert result.status == "COMPLETE"
+        assert result.output == "Device configured."
+        assert result.duration_ms == 60000
+        assert len(result.messages) == 2
+
+    @pytest.mark.asyncio
+    async def test_describe_session_running_no_output(self):
+        """Test describe_session for a running session returns output=None"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-002",
+            "status": "RUNNING",
+            "agentSnapshot": {"name": "my-agent"},
+        }
+        mock_service.get_session_messages.return_value = [
+            {
+                "type": "tool-call",
+                "text": "looking up data",
+                "category": None,
+                "timestamp": None,
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session(ctx, "sess-002")
+
+        assert result.status == "RUNNING"
+        assert result.output is None
+        assert len(result.messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_describe_session_no_inference_succeeded_event(self):
+        """Test describe_session output is None when no inference-succeeded message"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-003",
+            "status": "FAILED",
+        }
+        mock_service.get_session_messages.return_value = [
+            {
+                "type": "agent-error",
+                "text": "something broke",
+                "category": None,
+                "timestamp": None,
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session(ctx, "sess-003")
+
+        assert result.output is None
+        assert result.status == "FAILED"
+        assert len(result.messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_describe_session_inference_succeeded_null_text_not_output(self):
+        """Test describe_session ignores inference-succeeded with None text for output"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-004",
+            "status": "COMPLETE",
+        }
+        mock_service.get_session_messages.return_value = [
+            {
+                "type": "inference-succeeded",
+                "text": None,
+                "category": None,
+                "timestamp": None,
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session(ctx, "sess-004")
+
+        assert result.output is None
+
+    @pytest.mark.asyncio
+    async def test_describe_session_epoch_timestamps_on_session_converted(self):
+        """Test describe_session converts epoch timestamps on the session record"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-005",
+            "status": "COMPLETE",
+            "startedAt": 1748779200000,
+            "endTime": 1748779260000,
+        }
+        mock_service.get_session_messages.return_value = []
+        ctx = _make_context(mock_service)
+
+        with patch(
+            "itential_mcp.tools.agent_session_manager.timeutils.epoch_to_timestamp"
+        ) as mock_ts:
+            mock_ts.side_effect = lambda ms: f"ts({ms})"
+            result = await agent_session_manager.describe_session(ctx, "sess-005")
+
+        assert result.started_at == "ts(1748779200000)"
+        assert result.end_time == "ts(1748779260000)"
+
+    @pytest.mark.asyncio
+    async def test_describe_session_epoch_timestamps_on_messages_converted(self):
+        """Test describe_session converts epoch timestamps on message records"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-006",
+            "status": "COMPLETE",
+        }
+        mock_service.get_session_messages.return_value = [
+            {
+                "type": "tool-call",
+                "text": "hi",
+                "category": None,
+                "timestamp": 1748779200000,
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        with patch(
+            "itential_mcp.tools.agent_session_manager.timeutils.epoch_to_timestamp"
+        ) as mock_ts:
+            mock_ts.return_value = "2025-06-01T12:00:00Z"
+            result = await agent_session_manager.describe_session(ctx, "sess-006")
+
+        assert result.messages[0].timestamp == "2025-06-01T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_describe_session_no_agent_snapshot(self):
+        """Test describe_session handles missing agentSnapshot gracefully"""
+        mock_service = AsyncMock()
+        mock_service.get_session.return_value = {
+            "sessionId": "sess-007",
+            "status": "COMPLETE",
+        }
+        mock_service.get_session_messages.return_value = []
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session(ctx, "sess-007")
+
+        assert result.agent_name is None
+
+    @pytest.mark.asyncio
+    async def test_describe_session_client_error_propagates(self):
+        """Test describe_session propagates errors from the service layer"""
+        mock_service = AsyncMock()
+        mock_service.get_session.side_effect = Exception("session not found")
+        ctx = _make_context(mock_service)
+
+        with pytest.raises(Exception, match="session not found"):
+            await agent_session_manager.describe_session(ctx, "sess-missing")


### PR DESCRIPTION
## Summary

- Introduces a dedicated `agent_session_manager` module (models, service, tools) that cleanly separates AgentSessionManager API concerns from `operations_manager`
- Adds `get_sessions` tool — lists agent sessions with optional `agent_name` filter, paginated
- Adds `describe_session` tool — full session detail including output extraction from `inference-succeeded` events and epoch timestamp conversion
- Models: `SessionMessage`, `SessionElement`, `GetSessionsResponse`, `DescribeSessionResponse`
- Service: `get_sessions`, `get_session`, `get_session_messages` against `/agent-session-manager/` routes
- 54 new tests across model, service, and tool layers

## Test plan

- [ ] `make ci` passes (2453 tests)
- [ ] `get_sessions` returns list of sessions, filters by agent_name
- [ ] `describe_session` returns output for COMPLETE sessions, None while RUNNING

## Notes

This is PR 1 of 3 in the agent support rollout:
- **PR 1 (this)**: `agent_session_manager` module — session listing and detail
- **PR 2**: `operations_manager` agent automation support — `get_agents`, `expose_agent`, `StartAgentResponse`
- **PR 3**: `trigger_automation` + `get_automations` — unified automation triggering

🤖 Generated with [Claude Code](https://claude.com/claude-code)