### PR TITLE
fix: handle union return types in tool output schema generation

### DIFF
--- a/src/itential_mcp/server/server.py
+++ b/src/itential_mcp/server/server.py
@@ -209,7 +209,15 @@ class Server:
 
                 try:
                     schema = toolutils.get_json_schema(f)
-                    if schema["type"] == "object":
+
+                    # The MCP spec requires an outputSchema to be an object
+                    # type at the root. Return types that are a Union of
+                    # BaseModel subclasses produce a top-level `anyOf`
+                    # schema instead, which FastMCP itself rejects as a
+                    # custom output_schema. In that case, omit
+                    # output_schema entirely and let FastMCP infer and
+                    # wrap the schema directly from the return annotation.
+                    if schema.get("type") == "object":
                         kwargs["output_schema"] = schema
 
                 except ValueError:

--- a/src/itential_mcp/utilities/tool.py
+++ b/src/itential_mcp/utilities/tool.py
@@ -2,15 +2,18 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import os
 import inspect
 import pathlib
 import importlib.util
+import types
 
-from typing import Any, Callable, Iterator, Tuple, Sequence
-from typing import get_type_hints
+from typing import Any, Callable, Iterator, Tuple, Sequence, Union
+from typing import get_type_hints, get_origin, get_args
 
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from ..cli import terminal
 
@@ -51,25 +54,43 @@ def tags(*tag_list) -> Callable:
     return decorator
 
 
-def get_json_schema(fn: Callable) -> str:
+def get_json_schema(fn: Callable) -> dict[str, Any]:
     """
     Extract JSON schema from a function's return type annotation.
 
     This function analyzes a function's type hints to extract the JSON schema
-    from the return type. The return type must be a Pydantic BaseModel subclass
-    for schema generation to work properly.
+    from the return type. The return type must either be a Pydantic BaseModel
+    subclass, or a Union (`X | Y` / `typing.Union[X, Y]`) whose members are all
+    Pydantic BaseModel subclasses, for schema generation to work properly.
 
     Args:
         fn (Callable): The function to extract the JSON schema from
 
     Returns:
-        str: The JSON schema as a string representation
+        dict[str, Any]: The JSON schema as a dictionary
 
     Raises:
         ValueError: If the function's return type is not a BaseModel subclass
+            and not a Union of BaseModel subclasses
     """
     hints = get_type_hints(fn)
     ret = hints.get("return", Any)
+
+    origin = get_origin(ret)
+
+    # Handle a Union (`X | Y` or `typing.Union[X, Y]`) of BaseModel subclasses
+    if origin is types.UnionType or origin is Union:
+        members = get_args(ret)
+        if not members or not all(
+            inspect.isclass(member) and issubclass(member, BaseModel)
+            for member in members
+        ):
+            raise ValueError(
+                "tool functions must subclass BaseModel or return a union of "
+                "BaseModel subclasses"
+            )
+
+        return TypeAdapter(ret).json_schema()
 
     # Check if ret is actually a class before using issubclass
     if not inspect.isclass(ret) or not issubclass(ret, BaseModel):

--- a/tests/utilities/test_tool.py
+++ b/tests/utilities/test_tool.py
@@ -2,12 +2,111 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import os
 import tempfile
 import pytest
 from unittest.mock import patch, MagicMock
 
-from itential_mcp.utilities.tool import tags, itertools, display_tools, display_tags
+from typing import Union
+
+from pydantic import BaseModel
+
+from itential_mcp.utilities.tool import (
+    tags,
+    itertools,
+    display_tools,
+    display_tags,
+    get_json_schema,
+)
+
+
+class _SchemaModelA(BaseModel):
+    """Simple BaseModel used to test get_json_schema regression behavior."""
+
+    a: str
+
+
+class _SchemaModelB(BaseModel):
+    """Second BaseModel used to test get_json_schema union handling."""
+
+    b: int
+
+
+class TestGetJsonSchema:
+    """Test the get_json_schema function"""
+
+    def test_get_json_schema_with_basemodel(self):
+        """A plain BaseModel return annotation should produce an object schema"""
+
+        def fn() -> _SchemaModelA:
+            return _SchemaModelA(a="x")
+
+        schema = get_json_schema(fn)
+
+        assert schema["type"] == "object"
+        assert "a" in schema["properties"]
+
+    def test_get_json_schema_with_union_of_basemodels_pipe_syntax(self):
+        """A `X | Y` union of BaseModel subclasses should produce a valid
+        schema instead of raising ValueError"""
+
+        def fn() -> _SchemaModelA | _SchemaModelB:
+            return _SchemaModelA(a="x")
+
+        schema = get_json_schema(fn)
+
+        assert "anyOf" in schema
+        assert len(schema["anyOf"]) == 2
+
+    def test_get_json_schema_with_typing_union_of_basemodels(self):
+        """A typing.Union of BaseModel subclasses should produce a valid
+        schema instead of raising ValueError"""
+
+        def fn() -> Union[_SchemaModelA, _SchemaModelB]:
+            return _SchemaModelA(a="x")
+
+        schema = get_json_schema(fn)
+
+        assert "anyOf" in schema
+        assert len(schema["anyOf"]) == 2
+
+    def test_get_json_schema_with_non_basemodel_raises(self):
+        """A return annotation that is not a BaseModel should raise ValueError"""
+
+        def fn() -> dict:
+            return {}
+
+        with pytest.raises(ValueError):
+            get_json_schema(fn)
+
+    def test_get_json_schema_with_union_of_non_basemodels_raises(self):
+        """A union of non-BaseModel types should raise ValueError"""
+
+        def fn() -> int | str:
+            return 1
+
+        with pytest.raises(ValueError):
+            get_json_schema(fn)
+
+    def test_get_json_schema_operations_manager_trigger_automation(self):
+        """Regression test: trigger_automation's union return type must
+        produce a valid schema without raising"""
+        from itential_mcp.tools import operations_manager
+
+        schema = get_json_schema(operations_manager.trigger_automation)
+
+        assert "anyOf" in schema
+
+    def test_get_json_schema_operations_manager_start_workflow(self):
+        """Regression test: start_workflow's union return type must
+        produce a valid schema without raising"""
+        from itential_mcp.tools import operations_manager
+
+        schema = get_json_schema(operations_manager.start_workflow)
+
+        assert "anyOf" in schema
 
 
 class TestTagsDecorator:


### PR DESCRIPTION
## Summary
- Fixes `get_json_schema()` in `utilities/tool.py` to handle `Union`/`X | Y` return-type annotations of Pydantic `BaseModel` subclasses (via `TypeAdapter`), not just a single `BaseModel` class.
- Fixes the caller in `server.py`'s `__init_tools__` to correctly omit `output_schema` when the derived schema is `anyOf`-shaped (no top-level `type`), letting FastMCP infer/wrap the schema itself — passing a raw `anyOf` schema through as an explicit `output_schema` is rejected by FastMCP outright.

Found live during integration-tester's end-to-end pass for the 0.13.0 release: `trigger_automation` and `start_workflow` (both returning `StartWorkflowResponse | StartAgentResponse`) were logging `"tool X has a missing or invalid output_schema"` at startup and registering with no output schema at all, because `get_json_schema()` only recognized a plain `BaseModel` class. Verified against the pinned `fastmcp==2.14.2` that when `output_schema` is omitted, FastMCP already infers and correctly wraps a union-typed return — so the real bug was the spurious exception/warning and the resulting inconsistency, not a functional runtime gap.

## Test plan
- [x] `make ci` (format, lint, headers, bandit, full test suite — 2503 passed, up from 2496) run clean on this branch
- [x] New tests cover both `X | Y` and `typing.Union[X, Y]` syntax, the BaseModel regression path, and negative cases (non-BaseModel members still raise)
- [x] Direct regression check against the real `operations_manager.trigger_automation` / `start_workflow` functions confirms no exception and a valid schema
