### PR TITLE
chore: bump pyjwt and python-multipart to patched versions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1125,11 +1125,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -1225,11 +1228,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `pyjwt` 2.11.0 -> 2.13.0 - fixes a high-severity dependabot advisory (JWK-as-HMAC-secret forgery).
- Bump `python-multipart` 0.0.22 -> 0.0.32 - fixes a high-severity dependabot advisory (negative Content-Length DoS).
- Both are transitive dependencies pulled in via `mcp`/`fastmcp` (no upper bound in `mcp 1.26.0`'s constraints), re-resolved cleanly via `uv lock --upgrade-package` on the first attempt. No direct dependency promotion was needed.
- `pyproject.toml` is untouched. Diff is `uv.lock` only.
- `server/auth.py` never calls pyjwt directly (goes through `fastmcp.server.auth.JWTVerifier`), and the pyjwt 2.13.0 hardening (JWK-as-HMAC-secret rejection, header `alg` binding, non-http(s) JWKS URI rejection) does not affect this codebase's usage patterns - verified analytically and via the existing auth test suite.

This is item #3 of a sequential dependency/security-fix queue (items #1/#2 already merged as #363, #364).

## Test plan
- [x] `make ci` - 2503 passed (including 46 auth-specific tests across `test_auth.py`, `test_auth_oauth.py`, `test_auth_coverage.py`), 99% coverage held
- [x] ruff / bandit / header checks clean
- [x] `uv lock --check` confirms lockfile consistency; confirmed no new top-level dependency added (only a new dependency edge from pyjwt to an already-present `typing-extensions`)
- Integration testing intentionally not run - lockfile-only bump, no `.py` files changed, no tool registration or return-type changes, auth compatibility verified analytically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
