### PR TITLE
fix: tolerate scalar cpuUsage and missing description in health response

### DIFF
--- a/src/itential_mcp/models/health.py
+++ b/src/itential_mcp/models/health.py
@@ -430,6 +430,31 @@ class CpuUsage(BaseModel):
     ]
 
 
+def _coerce_scalar_cpu_usage_to_none(value):
+    """Coerce a scalar cpuUsage placeholder value to None.
+
+    Some Itential Platform versions report cpuUsage as a bare scalar
+    placeholder (e.g. ``0``, ``0.0``, or ``"0"``) instead of a
+    ``{user, system}`` object when per-process CPU sampling isn't
+    populated. This normalizes any such scalar placeholder to None
+    rather than fabricating a breakdown that was never sampled.
+
+    Args:
+        value: The value to validate, expected to be either None, a
+            dict, a CpuUsage instance, or a scalar placeholder (int,
+            float, str, bool, etc).
+
+    Returns:
+        The original value unchanged if it is None, a dict, or a
+        CpuUsage instance. A list is also passed through unchanged so
+        that shape still raises a clear validation error. Any other
+        scalar value is coerced to None.
+    """
+    if value is None or isinstance(value, (dict, CpuUsage, list)):
+        return value
+    return None
+
+
 class ServerVersions(BaseModel):
     """
     Represents version information for Node.js and its dependencies.
@@ -550,7 +575,7 @@ class ServerInfo(BaseModel):
     ]
 
     cpu_usage: Annotated[
-        CpuUsage,
+        CpuUsage | None,
         Field(
             alias="cpuUsage",
             description=inspect.cleandoc(
@@ -558,6 +583,7 @@ class ServerInfo(BaseModel):
                 CPU usage statistics for the main server process
                 """
             ),
+            default=None,
         ),
     ]
 
@@ -594,6 +620,25 @@ class ServerInfo(BaseModel):
             default_factory=dict,
         ),
     ]
+
+    @field_validator("cpu_usage", mode="before")
+    @classmethod
+    def convert_scalar_cpu_usage_to_none(cls, value):
+        """Convert a scalar cpuUsage placeholder value to None.
+
+        Delegates to the shared `_coerce_scalar_cpu_usage_to_none` helper,
+        which coerces any non-mapping scalar placeholder to None rather
+        than fabricating a breakdown that was never sampled.
+
+        Args:
+            value: The value to validate, expected to be either a dict,
+                a CpuUsage instance, or a scalar placeholder.
+
+        Returns:
+            None if value is a scalar placeholder, otherwise returns the
+            original value unchanged.
+        """
+        return _coerce_scalar_cpu_usage_to_none(value)
 
 
 class ConnectionInfo(BaseModel):
@@ -737,13 +782,14 @@ class ApplicationInfo(BaseModel):
     ]
 
     description: Annotated[
-        str,
+        str | None,
         Field(
             description=inspect.cleandoc(
                 """
                 Human-readable description of the application
                 """
-            )
+            ),
+            default=None,
         ),
     ]
 
@@ -1001,6 +1047,25 @@ class AdapterInfo(BaseModel):
             default=None,
         ),
     ]
+
+    @field_validator("cpu_usage", mode="before")
+    @classmethod
+    def convert_scalar_cpu_usage_to_none(cls, value):
+        """Convert a scalar cpuUsage placeholder value to None.
+
+        Delegates to the shared `_coerce_scalar_cpu_usage_to_none` helper,
+        which coerces any non-mapping scalar placeholder to None rather
+        than fabricating a breakdown that was never sampled.
+
+        Args:
+            value: The value to validate, expected to be either a dict,
+                a CpuUsage instance, or a scalar placeholder.
+
+        Returns:
+            None if value is a scalar placeholder, otherwise returns the
+            original value unchanged.
+        """
+        return _coerce_scalar_cpu_usage_to_none(value)
 
     pid: Annotated[
         int | str | None,

--- a/tests/test_models_health.py
+++ b/tests/test_models_health.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
+import pytest
+from pydantic import ValidationError
+
 from itential_mcp.models.health import (
     ServiceStatus,
     PlatformStatus,
@@ -18,6 +21,7 @@ from itential_mcp.models.health import (
     ApplicationInfo,
     AdapterInfo,
     HealthResponse,
+    _coerce_scalar_cpu_usage_to_none,
 )
 
 
@@ -1772,3 +1776,434 @@ class TestLoggerConfigOptionalFields:
         logger = LoggerConfig(console="info", file="info", syslog={})
 
         assert logger.syslog == ""
+
+
+class TestHealthResponsePlatformVersionDrift:
+    """Regression tests for platform-version-driven response shape drift.
+
+    Different Itential Platform versions return different `cpuUsage` and
+    `description` shapes in their health payload. Older/differently
+    configured platforms may omit `applications[].description` entirely,
+    or return a scalar placeholder (e.g. ``0``, ``0.0``, or ``"0"``) for
+    `cpuUsage` instead of a `{user, system}` object when per-process CPU
+    sampling isn't populated. These models must tolerate both shapes.
+    """
+
+    def test_application_info_missing_description(self):
+        """ApplicationInfo must construct without a description field."""
+        payload = {
+            "id": "TestApp",
+            "package_id": "@itential/test-app",
+            "version": "1.0.0",
+            "type": "Application",
+            "routePrefix": "test-app",
+            "state": "RUNNING",
+            "uptime": 1000.0,
+            "memoryUsage": {"rss": 100000000},
+            "cpuUsage": {"user": 1000000, "system": 500000},
+            "pid": 123,
+            "logger": {},
+            "timestamp": 1757004595716,
+            "prevUptime": 999.0,
+        }
+
+        app_info = ApplicationInfo(**payload)
+
+        assert app_info.description is None
+
+    def test_adapter_info_scalar_cpu_usage(self):
+        """AdapterInfo must coerce a bare int cpuUsage placeholder to None."""
+        payload = {
+            "id": "TestAdapter",
+            "type": "Adapter",
+            "version": "1.0.0",
+            "state": "RUNNING",
+            "uptime": 2000.0,
+            "cpuUsage": 0,
+        }
+
+        adapter_info = AdapterInfo(**payload)
+
+        assert adapter_info.cpu_usage is None
+
+    def test_server_info_scalar_cpu_usage(self):
+        """ServerInfo must coerce a bare int cpuUsage placeholder to None."""
+        versions = ServerVersions(
+            node="20.3.0",
+            acorn="8.8.2",
+            ada="2.5.0",
+            ares="1.19.1",
+            brotli="1.0.9",
+            cjs_module_lexer="1.2.2",
+            cldr="43.0",
+            icu="73.1",
+            llhttp="8.1.0",
+            modules="115",
+            napi="9",
+            nghttp2="1.53.0",
+            openssl="3.0.8+quic",
+            simdutf="3.2.12",
+            tz="2023c",
+            undici="5.22.1",
+            unicode="15.0",
+            uv="1.45.0",
+            uvwasi="0.0.18",
+            v8="11.3.244.8-node.9",
+            zlib="1.2.13.1-motley",
+        )
+
+        server_info = ServerInfo(
+            version="15.8.10-2023.2.44",
+            release="2023.2.9",
+            arch="x64",
+            platform="linux",
+            versions=versions,
+            memoryUsage={"rss": 469671936},
+            cpuUsage=0,
+            uptime=2083622.963931177,
+            pid=1,
+        )
+
+        assert server_info.cpu_usage is None
+
+    def test_server_info_dict_cpu_usage_still_works(self):
+        """Regression — a normal dict-shaped cpuUsage payload still constructs a CpuUsage."""
+        versions = ServerVersions(
+            node="20.3.0",
+            acorn="8.8.2",
+            ada="2.5.0",
+            ares="1.19.1",
+            brotli="1.0.9",
+            cjs_module_lexer="1.2.2",
+            cldr="43.0",
+            icu="73.1",
+            llhttp="8.1.0",
+            modules="115",
+            napi="9",
+            nghttp2="1.53.0",
+            openssl="3.0.8+quic",
+            simdutf="3.2.12",
+            tz="2023c",
+            undici="5.22.1",
+            unicode="15.0",
+            uv="1.45.0",
+            uvwasi="0.0.18",
+            v8="11.3.244.8-node.9",
+            zlib="1.2.13.1-motley",
+        )
+
+        server_info = ServerInfo(
+            version="15.8.10-2023.2.44",
+            release="2023.2.9",
+            arch="x64",
+            platform="linux",
+            versions=versions,
+            memoryUsage={"rss": 469671936},
+            cpuUsage={"user": 3815108692, "system": 621631048},
+            uptime=2083622.963931177,
+            pid=1,
+        )
+
+        assert isinstance(server_info.cpu_usage, CpuUsage)
+        assert server_info.cpu_usage.user == 3815108692
+        assert server_info.cpu_usage.system == 621631048
+
+    def test_adapter_info_dict_cpu_usage_still_works(self):
+        """Regression — a normal dict-shaped cpuUsage payload still constructs a CpuUsage."""
+        adapter_info = AdapterInfo(
+            id="TestAdapter",
+            type="Adapter",
+            version="1.0.0",
+            state="RUNNING",
+            uptime=2000.0,
+            cpuUsage={"user": 2000000, "system": 1000000},
+        )
+
+        assert isinstance(adapter_info.cpu_usage, CpuUsage)
+        assert adapter_info.cpu_usage.user == 2000000
+        assert adapter_info.cpu_usage.system == 1000000
+
+    def test_adapter_info_float_cpu_usage(self):
+        """AdapterInfo must coerce a float cpuUsage placeholder to None."""
+        adapter_info = AdapterInfo(
+            id="TestAdapter",
+            type="Adapter",
+            version="1.0.0",
+            state="RUNNING",
+            uptime=2000.0,
+            cpuUsage=0.0,
+        )
+
+        assert adapter_info.cpu_usage is None
+
+    def test_adapter_info_str_cpu_usage(self):
+        """AdapterInfo must coerce a str cpuUsage placeholder to None."""
+        adapter_info = AdapterInfo(
+            id="TestAdapter",
+            type="Adapter",
+            version="1.0.0",
+            state="RUNNING",
+            uptime=2000.0,
+            cpuUsage="0",
+        )
+
+        assert adapter_info.cpu_usage is None
+
+    def test_adapter_info_list_cpu_usage_raises(self):
+        """AdapterInfo must NOT silently swallow a list cpuUsage — it's an
+        unexpected shape that should still raise a clear validation error.
+        """
+        with pytest.raises(ValidationError):
+            AdapterInfo(
+                id="TestAdapter",
+                type="Adapter",
+                version="1.0.0",
+                state="RUNNING",
+                uptime=2000.0,
+                cpuUsage=[1, 2, 3],
+            )
+
+    def test_server_info_float_cpu_usage(self):
+        """ServerInfo must coerce a float cpuUsage placeholder to None."""
+        versions = ServerVersions(
+            node="20.3.0",
+            acorn="8.8.2",
+            ada="2.5.0",
+            ares="1.19.1",
+            brotli="1.0.9",
+            cjs_module_lexer="1.2.2",
+            cldr="43.0",
+            icu="73.1",
+            llhttp="8.1.0",
+            modules="115",
+            napi="9",
+            nghttp2="1.53.0",
+            openssl="3.0.8+quic",
+            simdutf="3.2.12",
+            tz="2023c",
+            undici="5.22.1",
+            unicode="15.0",
+            uv="1.45.0",
+            uvwasi="0.0.18",
+            v8="11.3.244.8-node.9",
+            zlib="1.2.13.1-motley",
+        )
+
+        server_info = ServerInfo(
+            version="15.8.10-2023.2.44",
+            release="2023.2.9",
+            arch="x64",
+            platform="linux",
+            versions=versions,
+            memoryUsage={"rss": 469671936},
+            cpuUsage=0.0,
+            uptime=2083622.963931177,
+            pid=1,
+        )
+
+        assert server_info.cpu_usage is None
+
+    def test_server_info_str_cpu_usage(self):
+        """ServerInfo must coerce a str cpuUsage placeholder to None."""
+        versions = ServerVersions(
+            node="20.3.0",
+            acorn="8.8.2",
+            ada="2.5.0",
+            ares="1.19.1",
+            brotli="1.0.9",
+            cjs_module_lexer="1.2.2",
+            cldr="43.0",
+            icu="73.1",
+            llhttp="8.1.0",
+            modules="115",
+            napi="9",
+            nghttp2="1.53.0",
+            openssl="3.0.8+quic",
+            simdutf="3.2.12",
+            tz="2023c",
+            undici="5.22.1",
+            unicode="15.0",
+            uv="1.45.0",
+            uvwasi="0.0.18",
+            v8="11.3.244.8-node.9",
+            zlib="1.2.13.1-motley",
+        )
+
+        server_info = ServerInfo(
+            version="15.8.10-2023.2.44",
+            release="2023.2.9",
+            arch="x64",
+            platform="linux",
+            versions=versions,
+            memoryUsage={"rss": 469671936},
+            cpuUsage="0",
+            uptime=2083622.963931177,
+            pid=1,
+        )
+
+        assert server_info.cpu_usage is None
+
+    def test_server_info_list_cpu_usage_raises(self):
+        """ServerInfo must NOT silently swallow a list cpuUsage — it's an
+        unexpected shape that should still raise a clear validation error.
+        """
+        versions = ServerVersions(
+            node="20.3.0",
+            acorn="8.8.2",
+            ada="2.5.0",
+            ares="1.19.1",
+            brotli="1.0.9",
+            cjs_module_lexer="1.2.2",
+            cldr="43.0",
+            icu="73.1",
+            llhttp="8.1.0",
+            modules="115",
+            napi="9",
+            nghttp2="1.53.0",
+            openssl="3.0.8+quic",
+            simdutf="3.2.12",
+            tz="2023c",
+            undici="5.22.1",
+            unicode="15.0",
+            uv="1.45.0",
+            uvwasi="0.0.18",
+            v8="11.3.244.8-node.9",
+            zlib="1.2.13.1-motley",
+        )
+
+        with pytest.raises(ValidationError):
+            ServerInfo(
+                version="15.8.10-2023.2.44",
+                release="2023.2.9",
+                arch="x64",
+                platform="linux",
+                versions=versions,
+                memoryUsage={"rss": 469671936},
+                cpuUsage=[1, 2, 3],
+                uptime=2083622.963931177,
+                pid=1,
+            )
+
+    def test_coerce_scalar_cpu_usage_to_none_helper_directly(self):
+        """The shared helper coerces bare int/float/str/bool scalars to
+        None, passes through None/dict/CpuUsage/list unchanged, and its
+        behavior via ServerInfo/AdapterInfo matches direct calls.
+        """
+        assert _coerce_scalar_cpu_usage_to_none(0) is None
+        assert _coerce_scalar_cpu_usage_to_none(0.0) is None
+        assert _coerce_scalar_cpu_usage_to_none("0") is None
+        assert _coerce_scalar_cpu_usage_to_none(True) is None
+        assert _coerce_scalar_cpu_usage_to_none(False) is None
+        assert _coerce_scalar_cpu_usage_to_none(None) is None
+
+        cpu_usage = CpuUsage(user=1, system=2)
+        assert _coerce_scalar_cpu_usage_to_none(cpu_usage) is cpu_usage
+
+        payload = {"user": 1, "system": 2}
+        assert _coerce_scalar_cpu_usage_to_none(payload) is payload
+
+        values = [1, 2, 3]
+        assert _coerce_scalar_cpu_usage_to_none(values) is values
+
+    def test_health_response_live_failure_regression(self):
+        """Regression test replicating the exact live platform failure.
+
+        An application entry missing `description` AND an adapter with an
+        integer `cpuUsage` occurring simultaneously in the same payload —
+        this is the shape that raised a Pydantic ValidationError against
+        the live platform before this fix.
+        """
+        api_data = {
+            "status": {
+                "host": "platform.devel",
+                "serverId": "c0ecb6ba62d43b067c09a1c33488a7d41df592f6",
+                "services": [{"service": "redis", "status": "running"}],
+                "timestamp": 1757090849045,
+                "apps": "degraded",
+                "adapters": "running",
+            },
+            "system": {
+                "arch": "x64",
+                "release": "6.13.12-100.fc40.x86_64",
+                "uptime": 4755065.68,
+                "freemem": 53909569536,
+                "totalmem": 67111694336,
+                "loadavg": [0.0, 0.05, 0.15],
+                "cpus": [],
+            },
+            "server": {
+                "version": "15.8.10-2023.2.44",
+                "release": "2023.2.9",
+                "arch": "x64",
+                "platform": "linux",
+                "versions": {
+                    "node": "20.3.0",
+                    "acorn": "8.8.2",
+                    "ada": "2.5.0",
+                    "ares": "1.19.1",
+                    "brotli": "1.0.9",
+                    "cjs_module_lexer": "1.2.2",
+                    "cldr": "43.0",
+                    "icu": "73.1",
+                    "llhttp": "8.1.0",
+                    "modules": "115",
+                    "napi": "9",
+                    "nghttp2": "1.53.0",
+                    "openssl": "3.0.8+quic",
+                    "simdutf": "3.2.12",
+                    "tz": "2023c",
+                    "undici": "5.22.1",
+                    "unicode": "15.0",
+                    "uv": "1.45.0",
+                    "uvwasi": "0.0.18",
+                    "v8": "11.3.244.8-node.9",
+                    "zlib": "1.2.13.1-motley",
+                },
+                "memoryUsage": {"rss": 490758144},
+                "cpuUsage": 0,
+                "uptime": 2169876.158544452,
+                "pid": 1,
+            },
+            "applications": [
+                {
+                    "id": "AGManager",
+                    "package_id": "@itential/app-ag_manager",
+                    "version": "1.20.3-2023.2.1",
+                    "type": "Application",
+                    "routePrefix": "ag-manager",
+                    "state": "RUNNING",
+                    "uptime": 846338.466451258,
+                    "memoryUsage": {"rss": 181534720},
+                    "cpuUsage": {"user": 289119808, "system": 125456921},
+                    "pid": 715,
+                    "logger": {},
+                    "timestamp": 1757090846633,
+                    "prevUptime": 846333.466399005,
+                }
+            ],
+            "adapters": [
+                {
+                    "id": "Gateway",
+                    "package_id": "@itential/adapter-automation_gateway",
+                    "version": "4.31.4-2023.2.1",
+                    "type": "Adapter",
+                    "description": "Itential Ansible Manager Adapter",
+                    "routePrefix": "automationgateway",
+                    "state": "RUNNING",
+                    "connection": {"state": "ONLINE"},
+                    "uptime": 846361.043660279,
+                    "memoryUsage": {"rss": 157736960},
+                    "cpuUsage": 0,
+                    "pid": 701,
+                    "logger": {},
+                    "timestamp": 1757090848784,
+                    "prevUptime": 846356.042837805,
+                }
+            ],
+        }
+
+        health_response = HealthResponse(**api_data)
+
+        assert health_response.applications[0].description is None
+        assert health_response.adapters[0].cpu_usage is None
+        assert health_response.server.cpu_usage is None

--- a/tests/test_tools_health.py
+++ b/tests/test_tools_health.py
@@ -792,3 +792,48 @@ class TestHealthTool:
         assert result.server.version == "0.0.0"
         assert len(result.applications) == 0
         assert len(result.adapters) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_health_platform_version_drift(self):
+        """Test get_health tolerates platform-version-driven response shape drift.
+
+        Some Itential Platform versions omit `applications[].description`
+        and/or report `cpuUsage` as a bare int placeholder instead of a
+        `{user, system}` object. This end-to-end test replicates that
+        anomalous shape and confirms get_health still returns a valid
+        HealthResponse instead of raising a ToolError.
+        """
+        mock_data = self.create_mock_health_data()
+
+        # Application missing description entirely
+        del mock_data["applications_data"]["results"][0]["description"]
+
+        # Server and adapter cpuUsage reported as bare int placeholders
+        mock_data["server_data"]["cpuUsage"] = 0
+        mock_data["adapters_data"]["results"][0]["cpuUsage"] = 0
+
+        # Configure service method returns
+        self.mock_health_service.get_status_health.return_value = mock_data[
+            "status_data"
+        ]
+        self.mock_health_service.get_system_health.return_value = mock_data[
+            "system_data"
+        ]
+        self.mock_health_service.get_server_health.return_value = mock_data[
+            "server_data"
+        ]
+        self.mock_health_service.get_applications_health.return_value = mock_data[
+            "applications_data"
+        ]
+        self.mock_health_service.get_adapters_health.return_value = mock_data[
+            "adapters_data"
+        ]
+
+        # Call the function - must not raise a ToolError/ValidationError
+        result = await get_health(self.mock_context)
+
+        # Verify result is a valid HealthResponse despite anomalous shapes
+        assert isinstance(result, HealthResponse)
+        assert result.applications[0].description is None
+        assert result.adapters[0].cpu_usage is None
+        assert result.server.cpu_usage is None


### PR DESCRIPTION
## Summary
- Fixes `get_health` throwing a Pydantic validation error against some Itential Platform versions:
  - `applications[].description` was required but at least one platform omits it for some entries -> made optional (`str | None = None`).
  - `adapters[].cpuUsage` / `server.cpuUsage` are typed as a `CpuUsage` object (`{user, system}`) but at least one platform sends a scalar placeholder instead -> a `field_validator(mode="before")` now coerces any non-mapping scalar (int, float, str, bool) to `None` rather than raising or fabricating fake `user`/`system` values.
- Both `ServerInfo` and `AdapterInfo` delegate to a single shared `_coerce_scalar_cpu_usage_to_none` helper - no duplicated validator logic.
- `list` inputs are deliberately NOT coerced - an unexpected list shape still raises a normal `ValidationError`, since that's a genuinely different problem than the known scalar-placeholder pattern.
- This is root-caused as platform-version-driven response drift (older/differently-configured platforms omit fields or send scalar placeholders where newer ones send full objects), not malformed data - the fix tolerates both shapes rather than assuming the platform is wrong.
- No `int | CpuUsage` union was introduced anywhere - the `cpu_usage` field stays a plain `CpuUsage | None` in the schema; all scalar tolerance lives inside the before-validator. This deliberately avoids the Union-return output_schema-generation bug fixed in #361.

Found live 2026-07-24 while integration-testing an unrelated dependency bump (#366); reproduced independently on `devel` HEAD in this session and confirmed unrelated to that bump.

## Test plan
- [x] `make ci` - 2517 passed, 99% coverage held (health.py itself at 100%), bandit 0 issues
- [x] New regression tests replicate the exact live failure (missing description + scalar cpuUsage in the same payload), plus dedicated coverage for float/str/bool scalar coercion and confirmation that list inputs still raise
- [x] **Live integration test** against the exact platform that surfaced this bug (`itential-se-poc-dev01.trial.itential.io`): reproduced the failure fresh on `devel` HEAD in this session, then confirmed this branch's fix succeeds against the same live platform. Field-level check confirmed the two previously-broken fields now render as `null` (not fabricated values), and 17/18 other adapters with real `cpuUsage` data were unaffected.
- [x] Sanity-checked a second read-path tool (`get_devices`) against the same live platform - no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
