### PR TITLE
chore: constrain mcp to >=1.28.1,<2 (resolves 3 high-severity mcp SDK advisories)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Documentation = "https://github.com/itential/itential-mcp"
 itential-mcp = "itential_mcp.app:run"
 
 [tool.uv]
-constraint-dependencies = ["cryptography>=46.0.7,<47"]
+constraint-dependencies = ["cryptography>=46.0.7,<47", "mcp>=1.28.1,<2"]
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,18 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [manifest]
-constraints = [{ name = "cryptography", specifier = ">=46.0.7,<47" }]
+constraints = [
+    { name = "cryptography", specifier = ">=46.0.7,<47" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
+]
 
 [[package]]
 name = "aiofile"
@@ -883,7 +892,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -901,9 +910,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Raise the transitive `mcp` (Python MCP SDK) floor to `>=1.28.1,<2` via `[tool.uv] constraint-dependencies` in `pyproject.toml`, resolving `mcp` from `1.26.0` to `1.29.0`. Fixes 3 high-severity `mcp` SDK advisories.
- `mcp` is a transitive dependency pulled in via `fastmcp`/`fastmcp-slim`, which only floors `mcp>=1.24.0` - so the earlier `fastmcp>=3.4.1` bump (#369) didn't lift it on its own. This PR adds the targeted constraint needed, following the same floor+ceiling pattern already used for `cryptography`.
- The `<2` ceiling explicitly excludes `mcp 2.0.0` (a same-day major redesign, released the same day this constraint was added) - out of scope for this CVE fix.
- `starlette` (`1.3.1`) and `fastmcp`/`fastmcp-slim` (`3.4.4`) are unchanged. No other package in `uv.lock` drifted. No `.py` files changed.

## Why this needed extra scrutiny
`mcp` v1.27.1 modified output-schema generation code ("catch PydanticUserError when generating output schema, pydantic 2.13 compat") - this touches the exact code path that broke `trigger_automation`/`start_workflow`'s union return type (`StartWorkflowResponse | StartAgentResponse`) in a prior real incident (#356/#361, where a live platform run - not unit tests - caught the bug). This bump was treated with the same rigor as that incident's lesson demands.

## Test plan
- [x] `make ci` - 2519 passed, 99% coverage held, bandit 0 issues
- [x] Confirmed resolved versions: `mcp==1.29.0` (not `2.0.0`), `starlette==1.3.1` and `fastmcp==3.4.4`/`fastmcp-slim==3.4.4` unchanged, no other package drifted
- [x] Statically inspected the raw generated `output_schema` JSON for `trigger_automation`/`start_workflow` - confirmed structurally correct `anyOf` union with proper `$defs`, no leaked raw type, no `PydanticUserError`
- [x] Ran the full test suite with `-W error::DeprecationWarning` to confirm no new WebSocket/wsproto deprecation warnings (mcp 1.28.0 added these) - clean pass, not masked by repo's `filterwarnings` config
- [x] **Live integration test** against `itential-se-poc-dev01.trial.itential.io`: clean server startup, all 68 tools/13 service plugins registered with no schema-generation exceptions. Triggered a real workflow automation end-to-end - valid `StartWorkflowResponse` returned, followed by a successful `describe_job`. Confirmed identical shape/success against `devel` HEAD (pre-bump, `mcp==1.26.0`) via a worktree comparison for the same payload.

### Known gap in this testing (not a regression, tracked separately)
Could not live-verify the `StartAgentResponse` branch of the union - all 3 agent-type automation routes tried on this platform returned a live `400 Bad Request`, even with well-formed, schema-matching payloads. Confirmed via the same `devel`-HEAD worktree comparison that this 400 is **pre-existing and unrelated to this bump** (identical failure with `mcp==1.26.0`). The schema-generation risk this PR was actually flagged for is a static, at-registration-time property of the union type, and was verified two ways (static schema inspection covering both branches + a clean live registration of all tools with zero exceptions), so this gap doesn't block the fix itself. Root cause of the 400s is untriaged and tracked as its own follow-up.
