### PR TITLE
feat: add agent automation support to operations manager

### DIFF
--- a/src/itential_mcp/models/operations_manager.py
+++ b/src/itential_mcp/models/operations_manager.py
@@ -462,6 +462,158 @@ class DescribeJobResponse(BaseModel):
     ]
 
 
+class StartAgentResponse(BaseModel):
+    """
+    Response returned when an agent endpoint trigger fires successfully.
+
+    Agent triggers return a session object rather than a job object. Use
+    session_id with describe_session to poll for completion and read the
+    output.
+
+    Attributes:
+        session_id: Unique session identifier for this agent run.
+        status: Initial session status (RUNNING or COMPLETE).
+    """
+
+    session_id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique session identifier; use with describe_session to poll for
+                completion and retrieve the agent output
+                """
+            )
+        ),
+    ]
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Initial session status (RUNNING or COMPLETE)
+                """
+            )
+        ),
+    ]
+
+
+class AgentElement(BaseModel):
+    """
+    Represents a single agent automation from the operations manager.
+
+    Agents are AI-driven automation components that can be exposed as API
+    endpoints and triggered similarly to workflows.
+
+    Attributes:
+        name: Human-readable name of the automation wrapping the agent.
+        description: Description of the agent automation.
+        agent_id: UUID of the underlying agent component; use this to identify the agent.
+        route_name: API route name for triggering this agent (use with trigger_automation).
+        input_schema: JSON Schema describing the input the agent endpoint accepts.
+        last_executed: ISO 8601 timestamp of last endpoint trigger execution.
+    """
+
+    name: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Human-readable name of the automation wrapping the agent
+                """
+            )
+        ),
+    ]
+
+    description: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Description of the agent automation
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    agent_id: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                UUID of the underlying agent component; use this to identify the agent
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    route_name: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                API route name for triggering this agent (use with trigger_automation);
+                None means no endpoint trigger has been created yet — use expose_agent
+                to create one
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    input_schema: Annotated[
+        Mapping[str, Any] | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                JSON Schema describing the input the agent endpoint accepts
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    last_executed: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 timestamp of last endpoint trigger execution (null if never
+                executed)
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+
+class GetAgentsResponse(RootModel):
+    """
+    Response model for agent automation collection endpoints.
+
+    Wraps a list of AgentElement objects returned from the operations manager
+    when querying for agent-type automations.
+
+    Attributes:
+        root: List of AgentElement objects with agent metadata and trigger info.
+    """
+
+    root: Annotated[
+        list[AgentElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of agent automation objects with identity and trigger metadata
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+
 class ExposeWorkflowResponse(BaseModel):
     """Response model for workflow exposure endpoints.
 

--- a/src/itential_mcp/platform/services/operations_manager.py
+++ b/src/itential_mcp/platform/services/operations_manager.py
@@ -130,7 +130,86 @@ class Service(ServiceBase):
             json=data,
         )
 
-        return res.json().get("data")
+        body = res.json()
+        if "data" in body and body["data"] is not None:
+            return body["data"]
+        return body
+
+    async def get_agents(self) -> list[dict]:
+        """Retrieve all agent automations and join their endpoint triggers.
+
+        Fetches automations where componentType is "agents", then fetches all
+        endpoint triggers and joins them by actionId so callers can surface the
+        route_name and input_schema for each agent in a single response.
+
+        Returns:
+            list[dict]: Each dict contains: name, description, agent_id, route_name,
+                input_schema, last_executed. Last three are None when no endpoint
+                trigger exists. Automations with no componentId are skipped.
+
+        Raises:
+            Exception: If either API call fails.
+        """
+        limit = 100
+        skip = 0
+        automations = []
+
+        while True:
+            res = await self.client.get(
+                "/operations-manager/automations",
+                params={
+                    "limit": limit,
+                    "skip": skip,
+                    "equalsField": "componentType",
+                    "equals": "agents",
+                },
+            )
+            data = res.json()
+            automations.extend(data.get("data", []))
+            if len(automations) >= data.get("metadata", {}).get("total", 0):
+                break
+            skip += limit
+
+        skip = 0
+        endpoint_triggers: dict[str, dict] = {}
+
+        while True:
+            res = await self.client.get(
+                "/operations-manager/triggers",
+                params={
+                    "limit": limit,
+                    "skip": skip,
+                    "equalsField": "type",
+                    "equals": "endpoint",
+                },
+            )
+            data = res.json()
+            for trigger in data.get("data", []):
+                action_id = trigger.get("actionId")
+                if action_id and action_id not in endpoint_triggers:
+                    endpoint_triggers[action_id] = trigger
+            total = data.get("metadata", {}).get("total", 0)
+            skip += limit
+            if skip >= total:
+                break
+
+        results = []
+        for auto in automations:
+            if not auto.get("componentId"):
+                continue
+            trigger = endpoint_triggers.get(auto["_id"])
+            results.append(
+                {
+                    "name": auto.get("name"),
+                    "description": auto.get("description"),
+                    "agent_id": auto.get("componentId"),
+                    "route_name": trigger.get("routeName") if trigger else None,
+                    "input_schema": trigger.get("schema") if trigger else None,
+                    "last_executed": trigger.get("lastExecuted") if trigger else None,
+                }
+            )
+
+        return results
 
     async def get_jobs(self, name: str, project: str | None = None) -> list[dict]:
         """
@@ -335,29 +414,32 @@ class Service(ServiceBase):
     async def create_automation(
         self,
         name: str,
-        component_type: Literal["workflows", "ucm_compliance_plan"],
+        component_type: Literal["workflows", "ucm_compliance_plan", "agents"],
         component_name: str | None = None,
         description: str | None = None,
     ) -> Mapping[str, Any]:
         """Create a new automation in the Operations Manager.
 
-        This method creates an automation object that wraps a workflow or compliance
-        plan for execution through the Operations Manager. Automations serve as the
-        execution containers that can be triggered through various mechanisms including
-        manual triggers, scheduled triggers, or API endpoints.
+        This method creates an automation object that wraps a workflow, compliance
+        plan, or FlowAgent agent for execution through the Operations Manager.
+        Automations serve as the execution containers that can be triggered through
+        various mechanisms including manual triggers, scheduled triggers, or API
+        endpoints.
 
-        The automation acts as a bridge between the underlying component (workflow or
-        compliance plan) and the trigger mechanisms that initiate execution.
+        The automation acts as a bridge between the underlying component (workflow,
+        compliance plan, or agent) and the trigger mechanisms that initiate execution.
 
         Args:
             name (str): The name of the automation to create. This name will be
                 used to identify the automation in the Operations Manager.
-            component_type (Literal["workflows", "ucm_compliance_plan"]): The type
-                of component this automation will execute. "workflows" for Automation
-                Studio workflows, "ucm_compliance_plan" for compliance plans.
-            component_name (str | None): The name of the specific component to
+            component_type (Literal["workflows", "ucm_compliance_plan", "agents"]): The
+                type of component this automation will execute. "workflows" for
+                Automation Studio workflows, "ucm_compliance_plan" for compliance plans,
+                "agents" for FlowAgent agents.
+            component_name (str | None): The name or ID of the specific component to
                 associate with this automation. If provided, the method will look up
-                the component ID. Defaults to None.
+                the component ID (for workflows) or set it directly (for agents).
+                Defaults to None.
             description (str | None): Optional description for the automation.
                 Defaults to None.
 
@@ -393,6 +475,10 @@ class Service(ServiceBase):
 
             elif component_type == "ucm_compliance_plan":
                 pass
+
+            elif component_type == "agents":
+                body["componentId"] = component_name
+                body["componentName"] = component_name
 
         res = await self.client.post("/operations-manager/automations", json=body)
 

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -170,6 +170,56 @@ async def get_workflows(
     return models.GetWorkflowsResponse(root=workflow_elements)
 
 
+async def get_agents(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+) -> models.GetAgentsResponse:
+    """
+    Get all agent automations from Itential Platform.
+
+    Agents are AI-driven automation components managed by the Operations Manager.
+    Each agent automation may optionally have an endpoint trigger that exposes it
+    for programmatic invocation via the same mechanism as workflows.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+
+    Returns:
+        models.GetAgentsResponse: List of agent objects with the following fields:
+            - name: Human-readable name of the automation wrapping the agent
+            - description: Description of the agent automation
+            - agent_id: UUID of the underlying agent component
+            - route_name: API route name for triggering (use with trigger_automation);
+              None means no endpoint trigger exists yet — use expose_agent to create one
+            - input_schema: JSON Schema for the endpoint input (None if no endpoint trigger)
+            - last_executed: ISO 8601 timestamp of last endpoint trigger execution
+
+    Notes:
+        - Use agent_id when creating a new automation via create_automation
+        - Use route_name with trigger_automation to trigger an agent that has an endpoint
+        - Agents without a route_name must be exposed first via expose_agent
+    """
+    await ctx.info("inside get_agents(...)")
+    client = ctx.request_context.lifespan_context.get("client")
+    data = await client.operations_manager.get_agents()
+
+    agent_elements = []
+    for item in data:
+        last_executed = None
+        if item.get("last_executed") is not None:
+            last_executed = timeutils.epoch_to_timestamp(item["last_executed"])
+        agent_elements.append(
+            models.AgentElement(
+                name=item["name"],
+                description=item.get("description"),
+                agent_id=item["agent_id"],
+                route_name=item.get("route_name"),
+                input_schema=item.get("input_schema"),
+                last_executed=last_executed,
+            )
+        )
+    return models.GetAgentsResponse(root=agent_elements)
+
+
 async def start_workflow(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     route_name: Annotated[
@@ -183,13 +233,14 @@ async def start_workflow(
             default=None,
         ),
     ],
-) -> models.StartWorkflowResponse:
+) -> models.StartWorkflowResponse | models.StartAgentResponse:
     """
     Execute a workflow by triggering its API endpoint.
 
     Workflows are the core automation processes in Itential Platform. This function
     initiates workflow execution and returns a job object that can be monitored
-    for progress and results.
+    for progress and results. When the triggered route belongs to an agent automation,
+    a StartAgentResponse with a session_id is returned instead.
 
     Args:
         ctx (Context): The FastMCP Context object
@@ -202,19 +253,17 @@ async def start_workflow(
             field from `get_workflows`).
 
     Returns:
-        models.StartWorkflowResponse: Job execution details with the following fields:
-            - object_id: Unique job identifier (use with `describe_job` for monitoring)
-            - name: Workflow name that was executed
-            - description: Workflow description
-            - tasks: Complete set of tasks to be executed in the workflow
-            - status: Current job status (error, complete, running, canceled, incomplete, paused)
-            - metrics: Job execution metrics including start_time, end_time, and user
+        models.StartWorkflowResponse | models.StartAgentResponse: Job execution details
+            or agent session details. If the route triggers an agent, a
+            StartAgentResponse with session_id and status is returned instead of
+            the normal job response.
 
     Notes:
         - Use the returned 'object_id' field with `describe_job` to monitor workflow progress
         - The 'data' parameter must conform to the workflow's input schema
         - Job status can be monitored using the `get_jobs` or `describe_job` functions
         - Workflow schemas are available via the `get_workflows` function
+        - Agent triggers return `StartAgentResponse` with `session_id` instead of a job object
     """
     await ctx.info("inside start_workflow(...)")
 
@@ -247,6 +296,12 @@ async def start_workflow(
             )
 
     res = await client.operations_manager.start_workflow(route_name, data)
+
+    if "sessionId" in res:
+        return models.StartAgentResponse(
+            session_id=res["sessionId"],
+            status=res.get("status", "RUNNING"),
+        )
 
     metrics_data = res.get("metrics") or {}
 
@@ -490,4 +545,89 @@ async def expose_workflow(
 
     return models.ExposeWorkflowResponse(
         message=f"Successfully exposed workflow `{name}` with route `{route_name}`"
+    )
+
+
+async def expose_agent(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    agent_id: Annotated[
+        str, Field(description="UUID of the agent to expose (agent_id from get_agents)")
+    ],
+    automation_name: Annotated[
+        str, Field(description="Name for the automation wrapping the agent")
+    ],
+    route_name: Annotated[
+        str | None,
+        Field(
+            description="API route name; defaults to automation_name with spaces replaced by underscores",
+            default=None,
+        ),
+    ],
+    endpoint_name: Annotated[
+        str | None, Field(description="Name for the trigger endpoint", default=None)
+    ],
+    endpoint_description: Annotated[
+        str | None,
+        Field(description="Description for the endpoint trigger", default=None),
+    ],
+    endpoint_schema: Annotated[
+        dict | None,
+        Field(
+            description="JSON Schema for endpoint input; defaults to open schema",
+            default=None,
+        ),
+    ],
+) -> models.ExposeWorkflowResponse:
+    """Expose an agent as an API endpoint trigger.
+
+    Creates an automation wrapping the specified agent and an endpoint trigger
+    so the agent can be started via trigger_automation using the assigned route_name.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        agent_id (str): UUID of the agent component to expose. Use get_agents to
+            retrieve available agent UUIDs.
+        automation_name (str): Name for the automation that wraps this agent in
+            the Operations Manager.
+        route_name (str | None): API route name for the endpoint. Defaults to
+            automation_name with spaces replaced by underscores.
+        endpoint_name (str | None): Display name for the trigger.
+        endpoint_description (str | None): Description for the trigger.
+        endpoint_schema (dict | None): JSON Schema for trigger input validation.
+            Defaults to an open schema that accepts any object.
+
+    Returns:
+        models.ExposeWorkflowResponse: Status message confirming the operation.
+
+    Raises:
+        exceptions.ConfigurationException: If the endpoint trigger cannot be created.
+        Exception: If the automation cannot be created.
+    """
+    await ctx.info("inside expose_agent(...)")
+    client = ctx.request_context.lifespan_context.get("client")
+
+    res = await client.operations_manager.create_automation(
+        name=automation_name,
+        component_type="agents",
+        component_name=agent_id,
+        description="auto-created by itential-mcp",
+    )
+
+    automation_id = res["_id"]
+    resolved_route = route_name or automation_name.replace(" ", "_")
+
+    try:
+        await client.operations_manager.create_endpoint_trigger(
+            name=endpoint_name or f"API Route for {automation_name}",
+            automation_id=automation_id,
+            description=endpoint_description or "auto-created by itential-mcp",
+            route_name=resolved_route,
+            schema=endpoint_schema,
+        )
+    except Exception as exc:
+        await client.operations_manager.delete_automation(automation_id)
+        raise exceptions.ConfigurationException(f"failed to expose agent: {exc}")
+
+    return models.ExposeWorkflowResponse(
+        message=f"Successfully exposed agent `{agent_id}` as automation `{automation_name}` with route `{resolved_route}`"
     )

--- a/tests/test_models_operations_manager.py
+++ b/tests/test_models_operations_manager.py
@@ -13,6 +13,9 @@ from itential_mcp.models.operations_manager import (
     JobElement,
     GetJobsResponse,
     DescribeJobResponse,
+    StartAgentResponse,
+    AgentElement,
+    GetAgentsResponse,
 )
 
 
@@ -393,3 +396,81 @@ class TestDescribeJobResponse:
         )
 
         assert job_detail.variables is None
+
+
+class TestStartAgentResponse:
+    """Test the StartAgentResponse model"""
+
+    def test_required_fields(self):
+        """Test StartAgentResponse with required fields"""
+        response = StartAgentResponse(session_id="sess-001", status="RUNNING")
+
+        assert response.session_id == "sess-001"
+        assert response.status == "RUNNING"
+
+    def test_complete_status(self):
+        """Test StartAgentResponse with COMPLETE status"""
+        response = StartAgentResponse(session_id="sess-002", status="COMPLETE")
+
+        assert response.session_id == "sess-002"
+        assert response.status == "COMPLETE"
+
+
+class TestAgentElement:
+    """Test the AgentElement model"""
+
+    def test_required_fields_only(self):
+        """Test AgentElement with required fields only"""
+        element = AgentElement(name="Agent")
+
+        assert element.name == "Agent"
+        assert element.description is None
+        assert element.agent_id is None
+        assert element.route_name is None
+        assert element.input_schema is None
+        assert element.last_executed is None
+
+    def test_all_fields(self):
+        """Test AgentElement with all fields populated"""
+        element = AgentElement(
+            name="My Agent",
+            description="An agent automation",
+            agent_id="uuid-agent-001",
+            route_name="my_agent_route",
+            input_schema={"type": "object", "properties": {}},
+            last_executed="2025-01-01T10:00:00Z",
+        )
+
+        assert element.name == "My Agent"
+        assert element.description == "An agent automation"
+        assert element.agent_id == "uuid-agent-001"
+        assert element.route_name == "my_agent_route"
+        assert element.input_schema == {"type": "object", "properties": {}}
+        assert element.last_executed == "2025-01-01T10:00:00Z"
+
+    def test_agent_id_optional(self):
+        """Test AgentElement without agent_id"""
+        element = AgentElement(name="No ID Agent")
+
+        assert element.agent_id is None
+
+
+class TestGetAgentsResponse:
+    """Test the GetAgentsResponse model"""
+
+    def test_empty_default(self):
+        """Test GetAgentsResponse default produces empty list"""
+        response = GetAgentsResponse()
+
+        assert response.root == []
+
+    def test_with_elements(self):
+        """Test GetAgentsResponse with two AgentElements"""
+        element1 = AgentElement(name="Agent One", agent_id="uuid-a")
+        element2 = AgentElement(name="Agent Two", agent_id="uuid-b")
+
+        response = GetAgentsResponse(root=[element1, element2])
+
+        assert len(response.root) == 2
+        assert response.root[0].name == "Agent One"
+        assert response.root[1].name == "Agent Two"

--- a/tests/test_services_operations_manager.py
+++ b/tests/test_services_operations_manager.py
@@ -1675,3 +1675,140 @@ class TestDeleteAutomation:
         service.client.delete.assert_called_once_with(
             "/operations-manager/automations/"
         )
+
+
+class TestGetAgents:
+    """Test the get_agents method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock AsyncPlatform client"""
+        return AsyncMock(spec=AsyncPlatform)
+
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create a Service instance with mock client"""
+        return Service(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_joins_triggers(self, service):
+        """Test get_agents joins triggers to matching automations by _id/actionId"""
+        auto_response = MagicMock()
+        auto_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "auto-uuid-a",
+                    "name": "My Agent Automation",
+                    "description": "Agent desc",
+                    "componentId": "uuid-a",
+                    "componentType": "agents",
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+
+        trigger_response = MagicMock()
+        trigger_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "trigger-1",
+                    "actionId": "auto-uuid-a",
+                    "type": "endpoint",
+                    "routeName": "agent_route",
+                    "schema": {"type": "object"},
+                    "lastExecuted": None,
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+
+        service.client.get = AsyncMock(side_effect=[auto_response, trigger_response])
+
+        result = await service.get_agents()
+
+        assert len(result) == 1
+        assert result[0]["route_name"] == "agent_route"
+        assert result[0]["agent_id"] == "uuid-a"
+        assert result[0]["name"] == "My Agent Automation"
+
+    @pytest.mark.asyncio
+    async def test_skips_no_component_id(self, service):
+        """Test get_agents skips automations with no componentId"""
+        auto_response = MagicMock()
+        auto_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "auto-no-comp",
+                    "name": "No Component Agent",
+                    "description": None,
+                    # no componentId
+                    "componentType": "agents",
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+
+        trigger_response = MagicMock()
+        trigger_response.json.return_value = {
+            "data": [],
+            "metadata": {"total": 0},
+        }
+
+        service.client.get = AsyncMock(side_effect=[auto_response, trigger_response])
+
+        result = await service.get_agents()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_no_matching_trigger_returns_none(self, service):
+        """Test get_agents returns None for route_name when no trigger matches"""
+        auto_response = MagicMock()
+        auto_response.json.return_value = {
+            "data": [
+                {
+                    "_id": "auto-uuid-b",
+                    "name": "Untriggered Agent",
+                    "description": None,
+                    "componentId": "uuid-b",
+                    "componentType": "agents",
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+
+        trigger_response = MagicMock()
+        trigger_response.json.return_value = {
+            "data": [],
+            "metadata": {"total": 0},
+        }
+
+        service.client.get = AsyncMock(side_effect=[auto_response, trigger_response])
+
+        result = await service.get_agents()
+
+        assert len(result) == 1
+        assert result[0]["route_name"] is None
+        assert result[0]["input_schema"] is None
+        assert result[0]["last_executed"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_empty_list(self, service):
+        """Test get_agents returns empty list when there are no agent automations"""
+        auto_response = MagicMock()
+        auto_response.json.return_value = {
+            "data": [],
+            "metadata": {"total": 0},
+        }
+
+        trigger_response = MagicMock()
+        trigger_response.json.return_value = {
+            "data": [],
+            "metadata": {"total": 0},
+        }
+
+        service.client.get = AsyncMock(side_effect=[auto_response, trigger_response])
+
+        result = await service.get_agents()
+
+        assert result == []

--- a/tests/test_tools_operations_manager.py
+++ b/tests/test_tools_operations_manager.py
@@ -30,10 +30,12 @@ class TestModule:
         """Test all expected functions exist in the module"""
         expected_functions = [
             "get_workflows",
+            "get_agents",
             "start_workflow",
             "get_jobs",
             "describe_job",
             "expose_workflow",
+            "expose_agent",
             "_account_id_to_username",
         ]
 
@@ -48,10 +50,12 @@ class TestModule:
         functions_to_test = [
             operations_manager._account_id_to_username,
             operations_manager.get_workflows,
+            operations_manager.get_agents,
             operations_manager.start_workflow,
             operations_manager.get_jobs,
             operations_manager.describe_job,
             operations_manager.expose_workflow,
+            operations_manager.expose_agent,
         ]
 
         for func in functions_to_test:
@@ -1408,3 +1412,215 @@ class TestErrorHandling:
 
         with pytest.raises(Exception, match="Authorization API Error"):
             await operations_manager._account_id_to_username(mock_context, "user-123")
+
+
+class TestGetAgentsTool:
+    """Test the get_agents tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_operations_manager = AsyncMock()
+        mock_client.operations_manager = mock_operations_manager
+
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+
+        return context
+
+    @pytest.mark.asyncio
+    async def test_returns_response(self, mock_context):
+        """Test get_agents returns GetAgentsResponse with one AgentElement"""
+        from itential_mcp.models.operations_manager import GetAgentsResponse
+
+        mock_data = [
+            {
+                "name": "Test Agent",
+                "description": "An agent",
+                "agent_id": "uuid-agent-001",
+                "route_name": "test_agent_route",
+                "input_schema": {"type": "object"},
+                "last_executed": None,
+            }
+        ]
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_agents.return_value = mock_data
+
+        result = await operations_manager.get_agents(mock_context)
+
+        assert isinstance(result, GetAgentsResponse)
+        assert len(result.root) == 1
+        assert result.root[0].name == "Test Agent"
+        assert result.root[0].agent_id == "uuid-agent-001"
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_context):
+        """Test get_agents with empty data returns empty response"""
+        from itential_mcp.models.operations_manager import GetAgentsResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_agents.return_value = []
+
+        result = await operations_manager.get_agents(mock_context)
+
+        assert isinstance(result, GetAgentsResponse)
+        assert len(result.root) == 0
+
+    @pytest.mark.asyncio
+    async def test_epoch_timestamp_converted(self, mock_context):
+        """Test get_agents converts epoch last_executed via timeutils"""
+        mock_data = [
+            {
+                "name": "Timestamped Agent",
+                "description": None,
+                "agent_id": "uuid-ts",
+                "route_name": "ts_route",
+                "input_schema": None,
+                "last_executed": 1640995200000,
+            }
+        ]
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.get_agents.return_value = mock_data
+
+        with patch(
+            "itential_mcp.tools.operations_manager.timeutils.epoch_to_timestamp"
+        ) as mock_timestamp:
+            mock_timestamp.return_value = "2022-01-01T00:00:00Z"
+
+            await operations_manager.get_agents(mock_context)
+
+            mock_timestamp.assert_called_once_with(1640995200000)
+
+
+class TestStartWorkflowAgentBranch:
+    """Test the agent-detection branch in start_workflow"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_operations_manager = AsyncMock()
+        mock_client.operations_manager = mock_operations_manager
+
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+
+        return context
+
+    @pytest.mark.asyncio
+    async def test_returns_start_agent_response(self, mock_context):
+        """Test start_workflow returns StartAgentResponse when response contains sessionId"""
+        from itential_mcp.models.operations_manager import StartAgentResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.start_workflow.return_value = {
+            "sessionId": "sess-xyz",
+            "status": "RUNNING",
+        }
+
+        result = await operations_manager.start_workflow(
+            mock_context, "agent-route", None
+        )
+
+        assert isinstance(result, StartAgentResponse)
+        assert result.session_id == "sess-xyz"
+        assert result.status == "RUNNING"
+
+    @pytest.mark.asyncio
+    async def test_workflow_response_unchanged(self, mock_context):
+        """Test start_workflow returns StartWorkflowResponse for normal job responses"""
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.start_workflow.return_value = {
+            "_id": "job-normal",
+            "name": "Normal Workflow",
+            "tasks": {},
+            "status": "running",
+            "metrics": {},
+        }
+
+        result = await operations_manager.start_workflow(
+            mock_context, "workflow-route", None
+        )
+
+        assert isinstance(result, StartWorkflowResponse)
+        assert result.object_id == "job-normal"
+
+
+class TestExposeAgentTool:
+    """Test the expose_agent tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.info = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_operations_manager = AsyncMock()
+        mock_client.operations_manager = mock_operations_manager
+
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+
+        return context
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_context):
+        """Test expose_agent creates automation and trigger, returns ExposeWorkflowResponse"""
+        from itential_mcp.models.operations_manager import ExposeWorkflowResponse
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.create_automation.return_value = {
+            "_id": "auto-1"
+        }
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.create_endpoint_trigger.return_value = {
+            "_id": "trigger-1"
+        }
+
+        result = await operations_manager.expose_agent(
+            mock_context,
+            agent_id="uuid-agent-001",
+            automation_name="My Agent Automation",
+            route_name=None,
+            endpoint_name=None,
+            endpoint_description=None,
+            endpoint_schema=None,
+        )
+
+        assert isinstance(result, ExposeWorkflowResponse)
+        assert "uuid-agent-001" in result.message
+        assert "My Agent Automation" in result.message
+
+    @pytest.mark.asyncio
+    async def test_trigger_failure_rolls_back(self, mock_context):
+        """Test expose_agent deletes automation when trigger creation fails"""
+        from itential_mcp.core.exceptions import ConfigurationException
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.create_automation.return_value = {
+            "_id": "auto-rollback"
+        }
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.create_endpoint_trigger.side_effect = Exception(
+            "trigger failed"
+        )
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.delete_automation.return_value = {
+            "message": "deleted"
+        }
+
+        with pytest.raises(ConfigurationException, match="failed to expose agent"):
+            await operations_manager.expose_agent(
+                mock_context,
+                agent_id="uuid-agent-fail",
+                automation_name="Failing Agent",
+                route_name=None,
+                endpoint_name=None,
+                endpoint_description=None,
+                endpoint_schema=None,
+            )
+
+        mock_context.request_context.lifespan_context.get.return_value.operations_manager.delete_automation.assert_called_once_with(
+            "auto-rollback"
+        )


### PR DESCRIPTION
## Summary

- Adds `get_agents` tool — lists all agent-type automations from Operations Manager, joined with their endpoint triggers to surface `route_name` and `input_schema` in a single response
- Adds `expose_agent` tool — creates an automation wrapping an agent UUID and an endpoint trigger, with rollback on failure
- Updates `start_workflow` to detect agent session responses (`sessionId` key) and return `StartAgentResponse` instead of attempting to parse a job object
- Extends `create_automation` service to accept `agents` component type
- New models: `StartAgentResponse`, `AgentElement`, `GetAgentsResponse`
- Full test coverage: model, service, and tool layers

## Dependencies

None — standalone off `devel`.

## Notes

This is PR 2 of 3:
- **PR 1** (#354): `agent_session_manager` module — session listing and detail
- **PR 2 (this)**: agent automation support in `operations_manager`
- **PR 3**: `trigger_automation` + `get_automations`

## Test plan

- [ ] `make ci` passes
- [ ] `get_agents` returns agent automations with joined trigger metadata
- [ ] `expose_agent` creates automation + trigger, rolls back on trigger failure
- [ ] `start_workflow` with an agent route returns `StartAgentResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)