### PR TITLE
fix: use removesuffix instead of rstrip for OAuth base_url derivation

### DIFF
--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -121,7 +121,7 @@ def _build_oauth_provider(auth_config: dict[str, Any]) -> AuthProvider:
         )
 
     oauth_kwargs = {
-        "base_url": auth_config["redirect_uri"].rstrip("/auth/callback"),
+        "base_url": auth_config["redirect_uri"].removesuffix("/auth/callback"),
     }
 
     # Add optional parameters
@@ -179,7 +179,7 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
         # Fallback to JWT verifier if StaticTokenVerifier not available
         token_verifier = JWTVerifier()
 
-    base_url = auth_config["redirect_uri"].rstrip("/auth/callback")
+    base_url = auth_config["redirect_uri"].removesuffix("/auth/callback")
 
     oauth_kwargs = {
         "upstream_authorization_endpoint": auth_config["authorization_url"],
@@ -224,6 +224,8 @@ def _get_provider_config(
     Raises:
         ConfigurationException: If provider type is not supported.
     """
+    # TODO: not currently called by any provider builder — oauth_provider_type
+    # config/CLI flag is accepted but has no effect until this is wired in.
     config: dict[str, Any] = {}
 
     # Add custom scopes if specified

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -129,6 +129,40 @@ class TestOAuthProviderBuilding:
         assert result == mock_provider
         mock_oauth_provider.assert_called_once_with(base_url="http://localhost:8000")
 
+    @patch("itential_mcp.server.auth.OAuthProvider")
+    def test_build_oauth_provider_base_url_suffix_removal_only(
+        self, mock_oauth_provider
+    ):
+        """Test that base_url derivation only strips the literal suffix.
+
+        Regression test for a bug where ``str.rstrip("/auth/callback")`` was
+        used instead of ``str.removesuffix("/auth/callback")``. ``rstrip``
+        treats its argument as a set of characters to strip from the end of
+        the string, not a literal suffix, so a redirect URI whose host ends
+        in any of the characters in "/auth/callback" (e.g. "u" or "k" from a
+        ".uk" TLD) would have those trailing host characters incorrectly
+        eaten as well. Under the old ``rstrip`` behavior this would have
+        produced "https://auth-host.example." instead of the correct
+        "https://auth-host.example.uk".
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth",
+                oauth_redirect_uri="https://auth-host.example.uk/auth/callback",
+            )
+        )
+
+        mock_provider = MagicMock()
+        mock_oauth_provider.return_value = mock_provider
+
+        _build_oauth_provider(auth_config)
+
+        mock_oauth_provider.assert_called_once_with(
+            base_url="https://auth-host.example.uk"
+        )
+
     def test_build_oauth_provider_missing_required_fields(self):
         """Test OAuth provider building with missing required fields."""
         from itential_mcp.config.converters import auth_to_dict
@@ -198,6 +232,53 @@ class TestOAuthProviderBuilding:
             upstream_client_secret="test_secret",
             token_verifier=mock_verifier_instance,
             base_url="http://localhost:8000",
+        )
+
+    @patch("itential_mcp.server.auth.OAuthProxy")
+    @patch("fastmcp.server.auth.StaticTokenVerifier")
+    def test_build_oauth_proxy_provider_base_url_suffix_removal_only(
+        self, mock_token_verifier, mock_oauth_proxy
+    ):
+        """Test that base_url derivation only strips the literal suffix.
+
+        Regression test for a bug where ``str.rstrip("/auth/callback")`` was
+        used instead of ``str.removesuffix("/auth/callback")``. ``rstrip``
+        treats its argument as a set of characters to strip from the end of
+        the string, not a literal suffix, so a redirect URI whose host ends
+        in any of the characters in "/auth/callback" (e.g. "u" or "k" from a
+        ".uk" TLD) would have those trailing host characters incorrectly
+        eaten as well. Under the old ``rstrip`` behavior this would have
+        produced "https://auth-host.example." instead of the correct
+        "https://auth-host.example.uk".
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="https://auth-host.example.uk/auth/callback",
+            )
+        )
+
+        mock_verifier_instance = MagicMock()
+        mock_token_verifier.return_value = mock_verifier_instance
+
+        mock_provider = MagicMock()
+        mock_oauth_proxy.return_value = mock_provider
+
+        _build_oauth_proxy_provider(auth_config)
+
+        mock_oauth_proxy.assert_called_once_with(
+            upstream_authorization_endpoint="https://accounts.google.com/oauth/authorize",
+            upstream_token_endpoint="https://oauth2.googleapis.com/token",
+            upstream_client_id="test_client",
+            upstream_client_secret="test_secret",
+            token_verifier=mock_verifier_instance,
+            base_url="https://auth-host.example.uk",
         )
 
     def test_build_oauth_proxy_provider_missing_fields(self):


### PR DESCRIPTION
## Summary
- Fixes a `str.rstrip()` vs `str.removesuffix()` bug in OAuth `base_url` derivation, at two call sites in `src/itential_mcp/server/auth.py`: `_build_oauth_provider` and `_build_oauth_proxy_provider`.
- `rstrip("/auth/callback")` treats its argument as a character SET, not a suffix - it strips any trailing characters matching `{/, a, u, t, h, c, l, b, k}`, which can silently corrupt `base_url` for redirect URIs whose host ends in characters from that set (e.g. a `.uk`-TLD host). Fixed to `removesuffix("/auth/callback")`, which is suffix-safe.
- Only affects OAuth (`type=oauth` / `type=oauth_proxy`) provider construction - JWT auth and no-auth paths are untouched.
- Added a single TODO comment (no logic change) noting `_get_provider_config` is dead code, not called by any provider builder. Deliberately left unwired: making `--auth-oauth-provider-type` functional would be new user-visible capability (MINOR), not a bug fix, since the flag has never worked. Tracked separately as a future item.

## Test plan
- [x] `make ci` - 2519 passed, 99% coverage held, bandit 0 issues
- [x] Two new adversarial regression tests (`.uk`-TLD redirect URI) added to `tests/test_auth_oauth.py` - independently verified by reverting to `rstrip` and confirming they fail with the exact corruption described (`https://auth-host.example.` instead of `https://auth-host.example.uk`), then confirmed they pass with `removesuffix` restored.
- [x] All existing `_get_provider_config` tests unchanged and passing (function itself untouched aside from the comment).
- [x] **Live integration test** against `itential-se-poc-dev01.trial.itential.io`: this platform's MCP-server-facing auth type is `none` (not OAuth), so a full live OAuth handshake wasn't possible through this code path. Instead, verified correct `base_url` derivation by calling the real (unmocked) `_build_oauth_provider`/`_build_oauth_proxy_provider` functions directly with realistic and adversarial inputs. Confirmed the `type=none` path has no regression against the live platform (server starts cleanly, tool calls succeed).

### Note: unrelated pre-existing bug found during live testing
`_build_oauth_proxy_provider`'s fallback `StaticTokenVerifier()` call is missing a required `tokens=` argument on the currently pinned fastmcp version, meaning `type=oauth_proxy` currently cannot construct successfully at all when no token verifier override is supplied. Confirmed unrelated to this fix (pre-existing on `devel`). Tracked separately for a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
