### PR TITLE
chore: pin fastmcp dependency and declare MCP protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/itential/itential-mcp)
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen)](https://github.com/itential/itential-mcp)
+[![MCP Protocol](https://img.shields.io/badge/MCP_Protocol-2025--11--25-blue)](https://modelcontextprotocol.io/specification/2025-11-25)
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "itential-mcp"
 description = "Itential MCP Server"
 
 dependencies = [
-    "fastmcp",
+    "fastmcp>=3.0.2,<4",
     "ipsdk>=0.7.0",
     "python-toon",
     "wsproto",

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp" },
+    { name = "fastmcp", specifier = ">=3.0.2,<4" },
     { name = "ipsdk", specifier = ">=0.7.0" },
     { name = "python-toon" },
     { name = "wsproto" },


### PR DESCRIPTION
## Summary
- Pin `fastmcp` to `>=3.0.2,<4` in `pyproject.toml` so the inherited MCP `2025-11-25` protocol claim is reproducible (no fresh install can silently resolve a FastMCP major with different protocol behavior).
- Regenerate `uv.lock` — no-op resolution change, already locked at `3.0.2`.
- Add an MCP Protocol `2025-11-25` badge to the README, linked to the spec.

This is WI-1 of the MCP `2025-11-25` compliance plan (first item in a sequential dependency/security-fix queue being worked one item at a time).

## Test plan
- [x] `make ci` — 2503 passed, coverage held at 99%
- [x] ruff / bandit / header checks clean
- [x] `uv lock --check` confirms lockfile consistency
- [x] README badge link verified live (200)
- Integration testing intentionally not run — no `.py` files changed, no tool registration or return-type changes, zero runtime-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)