### PR TITLE
fix: add future annotations import and pagination test coverage for get_automations

### DIFF
--- a/src/itential_mcp/platform/services/agent_session_manager.py
+++ b/src/itential_mcp/platform/services/agent_session_manager.py
@@ -2,6 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 from itential_mcp.platform.services import ServiceBase
 
 

--- a/src/itential_mcp/platform/services/operations_manager.py
+++ b/src/itential_mcp/platform/services/operations_manager.py
@@ -2,6 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 from typing import Literal, Mapping, Any
 
 from itential_mcp.core import exceptions

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from typing import Annotated
 
 from pydantic import Field
@@ -119,8 +121,10 @@ async def describe_session(
 
     client = ctx.request_context.lifespan_context.get("client")
 
-    session = await client.agent_session_manager.get_session(session_id)
-    raw_messages = await client.agent_session_manager.get_session_messages(session_id)
+    session, raw_messages = await asyncio.gather(
+        client.agent_session_manager.get_session(session_id),
+        client.agent_session_manager.get_session_messages(session_id),
+    )
 
     agent_snapshot = session.get("agentSnapshot") or {}
     agent_name = agent_snapshot.get("name")

--- a/tests/test_services_operations_manager.py
+++ b/tests/test_services_operations_manager.py
@@ -1974,3 +1974,152 @@ class TestGetAutomations:
         assert len(result) == 1
         assert result[0]["component_type"] == "ucm_compliance_plan"
         assert result[0]["name"] == "Compliance Plan Auto"
+
+    @pytest.mark.asyncio
+    async def test_paginates_automations_across_multiple_pages(self, service):
+        """get_automations fetches subsequent pages when total exceeds one page of results"""
+        automation_id_1 = "auto-id-1"
+        automation_id_2 = "auto-id-2"
+
+        mock_automations_page_1 = MagicMock()
+        mock_automations_page_1.json.return_value = {
+            "data": [
+                {
+                    "_id": automation_id_1,
+                    "name": "Workflow Auto",
+                    "description": "A workflow automation",
+                    "componentType": "workflows",
+                    "componentId": "wf-comp-1",
+                }
+            ],
+            "metadata": {"total": 2},
+        }
+
+        mock_automations_page_2 = MagicMock()
+        mock_automations_page_2.json.return_value = {
+            "data": [
+                {
+                    "_id": automation_id_2,
+                    "name": "Agent Auto",
+                    "description": None,
+                    "componentType": "agents",
+                    "componentId": "agent-comp-2",
+                }
+            ],
+            "metadata": {"total": 2},
+        }
+
+        mock_triggers_response = MagicMock()
+        mock_triggers_response.json.return_value = {
+            "data": [
+                {
+                    "actionId": automation_id_1,
+                    "routeName": "workflow-auto-route",
+                    "schema": {"type": "object", "properties": {}},
+                    "lastExecuted": None,
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+
+        service.client.get = AsyncMock(
+            side_effect=[
+                mock_automations_page_1,
+                mock_automations_page_2,
+                mock_triggers_response,
+            ]
+        )
+
+        result = await service.get_automations()
+
+        assert len(result) == 2
+
+        # Verify automations required two paginated calls, plus one for triggers
+        assert service.client.get.call_count == 3
+
+        first_call = service.client.get.call_args_list[0]
+        assert first_call[0] == ("/operations-manager/automations",)
+        assert first_call[1]["params"]["skip"] == 0
+
+        second_call = service.client.get.call_args_list[1]
+        assert second_call[0] == ("/operations-manager/automations",)
+        assert second_call[1]["params"]["skip"] == 100
+
+        matched = next(r for r in result if r["name"] == "Workflow Auto")
+        assert matched["route_name"] == "workflow-auto-route"
+        assert matched["input_schema"] == {"type": "object", "properties": {}}
+
+        unmatched = next(r for r in result if r["name"] == "Agent Auto")
+        assert unmatched["route_name"] is None
+        assert unmatched["input_schema"] is None
+
+    @pytest.mark.asyncio
+    async def test_paginates_triggers_across_multiple_pages(self, service):
+        """get_automations fetches subsequent trigger pages when total exceeds one page"""
+        automation_id_1 = "auto-id-1"
+
+        mock_automations_response = MagicMock()
+        mock_automations_response.json.return_value = {
+            "data": [
+                {
+                    "_id": automation_id_1,
+                    "name": "Workflow Auto",
+                    "description": "A workflow automation",
+                    "componentType": "workflows",
+                    "componentId": "wf-comp-1",
+                }
+            ],
+            "metadata": {"total": 1},
+        }
+
+        mock_triggers_page_1 = MagicMock()
+        mock_triggers_page_1.json.return_value = {
+            "data": [
+                {
+                    "actionId": "unrelated-automation",
+                    "routeName": "unrelated-route",
+                    "schema": {"type": "object", "properties": {}},
+                    "lastExecuted": None,
+                }
+            ],
+            "metadata": {"total": 101},
+        }
+
+        mock_triggers_page_2 = MagicMock()
+        mock_triggers_page_2.json.return_value = {
+            "data": [
+                {
+                    "actionId": automation_id_1,
+                    "routeName": "workflow-auto-route",
+                    "schema": {"type": "object", "properties": {}},
+                    "lastExecuted": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "metadata": {"total": 101},
+        }
+
+        service.client.get = AsyncMock(
+            side_effect=[
+                mock_automations_response,
+                mock_triggers_page_1,
+                mock_triggers_page_2,
+            ]
+        )
+
+        result = await service.get_automations()
+
+        assert len(result) == 1
+
+        # Verify triggers required two paginated calls, plus one for automations
+        assert service.client.get.call_count == 3
+
+        second_call = service.client.get.call_args_list[1]
+        assert second_call[0] == ("/operations-manager/triggers",)
+        assert second_call[1]["params"]["skip"] == 0
+
+        third_call = service.client.get.call_args_list[2]
+        assert third_call[0] == ("/operations-manager/triggers",)
+        assert third_call[1]["params"]["skip"] == 100
+
+        assert result[0]["route_name"] == "workflow-auto-route"
+        assert result[0]["last_executed"] == "2026-01-01T00:00:00Z"


### PR DESCRIPTION
## Summary
- Adds the missing `from __future__ import annotations` to `platform/services/operations_manager.py` and `platform/services/agent_session_manager.py` (pre-existing gaps, this repo's convention per CLAUDE.md; both files were heavily touched by the 0.13.0 trigger/agent-automation PRs, so fixing now).
- Adds two pagination tests to `TestGetAutomations` covering the automations-fetch loop and the triggers-fetch loop in `get_automations`, both previously untested code paths.
- Parallelizes the two independent awaited calls in `agent_session_manager.describe_session` (`get_session` + `get_session_messages`) via `asyncio.gather()`, matching the established pattern elsewhere in the codebase (e.g. `tools/health.py`).

Follow-up from `code-quality-validator`'s review of #356 and a whole-devel quality pass after #354/#355/#356 merged — all non-blocking but agreed to land before the 0.13.0 tag.

## Test plan
- [x] `make ci` (format, lint, headers, bandit, full test suite — 2496 passed) run clean on this branch
