### PR TITLE
chore: demote entry-trace log calls to debug level

### DIFF
--- a/src/itential_mcp/tools/adapters.py
+++ b/src/itential_mcp/tools/adapters.py
@@ -27,7 +27,7 @@ async def get_adapters(
         GetAdaptersResponse: Response object that provides the list of
             configured adapters from the server
     """
-    await ctx.info("inside get_adapters(...)")
+    await ctx.debug("inside get_adapters(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -81,7 +81,7 @@ async def start_adapter(
         - Adapter name is case-sensitive
         - Function polls adapter state every second until timeout
     """
-    await ctx.info("inside start_adapter(...)")
+    await ctx.debug("inside start_adapter(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.adapters.start_adapter(name=name, timeout=timeout)
     return models.StartAdapterResponse(name=data["id"], state=data["state"])
@@ -119,7 +119,7 @@ async def stop_adapter(
         - Adapter name is case-sensitive
         - Function polls adapter state every second until timeout
     """
-    await ctx.info("inside stop_adapter(...)")
+    await ctx.debug("inside stop_adapter(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.adapters.stop_adapter(name=name, timeout=timeout)
     return models.StopAdapterResponse(name=data["id"], state=data["state"])
@@ -158,7 +158,7 @@ async def restart_adapter(
         - For STOPPED adapters, use `start_adapter` instead
         - Function polls adapter state every second until timeout
     """
-    await ctx.info("inside restart_adapter(...)")
+    await ctx.debug("inside restart_adapter(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.adapters.restart_adapter(name=name, timeout=timeout)
     return models.RestartAdapterResponse(name=data["id"], state=data["state"])

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -54,7 +54,7 @@ async def get_sessions(
         - Use describe_session with a session_id to get the full event log and output
         - Timestamps are converted from epoch milliseconds to ISO 8601 format
     """
-    await ctx.info("inside get_sessions(...)")
+    await ctx.debug("inside get_sessions(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -117,7 +117,7 @@ async def describe_session(
         - The output field is extracted from the inference-succeeded event message
         - Message timestamps are converted from epoch milliseconds to ISO 8601 format
     """
-    await ctx.info("inside describe_session(...)")
+    await ctx.debug("inside describe_session(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/applications.py
+++ b/src/itential_mcp/tools/applications.py
@@ -30,7 +30,7 @@ async def get_applications(
     Raises:
         Exception: If there is an error retrieving applications from the platform
     """
-    await ctx.info("inside get_applications(...)")
+    await ctx.debug("inside get_applications(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -86,7 +86,7 @@ async def start_application(
         - Application name is case-sensitive
         - Function polls application state every second until timeout
     """
-    await ctx.info("inside start_application(...)")
+    await ctx.debug("inside start_application(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.applications.start_application(name, timeout)
     return models.StartApplicationResponse(name=data["id"], state=data["state"])
@@ -124,7 +124,7 @@ async def stop_application(
         - Application name is case-sensitive
         - Function polls application state every second until timeout
     """
-    await ctx.info("inside stop_application(...)")
+    await ctx.debug("inside stop_application(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.applications.stop_application(name=name, timeout=timeout)
     return models.StopApplicationResponse(name=data["id"], state=data["state"])
@@ -163,7 +163,7 @@ async def restart_application(
         - For STOPPED applications, use `start_application` instead
         - Function polls application state every second until timeout
     """
-    await ctx.info("inside restart_application(...)")
+    await ctx.debug("inside restart_application(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.applications.restart_application(name=name, timeout=timeout)
     return models.RestartApplicationResponse(name=data["id"], state=data["state"])

--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -32,7 +32,7 @@ async def get_command_templates(
     Raises:
         Exception: If there is an error retrieving command templates from the platform
     """
-    await ctx.info("inside get_command_templates(...)")
+    await ctx.debug("inside get_command_templates(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -76,7 +76,7 @@ async def describe_command_template(
     Raises:
         Exception: If there is an error retrieving the command template or template is not found
     """
-    await ctx.info("inside describe_command_template(...)")
+    await ctx.debug("inside describe_command_template(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -121,7 +121,7 @@ async def run_command_template(
     Raises:
         Exception: If there is an error running the command template or template is not found
     """
-    await ctx.info("inside run_command_templates(...)")
+    await ctx.debug("inside run_command_templates(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -179,7 +179,7 @@ async def run_command(
     Raises:
         Exception: If there is an error running the command on the devices
     """
-    await ctx.info("inside run_command(...)")
+    await ctx.debug("inside run_command(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -321,7 +321,7 @@ async def create_command_template(
             }
         ]
     """
-    await ctx.info("inside create_command_template(...)")
+    await ctx.debug("inside create_command_template(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -465,7 +465,7 @@ async def update_command_template(
             }
         ]
     """
-    await ctx.info("inside update_command_template(...)")
+    await ctx.debug("inside update_command_template(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/compliance_plans.py
+++ b/src/itential_mcp/tools/compliance_plans.py
@@ -32,7 +32,7 @@ async def get_compliance_plans(
     Raises:
         Exception: If there is an error retrieving compliance plans from the platform
     """
-    await ctx.info("inside get_compliance_plans(...)")
+    await ctx.debug("inside get_compliance_plans(...)")
     client = ctx.request_context.lifespan_context.get("client")
     results = await client.configuration_manager.get_compliance_plans()
     return models.GetCompliancePlansResponse(plans=results)
@@ -59,7 +59,7 @@ async def run_compliance_plan(
     Raises:
         ValueError: If the specified compliance plan name is not found
     """
-    await ctx.info("inside run_compliance_plan(...)")
+    await ctx.debug("inside run_compliance_plan(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.configuration_manager.run_compliance_plan(name=name)
     compliance_instance = models.CompliancePlanInstance(

--- a/src/itential_mcp/tools/compliance_reports.py
+++ b/src/itential_mcp/tools/compliance_reports.py
@@ -37,7 +37,7 @@ async def describe_compliance_report(
     Raises:
         Exception: If there is an error retrieving the compliance report or the report ID is not found
     """
-    await ctx.info("inside describe_compliance_report(...)")
+    await ctx.debug("inside describe_compliance_report(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.configuration_manager.describe_compliance_report(report_id)
     return models.DescribeComplianceReportResponse(result=res)

--- a/src/itential_mcp/tools/configuration_manager.py
+++ b/src/itential_mcp/tools/configuration_manager.py
@@ -44,7 +44,7 @@ async def render_template(
     Raises:
         Exception: If there is an error rendering the template
     """
-    await ctx.info("inside render_template()")
+    await ctx.debug("inside render_template()")
     client = ctx.request_context.lifespan_context.get("client")
 
     # Parse variables if it's a JSON string

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -37,7 +37,7 @@ async def get_device_groups(
     Raises:
         Exception: If there is an error retrieving device groups from the platform
     """
-    await ctx.info("inside get_device_groups(...)")
+    await ctx.debug("inside get_device_groups(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -82,7 +82,7 @@ async def create_device_group(
     Raises:
         ValueError: If a device group with the same name already exists
     """
-    await ctx.info("inside create_device_group(...)")
+    await ctx.debug("inside create_device_group(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -135,7 +135,7 @@ async def add_devices_to_group(
         Exception: If there is an error adding devices to the group
 
     """
-    await ctx.info("inside add_devices_to_group(...)")
+    await ctx.debug("inside add_devices_to_group(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -184,7 +184,7 @@ async def remove_devices_from_group(
     Raises:
         Exception: If there is an error removing devices from the group
     """
-    await ctx.info("inside remove_devices_from_group(...)")
+    await ctx.debug("inside remove_devices_from_group(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -33,7 +33,7 @@ async def get_devices(
     Raises:
         Exception: If there is an error retrieving devices from the platform
     """
-    await ctx.info("inside get_devices(...)")
+    await ctx.debug("inside get_devices(...)")
     client = ctx.request_context.lifespan_context.get("client")
     results = await client.configuration_manager.get_devices()
     return models.GetDevicesResponse(results)
@@ -59,7 +59,7 @@ async def get_device_configuration(
     Raises:
         ValueError: If there is an error retrieving the configuration or device is not found
     """
-    await ctx.info("inside get_device_configuration(...)")
+    await ctx.debug("inside get_device_configuration(...)")
     client = ctx.request_context.lifespan_context.get("client")
     return await client.configuration_manager.get_device_configuration(name)
 
@@ -96,7 +96,7 @@ async def backup_device_configuration(
     Raises:
         Exception: If there is an error creating the device configuration backup
     """
-    await ctx.info("inside backup_device_configuration(...)")
+    await ctx.debug("inside backup_device_configuration(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.configuration_manager.backup_device_configuration(
         name=name, description=description, notes=notes
@@ -130,7 +130,7 @@ async def apply_device_configuration(
     Raises:
         Exception: If there is an error applying the configuration to the device
     """
-    await ctx.info("inside apply_device_configuration(...)")
+    await ctx.debug("inside apply_device_configuration(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.configuration_manager.apply_device_configuration(
         device=device, config=config

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -37,7 +37,7 @@ async def get_services(
     Raises:
         Exception: If there is an error retrieving services from Gateway Manager
     """
-    await ctx.info("inside get_services(...)")
+    await ctx.debug("inside get_services(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -79,7 +79,7 @@ async def get_gateways(
     Raises:
         Exception: If there is an error retrieving gateways from Gateway Manager
     """
-    await ctx.info("inside get_gateways(...)")
+    await ctx.debug("inside get_gateways(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -148,7 +148,7 @@ async def run_service(
     Raises:
         Exception: If there is an error running the service on Gateway Manager
     """
-    await ctx.info("inside run_service(...)")
+    await ctx.debug("inside run_service(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/golden_config.py
+++ b/src/itential_mcp/tools/golden_config.py
@@ -41,7 +41,7 @@ async def get_golden_config_trees(
     Raises:
         None: This function does not raise any exceptions
     """
-    await ctx.info("inside get_golden_config_trees(...)")
+    await ctx.debug("inside get_golden_config_trees(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -105,7 +105,7 @@ async def create_golden_config_tree(
     Raises:
         ServerException: If there is an error creating the Golden Configuration tree
     """
-    await ctx.info("inside create_golden_config_tree(...)")
+    await ctx.debug("inside create_golden_config_tree(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -169,7 +169,7 @@ async def add_golden_config_node(
     Raises:
         ServerException: If there is an error adding the node to the Golden Configuration tree
     """
-    await ctx.info("inside add_golden_config_node(...)")
+    await ctx.debug("inside add_golden_config_node(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/health.py
+++ b/src/itential_mcp/tools/health.py
@@ -47,7 +47,7 @@ async def get_health(
         Exception: If there is an error retrieving health information from
             any platform component
     """
-    await ctx.info("inside get_health(...)")
+    await ctx.debug("inside get_health(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/integrations.py
+++ b/src/itential_mcp/tools/integrations.py
@@ -47,7 +47,7 @@ async def get_integrations(
     Raises:
         Exception: If there is an error retrieving integrations from the platform
     """
-    await ctx.info("inside get_integrations(...)")
+    await ctx.debug("inside get_integrations(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -87,7 +87,7 @@ async def get_integration_models(
             - version: Model version from the OpenAPI spec info block
             - description: Optional model description
     """
-    await ctx.info("inside get_integration_models(...)")
+    await ctx.debug("inside get_integration_models(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -135,7 +135,7 @@ async def create_integration_model(
         - Model identifier is derived from title:version in the OpenAPI spec info block
         - OpenAPI specification is validated before creation
     """
-    await ctx.info("inside create_integration_model(...)")
+    await ctx.debug("inside create_integration_model(...)")
 
     model_id = f"{model['info']['title']}:{model['info']['version']}"
 

--- a/src/itential_mcp/tools/inventory_manager.py
+++ b/src/itential_mcp/tools/inventory_manager.py
@@ -38,7 +38,7 @@ async def get_inventories(
     Raises:
         Exception: If there is an error retrieving inventories from the platform
     """
-    await ctx.info("inside get_inventories(...)")
+    await ctx.debug("inside get_inventories(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -81,7 +81,7 @@ async def describe_inventory(
     Raises:
         NotFoundError: If the specified inventory name cannot be found
     """
-    await ctx.info("inside describe_inventory(...)")
+    await ctx.debug("inside describe_inventory(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -142,7 +142,7 @@ async def create_inventory(
     Raises:
         ValueError: If an inventory with the same name already exists
     """
-    await ctx.info("inside create_inventory(...)")
+    await ctx.debug("inside create_inventory(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -203,7 +203,7 @@ async def add_nodes_to_inventory(
         NotFoundError: If the specified inventory name cannot be found
         Exception: If there is an error adding nodes to the inventory
     """
-    await ctx.info("inside add_nodes_to_inventory(...)")
+    await ctx.debug("inside add_nodes_to_inventory(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -242,7 +242,7 @@ async def delete_inventory(
     Raises:
         NotFoundError: If the specified inventory name cannot be found
     """
-    await ctx.info("inside delete_inventory(...)")
+    await ctx.debug("inside delete_inventory(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -37,7 +37,7 @@ async def get_resources(
             - name: Resource model name
             - description: Resource model description
     """
-    await ctx.info("inside get_resources(...)")
+    await ctx.debug("inside get_resources(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -94,7 +94,7 @@ async def create_resource(
         - Metadata fields like $schema, title should be passed as separate parameters
         - Resource models enable structured lifecycle management of network services
     """
-    await ctx.info("inside create_resource(...)")
+    await ctx.debug("inside create_resource(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -136,7 +136,7 @@ async def describe_resource(
             - type: The type of action (CREATE, UPDATE, DELETE)
             - input_schema: The input schema required to execute the action
     """
-    await ctx.info("inside describe_resource(...)")
+    await ctx.debug("inside describe_resource(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -214,7 +214,7 @@ async def get_instances(
             - instance_data: Data object associated with this instance
             - last_action: Last lifecycle action performed on the instance
     """
-    await ctx.info("inside get_instances(...)")
+    await ctx.debug("inside get_instances(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -271,7 +271,7 @@ async def describe_instance(
     Raises:
         NotFoundError: If the named instance cannot be found on the server
     """
-    await ctx.info("inside describe_instance(...)")
+    await ctx.debug("inside describe_instance(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -338,7 +338,7 @@ async def run_action(
         NotFoundError: If a resource, instance or action could not be found on
             the server
     """
-    await ctx.info("inside run_action(...)")
+    await ctx.debug("inside run_action(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -417,7 +417,7 @@ async def get_action_executions(
         # Get executions for both resource and instance
         get_action_executions(ctx, resource_name="MyResource", instance_name="prod")
     """
-    await ctx.info("inside get_action_executions(...)")
+    await ctx.debug("inside get_action_executions(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -142,7 +142,7 @@ async def get_workflows(
         - The 'input_schema' field defines required input parameters for workflow execution
         - Only enabled workflows are returned by this function
     """
-    await ctx.info("inside get_workflows(...)")
+    await ctx.debug("inside get_workflows(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -198,7 +198,7 @@ async def get_agents(
         - Use route_name with trigger_automation to trigger an agent that has an endpoint
         - Agents without a route_name must be exposed first via expose_agent
     """
-    await ctx.info("inside get_agents(...)")
+    await ctx.debug("inside get_agents(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.operations_manager.get_agents()
 
@@ -251,7 +251,7 @@ async def get_automations(
         - Use trigger_automation with route_name to execute an automation
         - Use expose_workflow if route_name is None for a workflow automation
     """
-    await ctx.info("inside get_automations(...)")
+    await ctx.debug("inside get_automations(...)")
     client = ctx.request_context.lifespan_context.get("client")
     data = await client.operations_manager.get_automations()
 
@@ -321,7 +321,7 @@ async def trigger_automation(
         - Use describe_session with session_id to monitor agent execution progress
         - Use expose_workflow first if the automation has no route_name
     """
-    await ctx.info("inside trigger_automation(...)")
+    await ctx.debug("inside trigger_automation(...)")
     client = ctx.request_context.lifespan_context.get("client")
 
     if isinstance(data, str):
@@ -441,7 +441,7 @@ async def get_jobs(
             - name: Job name
             - status: Current job status (error, complete, running, cancelled, incomplete, paused)
     """
-    await ctx.info("running get_jobs(...)")
+    await ctx.debug("running get_jobs(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -491,7 +491,7 @@ async def describe_job(
             - updated: Last update timestamp
             - variables: Job variable outputs produced during workflow execution
     """
-    await ctx.info("inside describe_job(...)")
+    await ctx.debug("inside describe_job(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -580,7 +580,7 @@ async def expose_workflow(
         Exception: If there is an error retrieving workflow information or
             creating the automation.
     """
-    await ctx.info("inside expose_workflow(...)")
+    await ctx.debug("inside expose_workflow(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 
@@ -678,7 +678,7 @@ async def expose_agent(
         exceptions.ConfigurationException: If the endpoint trigger cannot be created.
         Exception: If the automation cannot be created.
     """
-    await ctx.info("inside expose_agent(...)")
+    await ctx.debug("inside expose_agent(...)")
     client = ctx.request_context.lifespan_context.get("client")
 
     res = await client.operations_manager.create_automation(

--- a/src/itential_mcp/tools/projects.py
+++ b/src/itential_mcp/tools/projects.py
@@ -37,7 +37,7 @@ async def get_projects(
     Raises:
         Exception: If there is an error retrieving projects from the platform
     """
-    await ctx.info("inside get_projects(...)")
+    await ctx.debug("inside get_projects(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.automation_studio.get_projects()
 
@@ -79,7 +79,7 @@ async def describe_project(
     Raises:
         Exception: If there is an error retrieving the project or project is not found
     """
-    await ctx.info("inside describe_project(...)")
+    await ctx.debug("inside describe_project(...)")
 
     client = ctx.request_context.lifespan_context.get("client")
 

--- a/src/itential_mcp/tools/templates.py
+++ b/src/itential_mcp/tools/templates.py
@@ -51,7 +51,7 @@ async def get_templates(
         Exception: If there is an error retrieving templates from the
             Automation Studio service.
     """
-    await ctx.info("inside get_templates(...)")
+    await ctx.debug("inside get_templates(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.automation_studio.get_templates(template_type=template_type)
 
@@ -103,7 +103,7 @@ async def describe_template(
         Exception: If there is an error retrieving the template information
             from the Automation Studio API.
     """
-    await ctx.info("inside get_templates(...)")
+    await ctx.debug("inside get_templates(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.automation_studio.describe_template(name=name, project=project)
     return models.DescribeTemplateResponse(
@@ -188,7 +188,7 @@ async def create_template(
         Exception: If there is an error creating the template in the
             Automation Studio API.
     """
-    await ctx.info("inside create_template(...)")
+    await ctx.debug("inside create_template(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.automation_studio.create_template(
         name=name,
@@ -277,7 +277,7 @@ async def update_template(
         Exception: If there is an error updating the template in the
             Automation Studio API.
     """
-    await ctx.info("inside update_template(...)")
+    await ctx.debug("inside update_template(...)")
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.automation_studio.update_template(
         name=name, project=project, command=command, template=template, data=data

--- a/tests/test_tools_applications.py
+++ b/tests/test_tools_applications.py
@@ -25,7 +25,7 @@ class TestStartApplicationTool:
     def setup_method(self):
         """Set up shared mock fixtures."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         self.mock_client = MagicMock()
         self.mock_app_service = MagicMock()
@@ -100,7 +100,7 @@ class TestStartApplicationTool:
 
     @pytest.mark.asyncio
     async def test_start_application_logs_entry(self):
-        """start_application must log entry via ctx.info."""
+        """start_application must log entry via ctx.debug."""
         self.mock_app_service.start_application.return_value = {
             "id": "Tags",
             "state": "RUNNING",
@@ -108,4 +108,4 @@ class TestStartApplicationTool:
 
         await start_application(self.mock_context, name="Tags", timeout=10)
 
-        self.mock_context.info.assert_called_once_with("inside start_application(...)")
+        self.mock_context.debug.assert_called_once_with("inside start_application(...)")

--- a/tests/test_tools_compliance_plans.py
+++ b/tests/test_tools_compliance_plans.py
@@ -27,7 +27,7 @@ class TestGetCompliancePlansTool:
     def setup_method(self):
         """Set up shared mock fixtures."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         self.mock_client = MagicMock()
         self.mock_cm_service = MagicMock()
@@ -82,12 +82,12 @@ class TestGetCompliancePlansTool:
 
     @pytest.mark.asyncio
     async def test_get_compliance_plans_logs_entry(self):
-        """get_compliance_plans must log entry via ctx.info."""
+        """get_compliance_plans must log entry via ctx.debug."""
         self.mock_cm_service.get_compliance_plans.return_value = []
 
         await get_compliance_plans(self.mock_context)
 
-        self.mock_context.info.assert_called_once_with(
+        self.mock_context.debug.assert_called_once_with(
             "inside get_compliance_plans(...)"
         )
 
@@ -102,7 +102,7 @@ class TestRunCompliancePlanTool:
     def setup_method(self):
         """Set up shared mock fixtures."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         self.mock_client = MagicMock()
         self.mock_cm_service = MagicMock()

--- a/tests/test_tools_compliance_reports.py
+++ b/tests/test_tools_compliance_reports.py
@@ -22,7 +22,7 @@ class TestDescribeComplianceReportTool:
     def setup_method(self):
         """Set up shared mock fixtures."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         self.mock_client = MagicMock()
         self.mock_cm_service = MagicMock()
@@ -103,11 +103,11 @@ class TestDescribeComplianceReportTool:
 
     @pytest.mark.asyncio
     async def test_describe_compliance_report_logs_entry(self):
-        """describe_compliance_report must log entry via ctx.info."""
+        """describe_compliance_report must log entry via ctx.debug."""
         self.mock_cm_service.describe_compliance_report.return_value = {"id": "x"}
 
         await describe_compliance_report(self.mock_context, report_id="x")
 
-        self.mock_context.info.assert_called_once_with(
+        self.mock_context.debug.assert_called_once_with(
             "inside describe_compliance_report(...)"
         )

--- a/tests/test_tools_configuration_manager.py
+++ b/tests/test_tools_configuration_manager.py
@@ -24,7 +24,7 @@ class TestRenderTemplateTool:
     def setup_method(self):
         """Set up shared mock fixtures."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         self.mock_client = MagicMock()
         self.mock_cm_service = MagicMock()
@@ -120,7 +120,7 @@ class TestRenderTemplateTool:
 
     @pytest.mark.asyncio
     async def test_render_template_logs_entry(self):
-        """render_template must log entry via ctx.info."""
+        """render_template must log entry via ctx.debug."""
         self.mock_cm_service.render_template.return_value = "output"
 
         await render_template(
@@ -129,4 +129,4 @@ class TestRenderTemplateTool:
             variables=None,
         )
 
-        self.mock_context.info.assert_called_once_with("inside render_template()")
+        self.mock_context.debug.assert_called_once_with("inside render_template()")

--- a/tests/test_tools_device_groups.py
+++ b/tests/test_tools_device_groups.py
@@ -60,7 +60,7 @@ class TestGetDeviceGroups:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -135,14 +135,14 @@ class TestGetDeviceGroups:
 
     @pytest.mark.asyncio
     async def test_get_device_groups_logs_info(self, mock_context):
-        """Test get_device_groups logs info message"""
+        """Test get_device_groups logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.configuration_manager = MagicMock()
         mock_client.configuration_manager.get_device_groups = AsyncMock(return_value=[])
 
         await device_groups.get_device_groups(mock_context)
 
-        mock_context.info.assert_called_once_with("inside get_device_groups(...)")
+        mock_context.debug.assert_called_once_with("inside get_device_groups(...)")
 
     @pytest.mark.asyncio
     async def test_get_device_groups_handles_missing_fields(self, mock_context):
@@ -176,7 +176,7 @@ class TestCreateDeviceGroup:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -316,7 +316,7 @@ class TestCreateDeviceGroup:
 
     @pytest.mark.asyncio
     async def test_create_device_group_logs_info(self, mock_context):
-        """Test create_device_group logs info message"""
+        """Test create_device_group logs debug message"""
         mock_response_data = {
             "id": "test",
             "name": "test",
@@ -334,7 +334,7 @@ class TestCreateDeviceGroup:
             mock_context, name="Test", description=None, devices=[]
         )
 
-        mock_context.info.assert_called_once_with("inside create_device_group(...)")
+        mock_context.debug.assert_called_once_with("inside create_device_group(...)")
 
 
 class TestAddDevicesToGroup:
@@ -344,7 +344,7 @@ class TestAddDevicesToGroup:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -427,7 +427,7 @@ class TestAddDevicesToGroup:
 
     @pytest.mark.asyncio
     async def test_add_devices_to_group_logs_info(self, mock_context):
-        """Test add_devices_to_group logs info message"""
+        """Test add_devices_to_group logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.configuration_manager = MagicMock()
         mock_client.configuration_manager.add_devices_to_group = AsyncMock(
@@ -436,7 +436,7 @@ class TestAddDevicesToGroup:
 
         await device_groups.add_devices_to_group(mock_context, name="Test", devices=[])
 
-        mock_context.info.assert_called_once_with("inside add_devices_to_group(...)")
+        mock_context.debug.assert_called_once_with("inside add_devices_to_group(...)")
 
 
 class TestRemoveDevicesFromGroup:
@@ -446,7 +446,7 @@ class TestRemoveDevicesFromGroup:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client with configuration_manager
         mock_client = MagicMock()
@@ -596,7 +596,7 @@ class TestRemoveDevicesFromGroup:
 
     @pytest.mark.asyncio
     async def test_remove_devices_from_group_logs_info(self, mock_context):
-        """Test remove_devices_from_group logs info message"""
+        """Test remove_devices_from_group logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.configuration_manager = MagicMock()
         mock_client.configuration_manager.remove_devices_from_group = AsyncMock(
@@ -607,7 +607,7 @@ class TestRemoveDevicesFromGroup:
             mock_context, name="Test", devices=[]
         )
 
-        mock_context.info.assert_called_once_with(
+        mock_context.debug.assert_called_once_with(
             "inside remove_devices_from_group(...)"
         )
 
@@ -619,7 +619,7 @@ class TestToolsIntegration:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -24,7 +24,7 @@ class TestGatewayManagerTools:
     def setup_method(self):
         """Set up test fixtures before each test method."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         # Create mock client
         self.mock_client = MagicMock()
@@ -116,7 +116,7 @@ class TestGetServices(TestGatewayManagerTools):
         result = await get_services(self.mock_context)
 
         # Verify context info was called
-        self.mock_context.info.assert_called_once_with("inside get_services(...)")
+        self.mock_context.debug.assert_called_once_with("inside get_services(...)")
 
         # Verify client method was called
         self.mock_client.gateway_manager.get_services.assert_called_once()
@@ -239,7 +239,7 @@ class TestGetServices(TestGatewayManagerTools):
             await get_services(self.mock_context)
 
         # Verify context info was still called
-        self.mock_context.info.assert_called_once_with("inside get_services(...)")
+        self.mock_context.debug.assert_called_once_with("inside get_services(...)")
 
 
 class TestGetGateways(TestGatewayManagerTools):
@@ -293,7 +293,7 @@ class TestGetGateways(TestGatewayManagerTools):
         result = await get_gateways(self.mock_context)
 
         # Verify context info was called
-        self.mock_context.info.assert_called_once_with("inside get_gateways(...)")
+        self.mock_context.debug.assert_called_once_with("inside get_gateways(...)")
 
         # Verify client method was called
         self.mock_gateway_manager_service.get_gateways.assert_called_once()
@@ -394,7 +394,7 @@ class TestGetGateways(TestGatewayManagerTools):
             await get_gateways(self.mock_context)
 
         # Verify context info was still called
-        self.mock_context.info.assert_called_once_with("inside get_gateways(...)")
+        self.mock_context.debug.assert_called_once_with("inside get_gateways(...)")
 
 
 class TestRunService(TestGatewayManagerTools):
@@ -455,7 +455,7 @@ class TestRunService(TestGatewayManagerTools):
         )
 
         # Verify context info was called
-        self.mock_context.info.assert_called_once_with("inside run_service(...)")
+        self.mock_context.debug.assert_called_once_with("inside run_service(...)")
 
         # Verify client method was called with correct parameters
         self.mock_client.gateway_manager.run_service.assert_called_once_with(
@@ -654,7 +654,7 @@ class TestRunService(TestGatewayManagerTools):
             )
 
         # Verify context info was still called
-        self.mock_context.info.assert_called_once_with("inside run_service(...)")
+        self.mock_context.debug.assert_called_once_with("inside run_service(...)")
 
     @pytest.mark.asyncio
     async def test_run_service_with_empty_output(self):
@@ -825,7 +825,7 @@ class TestGatewayManagerErrorHandling:
     def setup_method(self):
         """Set up test fixtures."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
         self.mock_client = MagicMock()
         self.mock_context.request_context.lifespan_context.get.return_value = (
             self.mock_client

--- a/tests/test_tools_golden_config.py
+++ b/tests/test_tools_golden_config.py
@@ -64,7 +64,9 @@ class TestGoldenConfigTools:
 
         result = await get_golden_config_trees(mock_context)
 
-        mock_context.info.assert_called_once_with("inside get_golden_config_trees(...)")
+        mock_context.debug.assert_called_once_with(
+            "inside get_golden_config_trees(...)"
+        )
         mock_configuration_manager.get_golden_config_trees.assert_called_once()
 
         assert isinstance(result, GetGoldenConfigTreesResponse)
@@ -87,7 +89,9 @@ class TestGoldenConfigTools:
 
         result = await get_golden_config_trees(mock_context)
 
-        mock_context.info.assert_called_once_with("inside get_golden_config_trees(...)")
+        mock_context.debug.assert_called_once_with(
+            "inside get_golden_config_trees(...)"
+        )
         mock_configuration_manager.get_golden_config_trees.assert_called_once()
 
         assert isinstance(result, GetGoldenConfigTreesResponse)
@@ -136,7 +140,7 @@ class TestGoldenConfigTools:
             variables=None,
         )
 
-        mock_context.info.assert_called_once_with(
+        mock_context.debug.assert_called_once_with(
             "inside create_golden_config_tree(...)"
         )
         mock_configuration_manager.create_golden_config_tree.assert_called_once_with(
@@ -297,7 +301,7 @@ class TestGoldenConfigTools:
             template=None,
         )
 
-        mock_context.info.assert_called_once_with("inside add_golden_config_node(...)")
+        mock_context.debug.assert_called_once_with("inside add_golden_config_node(...)")
         mock_configuration_manager.add_golden_config_node.assert_called_once_with(
             name="interface-config",
             tree_name="test-tree",
@@ -563,8 +567,8 @@ class TestGoldenConfigTools:
         # Test get_golden_config_trees
         mock_configuration_manager.get_golden_config_trees.return_value = []
         await get_golden_config_trees(mock_context)
-        mock_context.info.assert_called_with("inside get_golden_config_trees(...)")
-        mock_context.info.reset_mock()
+        mock_context.debug.assert_called_with("inside get_golden_config_trees(...)")
+        mock_context.debug.reset_mock()
 
         # Test create_golden_config_tree
         mock_configuration_manager.create_golden_config_tree.return_value = {
@@ -572,15 +576,15 @@ class TestGoldenConfigTools:
             "deviceType": "cisco_ios",
         }
         await create_golden_config_tree(mock_context, "test", "cisco_ios", None, None)
-        mock_context.info.assert_called_with("inside create_golden_config_tree(...)")
-        mock_context.info.reset_mock()
+        mock_context.debug.assert_called_with("inside create_golden_config_tree(...)")
+        mock_context.debug.reset_mock()
 
         # Test add_golden_config_node
         mock_configuration_manager.add_golden_config_node.return_value = None
         await add_golden_config_node(
             mock_context, "tree", "node", "initial", "base", None
         )
-        mock_context.info.assert_called_with("inside add_golden_config_node(...)")
+        mock_context.debug.assert_called_with("inside add_golden_config_node(...)")
 
     @pytest.mark.asyncio
     async def test_client_context_retrieval(

--- a/tests/test_tools_health.py
+++ b/tests/test_tools_health.py
@@ -16,7 +16,7 @@ class TestHealthTool:
     def setup_method(self):
         """Set up test fixtures before each test method."""
         self.mock_context = AsyncMock(spec=Context)
-        self.mock_context.info = AsyncMock()
+        self.mock_context.debug = AsyncMock()
 
         # Create mock client with health service
         self.mock_client = MagicMock()
@@ -204,7 +204,7 @@ class TestHealthTool:
         result = await get_health(self.mock_context)
 
         # Verify context info was called
-        self.mock_context.info.assert_called_once_with("inside get_health(...)")
+        self.mock_context.debug.assert_called_once_with("inside get_health(...)")
 
         # Verify all service methods were called
         self.mock_health_service.get_status_health.assert_called_once()
@@ -408,7 +408,7 @@ class TestHealthTool:
             await get_health(self.mock_context)
 
         # Verify context info was called before error
-        self.mock_context.info.assert_called_once_with("inside get_health(...)")
+        self.mock_context.debug.assert_called_once_with("inside get_health(...)")
 
     @pytest.mark.asyncio
     async def test_get_health_context_setup(self):

--- a/tests/test_tools_integrations.py
+++ b/tests/test_tools_integrations.py
@@ -23,7 +23,7 @@ class TestGetIntegrationModels:
     def mock_context(self):
         """Create a mock FastMCP Context for testing."""
         context = Mock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock the lifespan context
         mock_client = Mock()
@@ -61,7 +61,7 @@ class TestGetIntegrationModels:
         result = await integrations.get_integration_models(mock_context)
 
         # Verify context.info was called
-        mock_context.info.assert_called_once_with("inside get_integration_models(...)")
+        mock_context.debug.assert_called_once_with("inside get_integration_models(...)")
 
         # Verify client was retrieved and method called
         mock_context.request_context.lifespan_context.get.assert_called_once_with(
@@ -184,7 +184,7 @@ class TestCreateIntegrationModel:
     def mock_context(self):
         """Create a mock FastMCP Context for testing."""
         context = Mock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock the lifespan context
         mock_client = Mock()
@@ -240,7 +240,7 @@ class TestCreateIntegrationModel:
             )
 
             # Verify context.info was called
-            mock_context.info.assert_called_once_with(
+            mock_context.debug.assert_called_once_with(
                 "inside create_integration_model(...)"
             )
 
@@ -502,7 +502,7 @@ class TestIntegrationModelsErrorScenarios:
     def mock_context(self):
         """Create a mock FastMCP Context for error testing."""
         context = Mock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock the lifespan context
         mock_client = Mock()
@@ -643,7 +643,7 @@ class TestGetIntegrations:
     def mock_context(self):
         """Create a mock FastMCP Context for testing."""
         context = Mock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock the lifespan context
         mock_client = Mock()
@@ -687,7 +687,7 @@ class TestGetIntegrations:
         result = await integrations.get_integrations(mock_context, model=None)
 
         # Verify context.info was called
-        mock_context.info.assert_called_once_with("inside get_integrations(...)")
+        mock_context.debug.assert_called_once_with("inside get_integrations(...)")
 
         # Verify client was retrieved and method called
         mock_context.request_context.lifespan_context.get.assert_called_once_with(
@@ -749,7 +749,7 @@ class TestGetIntegrations:
         result = await integrations.get_integrations(mock_context, model="cisco-ios")
 
         # Verify context.info was called
-        mock_context.info.assert_called_once_with("inside get_integrations(...)")
+        mock_context.debug.assert_called_once_with("inside get_integrations(...)")
 
         # Verify client was retrieved and method called with model filter
         mock_context.request_context.lifespan_context.get.assert_called_once_with(

--- a/tests/test_tools_inventory_manager.py
+++ b/tests/test_tools_inventory_manager.py
@@ -63,7 +63,7 @@ class TestGetInventories:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -138,14 +138,14 @@ class TestGetInventories:
 
     @pytest.mark.asyncio
     async def test_get_inventories_logs_info(self, mock_context):
-        """Test get_inventories logs info message"""
+        """Test get_inventories logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.inventory_manager = MagicMock()
         mock_client.inventory_manager.get_inventories = AsyncMock(return_value=[])
 
         await inventory_manager.get_inventories(mock_context)
 
-        mock_context.info.assert_called_once_with("inside get_inventories(...)")
+        mock_context.debug.assert_called_once_with("inside get_inventories(...)")
 
     @pytest.mark.asyncio
     async def test_get_inventories_handles_missing_fields(self, mock_context):
@@ -178,7 +178,7 @@ class TestDescribeInventory:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -259,7 +259,7 @@ class TestDescribeInventory:
 
     @pytest.mark.asyncio
     async def test_describe_inventory_logs_info(self, mock_context):
-        """Test describe_inventory logs info message"""
+        """Test describe_inventory logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.inventory_manager = MagicMock()
         mock_client.inventory_manager.describe_inventory = AsyncMock(
@@ -268,7 +268,7 @@ class TestDescribeInventory:
 
         await inventory_manager.describe_inventory(mock_context, name="test")
 
-        mock_context.info.assert_called_once_with("inside describe_inventory(...)")
+        mock_context.debug.assert_called_once_with("inside describe_inventory(...)")
 
 
 class TestCreateInventory:
@@ -278,7 +278,7 @@ class TestCreateInventory:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -386,7 +386,7 @@ class TestCreateInventory:
 
     @pytest.mark.asyncio
     async def test_create_inventory_logs_info(self, mock_context):
-        """Test create_inventory logs info message"""
+        """Test create_inventory logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.inventory_manager = MagicMock()
         mock_client.inventory_manager.create_inventory = AsyncMock(
@@ -401,7 +401,7 @@ class TestCreateInventory:
             devices=None,
         )
 
-        mock_context.info.assert_called_once_with("inside create_inventory(...)")
+        mock_context.debug.assert_called_once_with("inside create_inventory(...)")
 
 
 class TestAddNodesToInventory:
@@ -411,7 +411,7 @@ class TestAddNodesToInventory:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -556,7 +556,7 @@ class TestAddNodesToInventory:
 
     @pytest.mark.asyncio
     async def test_add_nodes_to_inventory_logs_info(self, mock_context):
-        """Test add_nodes_to_inventory logs info message"""
+        """Test add_nodes_to_inventory logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.inventory_manager = MagicMock()
         mock_client.inventory_manager.add_nodes_to_inventory = AsyncMock(
@@ -569,7 +569,7 @@ class TestAddNodesToInventory:
             nodes=[{"name": "node1", "attributes": {"itential_host": "1.1.1.1"}}],
         )
 
-        mock_context.info.assert_called_once_with("inside add_nodes_to_inventory(...)")
+        mock_context.debug.assert_called_once_with("inside add_nodes_to_inventory(...)")
 
 
 class TestDeleteInventory:
@@ -579,7 +579,7 @@ class TestDeleteInventory:
     def mock_context(self):
         """Create a mock Context object"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock client
         mock_client = MagicMock()
@@ -638,7 +638,7 @@ class TestDeleteInventory:
 
     @pytest.mark.asyncio
     async def test_delete_inventory_logs_info(self, mock_context):
-        """Test delete_inventory logs info message"""
+        """Test delete_inventory logs debug message"""
         mock_client = mock_context.request_context.lifespan_context.get.return_value
         mock_client.inventory_manager = MagicMock()
         mock_client.inventory_manager.delete_inventory = AsyncMock(
@@ -647,7 +647,7 @@ class TestDeleteInventory:
 
         await inventory_manager.delete_inventory(mock_context, name="test")
 
-        mock_context.info.assert_called_once_with("inside delete_inventory(...)")
+        mock_context.debug.assert_called_once_with("inside delete_inventory(...)")
 
 
 class TestToolsIntegration:
@@ -657,7 +657,7 @@ class TestToolsIntegration:
     def mock_context(self):
         """Create a mock Context object for integration tests"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = MagicMock()
 

--- a/tests/test_tools_lifecycle_manager.py
+++ b/tests/test_tools_lifecycle_manager.py
@@ -71,7 +71,7 @@ class TestGetResources:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         # Mock the nested structure
         mock_client = AsyncMock()
@@ -107,7 +107,7 @@ class TestGetResources:
         assert result.root[1].description == "Second resource"
 
         # Verify service calls
-        mock_context.info.assert_called_once_with("inside get_resources(...)")
+        mock_context.debug.assert_called_once_with("inside get_resources(...)")
         mock_client.lifecycle_manager.get_resources.assert_called_once()
 
     @pytest.mark.asyncio
@@ -161,7 +161,7 @@ class TestCreateResource:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -187,7 +187,7 @@ class TestCreateResource:
         )
 
         assert isinstance(result, CreateResourceResponse)
-        mock_context.info.assert_called_once_with("inside create_resource(...)")
+        mock_context.debug.assert_called_once_with("inside create_resource(...)")
         mock_client.lifecycle_manager.describe_resource.assert_called_once_with(
             "test-resource"
         )
@@ -249,7 +249,7 @@ class TestDescribeResource:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -449,7 +449,7 @@ class TestGetInstances:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -551,7 +551,7 @@ class TestDescribeInstance:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -620,7 +620,7 @@ class TestRunAction:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -783,7 +783,7 @@ class TestGetActionExecutions:
     def mock_context(self):
         """Create a mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -858,7 +858,7 @@ class TestGetActionExecutions:
         assert result.root[1].status == "running"
 
         # Verify service calls
-        mock_context.info.assert_called_once_with("inside get_action_executions(...)")
+        mock_context.debug.assert_called_once_with("inside get_action_executions(...)")
         mock_client.lifecycle_manager.get_action_executions.assert_called_once_with(
             resource_name="test-resource", instance_name="test-instance"
         )
@@ -1182,7 +1182,7 @@ class TestIntegration:
     def mock_context(self):
         """Create a comprehensive mock FastMCP context"""
         context = AsyncMock(spec=Context)
-        context.info = AsyncMock()
+        context.debug = AsyncMock()
 
         mock_client = AsyncMock()
         mock_lifecycle_manager = AsyncMock()
@@ -1307,7 +1307,7 @@ class TestIntegration:
         await lifecycle_manager.get_resources(mock_context)
 
         # Verify context methods were called
-        mock_context.info.assert_called_with("inside get_resources(...)")
+        mock_context.debug.assert_called_with("inside get_resources(...)")
         mock_context.request_context.lifespan_context.get.assert_called_with("client")
 
     def test_model_imports(self):

--- a/tests/test_tools_projects.py
+++ b/tests/test_tools_projects.py
@@ -15,7 +15,7 @@ class TestAutomationStudioProjects:
     def mock_context(self):
         """Create a mock FastMCP context."""
         mock_ctx = MagicMock()
-        mock_ctx.info = AsyncMock()
+        mock_ctx.debug = AsyncMock()
         mock_ctx.request_context.lifespan_context.get.return_value = MagicMock()
         return mock_ctx
 
@@ -127,7 +127,7 @@ class TestAutomationStudioProjects:
         assert result.root[1].id == "6824fa53eeefcae9174e2140"
 
         mock_client.automation_studio.get_projects.assert_called_once()
-        mock_context.info.assert_called_once_with("inside get_projects(...)")
+        mock_context.debug.assert_called_once_with("inside get_projects(...)")
 
     @pytest.mark.asyncio
     async def test_get_projects_empty_response(
@@ -168,7 +168,7 @@ class TestAutomationStudioProjects:
         mock_client.automation_studio.describe_project.assert_called_once_with(
             name="Application Infra Provisioning - Python + Infoblox + CMDB"
         )
-        mock_context.info.assert_called_once_with("inside describe_project(...)")
+        mock_context.debug.assert_called_once_with("inside describe_project(...)")
 
     @pytest.mark.asyncio
     async def test_describe_project_filters_data_correctly(

--- a/tests/test_tools_templates.py
+++ b/tests/test_tools_templates.py
@@ -21,7 +21,7 @@ class TestAutomationStudioTemplates:
     def mock_context(self):
         """Create a mock FastMCP context."""
         mock_ctx = MagicMock()
-        mock_ctx.info = AsyncMock()
+        mock_ctx.debug = AsyncMock()
         mock_ctx.request_context.lifespan_context.get.return_value = MagicMock()
         return mock_ctx
 
@@ -81,7 +81,7 @@ class TestAutomationStudioTemplates:
         )
 
         # Verify context logging was called
-        mock_context.info.assert_called_once_with("inside get_templates(...)")
+        mock_context.debug.assert_called_once_with("inside get_templates(...)")
 
         # Verify response structure and data
         assert isinstance(result, list)
@@ -402,7 +402,7 @@ class TestDescribeTemplate:
     def mock_context(self):
         """Create a mock FastMCP context."""
         mock_ctx = MagicMock()
-        mock_ctx.info = AsyncMock()
+        mock_ctx.debug = AsyncMock()
         mock_ctx.request_context.lifespan_context.get.return_value = MagicMock()
         return mock_ctx
 
@@ -448,7 +448,7 @@ class TestDescribeTemplate:
         )
 
         # Verify context logging was called
-        mock_context.info.assert_called_once_with("inside get_templates(...)")
+        mock_context.debug.assert_called_once_with("inside get_templates(...)")
 
         # Verify response structure and data
         assert isinstance(result, DescribeTemplateResponse)
@@ -551,7 +551,7 @@ class TestCreateTemplate:
     def mock_context(self):
         """Create a mock FastMCP context."""
         mock_ctx = MagicMock()
-        mock_ctx.info = AsyncMock()
+        mock_ctx.debug = AsyncMock()
         mock_ctx.request_context.lifespan_context.get.return_value = MagicMock()
         return mock_ctx
 
@@ -610,7 +610,7 @@ class TestCreateTemplate:
         )
 
         # Verify context logging was called
-        mock_context.info.assert_called_once_with("inside create_template(...)")
+        mock_context.debug.assert_called_once_with("inside create_template(...)")
 
         # Verify response structure and data
         assert isinstance(result, DescribeTemplateResponse)
@@ -729,7 +729,7 @@ class TestUpdateTemplate:
     def mock_context(self):
         """Create a mock FastMCP context."""
         mock_ctx = MagicMock()
-        mock_ctx.info = AsyncMock()
+        mock_ctx.debug = AsyncMock()
         mock_ctx.request_context.lifespan_context.get.return_value = MagicMock()
         return mock_ctx
 
@@ -784,7 +784,7 @@ class TestUpdateTemplate:
         )
 
         # Verify context logging was called
-        mock_context.info.assert_called_once_with("inside update_template(...)")
+        mock_context.debug.assert_called_once_with("inside update_template(...)")
 
         # Verify response structure and data
         assert isinstance(result, DescribeTemplateResponse)


### PR DESCRIPTION
## Summary
- Demote 64 `ctx.info("inside ...")` / `ctx.info("running ...")` entry-trace breadcrumb calls to `ctx.debug(...)` across all 18 tool modules under `src/itential_mcp/tools/`.
- These are developer-only entry traces, not user-relevant events, but were riding the `notifications/message` channel visible to MCP clients (and therefore the LLM) at `info` level.
- Update matching test assertions/mocks (`.info` to `.debug`) across 13 test files, including two files not originally scoped (`test_tools_compliance_plans.py`, `test_tools_compliance_reports.py`) and several fixture variable-name variants caught during verification.
- No tool return values, signatures, or registration changed - pure log-severity change.

This is WI-8 of the MCP `2025-11-25` compliance plan (item #2 of a sequential dependency/security-fix queue; item #1, WI-1, already merged as #363).

A follow-up item (WI-8b, tracked in `itential-mcp-maintainer/roadmap/compliance-plan.md`) will add genuinely user-relevant `ctx.info` events back in, deliberately, since this sweep found none existed prior to this change.

## Test plan
- [x] `make ci` - 2503 passed, 99% coverage held
- [x] ruff / bandit / header checks clean
- [x] Every `ctx.debug` message string cross-referenced against its corresponding test assertion - no mismatches
- [x] Confirmed `workflow_engine.py` (already used `ctx.debug`) and the one `ctx.warning` schema-coercion call in `operations_manager.py` are untouched
- Integration testing intentionally not run - no tool registration or return-type changes; log-level demotion has no live-platform-observable behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
