### PR TITLE
fix: surface CLI tool errors by default and include response body

### DIFF
--- a/src/itential_mcp/app.py
+++ b/src/itential_mcp/app.py
@@ -8,6 +8,7 @@ import asyncio
 from .runtime import parse_args
 from .core import env
 from .core import logging
+from .core import heuristics
 
 
 def run() -> int:
@@ -31,6 +32,14 @@ def run() -> int:
         raise
     except Exception as e:
         logging.error(f"Application error: {e}")
+        # Always print a clean, single-line error message to stderr. The
+        # application logger is pinned above FATAL by default, so this is
+        # the only guaranteed-visible error output unless the caller has
+        # configured logging explicitly. This message may now carry
+        # upstream HTTP response bodies, so it is run through the same
+        # sensitive-data redaction pipeline used by core.logging before
+        # being printed.
+        print(heuristics.scan_and_redact(f"ERROR: {e}"), file=sys.stderr)
         if env.getbool("ITENTIAL_MCP_DEBUG", False):
             import traceback
 

--- a/src/itential_mcp/core/heuristics.py
+++ b/src/itential_mcp/core/heuristics.py
@@ -98,10 +98,16 @@ class Scanner:
         Raises:
             None
         """
-        # API Keys and tokens (various formats)
+        # API Keys and tokens (various formats). The optional `["']?` before
+        # the key name and between the key name and the `[=:]` separator
+        # allows these patterns to also match JSON-formatted content where
+        # the key is quoted with either double or single quotes, e.g.
+        # `"api_key": "AKIA1234567890ABCDEF12"` or
+        # `'api_key': 'AKIA1234567890ABCDEF12'`, in addition to the plain
+        # `key=value` / `key: value` forms.
         self.add_pattern(
             "api_key",
-            r"(?i)\b(?:api[_-]?key|apikey)\s*[=:]\s*[\"']?([a-zA-Z0-9_\-]{16,})[\"']?",
+            r"(?i)[\"']?\b(?:api[_-]?key|apikey)[\"']?\s*[=:]\s*[\"']?([a-zA-Z0-9_\-]{16,})[\"']?",
         )
         self.add_pattern("bearer_token", r"(?i)\bbearer\s+([a-zA-Z0-9_\-\.]{20,})")
         self.add_pattern(
@@ -110,17 +116,17 @@ class Scanner:
         )
         self.add_pattern(
             "access_token",
-            r"(?i)\b(?:access[_-]?token|accesstoken)\s*[=:]\s*[\"']?([a-zA-Z0-9_\-]{20,})[\"']?",
+            r"(?i)[\"']?\b(?:access[_-]?token|accesstoken)[\"']?\s*[=:]\s*[\"']?([a-zA-Z0-9_\-]{20,})[\"']?",
         )
 
         # Password patterns
         self.add_pattern(
             "password",
-            r"(?i)\b(?:password|passwd|pwd)\s*[=:]\s*[\"']?([^\s\"']{6,})[\"']?",
+            r"(?i)[\"']?\b(?:password|passwd|pwd)[\"']?\s*[=:]\s*[\"']?([^\s\"']{6,})[\"']?",
         )
         self.add_pattern(
             "secret",
-            r"(?i)\b(?:secret|client_secret)\s*[=:]\s*[\"']?([a-zA-Z0-9_\-]{16,})[\"']?",
+            r"(?i)[\"']?\b(?:secret|client_secret)[\"']?\s*[=:]\s*[\"']?([a-zA-Z0-9_\-]{16,})[\"']?",
         )
 
         # URLs with authentication (check before email patterns)

--- a/src/itential_mcp/platform/client.py
+++ b/src/itential_mcp/platform/client.py
@@ -2,10 +2,13 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import asyncio
 import pathlib
 import importlib
 import importlib.util
+from typing import Any
 
 import ipsdk
 
@@ -18,6 +21,186 @@ from ..config.converters import platform_to_dict
 from . import response
 from ..core import exceptions
 from ..core import logging
+
+# Maximum number of characters of an upstream response body to include in an
+# error message. Longer bodies are truncated to keep error output readable.
+MAX_ERROR_BODY_LENGTH = 2048
+
+
+def _format_error_message(exc: Exception) -> str:
+    """Build an error message that includes the upstream response body.
+
+    When the underlying exception carries an HTTP response (e.g. from
+    ipsdk/httpx), the response body text is appended to the exception
+    message so callers can see the actual error returned by the
+    platform, not just a terse status line. The body is truncated to
+    `MAX_ERROR_BODY_LENGTH` characters to keep error output readable.
+
+    Only response bodies are ever included here -- request bodies are
+    never surfaced in error messages.
+
+    Args:
+        exc (Exception): The exception raised while sending the request.
+
+    Returns:
+        str: The formatted error message, including the response body
+            when available, or the plain exception message otherwise.
+
+    Raises:
+        None
+    """
+    if hasattr(exc, "response") and exc.response is not None:
+        try:
+            body = exc.response.text
+        except Exception:
+            body = None
+
+        if body:
+            if len(body) > MAX_ERROR_BODY_LENGTH:
+                body = f"{body[:MAX_ERROR_BODY_LENGTH]}... (truncated)"
+            return f"{exc} | response: {body}"
+
+    return str(exc)
+
+
+class _ErrorFormattingClient:
+    """Wraps a raw ipsdk client to surface upstream response bodies on error.
+
+    Service plugins under `platform/services/*.py` call `get`/`post`/`put`/
+    `delete` directly on the raw ipsdk `AsyncPlatform` client, bypassing
+    `PlatformClient.send_request()` entirely. This wrapper sits between the
+    service plugins and the raw client so that `ipsdk.exceptions.HTTPStatusError`
+    raised from any of those calls is reformatted to include the upstream
+    response body, matching the error detail already provided on the
+    `send_request()`/CLI code path.
+
+    Only `ipsdk.exceptions.HTTPStatusError` is intercepted here. All other
+    exceptions (network errors, timeouts, SDK errors, etc.) propagate
+    unchanged, exactly as they would without this wrapper.
+
+    The raw ipsdk response object is returned unchanged on success -- it is
+    not wrapped in `platform.response.Response` since services consume the
+    raw response shape directly (e.g. via `.json()`).
+
+    Attributes:
+        _client (AsyncPlatform): The wrapped raw ipsdk client.
+    """
+
+    def __init__(self, client: AsyncPlatform):
+        """Initialize the wrapper around a raw ipsdk client.
+
+        Args:
+            client (AsyncPlatform): The raw ipsdk client to wrap.
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        self._client = client
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        """Send an HTTP GET request via the wrapped client.
+
+        Args:
+            path (str): The URI path to request.
+            params (dict[str, Any] | None): Query string parameters. Defaults to None.
+
+        Returns:
+            Any: The raw ipsdk response object, unchanged.
+
+        Raises:
+            exceptions.ItentialMcpException: If the server returns an HTTP
+                error status, with the upstream response body included.
+        """
+        try:
+            return await self._client.get(path, params=params)
+        except ipsdk.exceptions.HTTPStatusError as exc:
+            raise exceptions.ItentialMcpException(_format_error_message(exc))
+
+    async def post(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json: str | bytes | dict | list | None = None,
+    ) -> Any:
+        """Send an HTTP POST request via the wrapped client.
+
+        Args:
+            path (str): The URI path to request.
+            params (dict[str, Any] | None): Query string parameters. Defaults to None.
+            json (str | bytes | dict | list | None): JSON body to send. Defaults to None.
+
+        Returns:
+            Any: The raw ipsdk response object, unchanged.
+
+        Raises:
+            exceptions.ItentialMcpException: If the server returns an HTTP
+                error status, with the upstream response body included.
+        """
+        try:
+            return await self._client.post(path, params=params, json=json)
+        except ipsdk.exceptions.HTTPStatusError as exc:
+            raise exceptions.ItentialMcpException(_format_error_message(exc))
+
+    async def put(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json: str | bytes | dict | list | None = None,
+    ) -> Any:
+        """Send an HTTP PUT request via the wrapped client.
+
+        Args:
+            path (str): The URI path to request.
+            params (dict[str, Any] | None): Query string parameters. Defaults to None.
+            json (str | bytes | dict | list | None): JSON body to send. Defaults to None.
+
+        Returns:
+            Any: The raw ipsdk response object, unchanged.
+
+        Raises:
+            exceptions.ItentialMcpException: If the server returns an HTTP
+                error status, with the upstream response body included.
+        """
+        try:
+            return await self._client.put(path, params=params, json=json)
+        except ipsdk.exceptions.HTTPStatusError as exc:
+            raise exceptions.ItentialMcpException(_format_error_message(exc))
+
+    async def delete(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        """Send an HTTP DELETE request via the wrapped client.
+
+        Args:
+            path (str): The URI path to request.
+            params (dict[str, Any] | None): Query string parameters. Defaults to None.
+
+        Returns:
+            Any: The raw ipsdk response object, unchanged.
+
+        Raises:
+            exceptions.ItentialMcpException: If the server returns an HTTP
+                error status, with the upstream response body included.
+        """
+        try:
+            return await self._client.delete(path, params=params)
+        except ipsdk.exceptions.HTTPStatusError as exc:
+            raise exceptions.ItentialMcpException(_format_error_message(exc))
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate any other attribute access to the wrapped client.
+
+        Args:
+            name (str): The attribute name being accessed.
+
+        Returns:
+            Any: The attribute value from the wrapped client.
+
+        Raises:
+            AttributeError: If the wrapped client does not have the attribute.
+        """
+        return getattr(self._client, name)
 
 
 class PlatformClient(object):
@@ -146,6 +329,13 @@ class PlatformClient(object):
         if not services_path.exists():
             return
 
+        # Wrap the raw ipsdk client so that service plugins get response
+        # bodies included in HTTP error messages, matching the behavior of
+        # PlatformClient.send_request(). Service plugins call get/post/put/
+        # delete directly on this wrapped client rather than going through
+        # send_request().
+        wrapped_client = _ErrorFormattingClient(self.client)
+
         # Get Python files, excluding private modules and __pycache__
         python_files = [
             f
@@ -175,7 +365,7 @@ class PlatformClient(object):
                     )
                     continue
 
-                service_instance = module.Service(self.client)
+                service_instance = module.Service(wrapped_client)
 
                 # Validate service instance has a name attribute
                 if not hasattr(service_instance, "name"):
@@ -308,7 +498,7 @@ class PlatformClient(object):
                 f"Request to {path} timed out after {request_timeout}s"
             )
         except Exception as exc:
-            raise exceptions.ItentialMcpException(str(exc))
+            raise exceptions.ItentialMcpException(_format_error_message(exc))
 
         return await self._make_response(res)
 

--- a/src/itential_mcp/runtime/runner.py
+++ b/src/itential_mcp/runtime/runner.py
@@ -44,6 +44,11 @@ async def run(tool: str, params: Mapping[str, Any] | None = None) -> None:
         ValueError: The one or more required parameters are missing
 
         ValueError: If there are invalid parameters
+
+        fastmcp.exceptions.ToolError: If the tool invocation fails on the
+            server side. This is intentionally not caught here so it
+            propagates to the caller (e.g. `app.run`) to be surfaced as a
+            visible error.
     """
     async with Server(config.get()) as srv:
         async with Client(srv.mcp) as client:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -268,6 +268,42 @@ class TestRun:
         assert result == 1
         mock_print_exc.assert_called_once()
 
+    @patch("sys.stderr", new_callable=StringIO)
+    @patch("os.environ", {})
+    @patch("itential_mcp.app.parse_args")
+    @patch("sys.argv", ["itential-mcp", "run"])
+    def test_run_exception_handling_prints_clean_error_without_debug(
+        self, mock_parse_args, mock_stderr
+    ):
+        """Test that a clean error line is written to stderr by default,
+        without ITENTIAL_MCP_DEBUG set, and the exit code is 1."""
+        mock_parse_args.side_effect = Exception("Test exception")
+
+        result = app.run()
+
+        assert result == 1
+        output = mock_stderr.getvalue()
+        assert "ERROR: Test exception" in output
+
+    @patch("traceback.print_exc")
+    @patch("sys.stderr", new_callable=StringIO)
+    @patch("os.environ", {"ITENTIAL_MCP_DEBUG": "true"})
+    @patch("itential_mcp.app.parse_args")
+    @patch("sys.argv", ["itential-mcp", "run"])
+    def test_run_exception_handling_prints_clean_error_and_traceback_in_debug_mode(
+        self, mock_parse_args, mock_stderr, mock_print_exc
+    ):
+        """Test that in debug mode both the clean stderr error line AND the
+        full traceback are emitted together, not just one or the other."""
+        mock_parse_args.side_effect = Exception("Test exception")
+
+        result = app.run()
+
+        assert result == 1
+        output = mock_stderr.getvalue()
+        assert "ERROR: Test exception" in output
+        mock_print_exc.assert_called_once()
+
     @patch("itential_mcp.core.logging.info")
     @patch("asyncio.run")
     @patch("itential_mcp.app.parse_args")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,10 @@ import tempfile
 import textwrap
 from unittest.mock import AsyncMock, patch, MagicMock
 
+import ipsdk
+
 from itential_mcp.platform import PlatformClient
+from itential_mcp.platform.client import _ErrorFormattingClient, _format_error_message
 from ipsdk.http import HTTPMethod
 
 
@@ -177,7 +180,10 @@ def test_init_plugins_loads_valid_services(
             # Should have loaded the valid service
             assert hasattr(client, "test_service")
             assert client.test_service.name == "test_service"
-            assert client.test_service.client is mock_ipsdk_client
+            # Services receive the error-formatting wrapper, not the raw
+            # ipsdk client, so that HTTP errors surface response bodies.
+            assert isinstance(client.test_service.client, _ErrorFormattingClient)
+            assert client.test_service.client._client is mock_ipsdk_client
 
             # Should not have loaded invalid or private services
             assert not hasattr(client, "invalid_service")
@@ -906,6 +912,89 @@ def test_init_client_with_disable_tls_warning(mock_config_with_disable_tls):
 
 
 @pytest.mark.asyncio
+async def test_send_request_includes_response_body(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test that send_request includes the upstream response body text in
+    the raised ItentialMcpException message when the underlying exception
+    carries a `.response` attribute."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    mock_response = MagicMock()
+    mock_response.text = '{"error": "invalid device_type"}'
+
+    error = Exception("400 Bad Request")
+    error.response = mock_response
+
+    mock_ipsdk_client._send_request = AsyncMock(side_effect=error)
+
+    client = PlatformClient()
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await client.send_request(method="POST", path="/test")
+
+    message = str(exc_info.value)
+    assert "400 Bad Request" in message
+    assert '{"error": "invalid device_type"}' in message
+
+
+@pytest.mark.asyncio
+async def test_send_request_truncates_long_response_body(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test that an overly long response body is truncated to
+    MAX_ERROR_BODY_LENGTH characters and suffixed with a truncation marker."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+    from itential_mcp.platform.client import MAX_ERROR_BODY_LENGTH
+
+    long_body = "x" * (MAX_ERROR_BODY_LENGTH + 500)
+
+    mock_response = MagicMock()
+    mock_response.text = long_body
+
+    error = Exception("500 Server Error")
+    error.response = mock_response
+
+    mock_ipsdk_client._send_request = AsyncMock(side_effect=error)
+
+    client = PlatformClient()
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await client.send_request(method="GET", path="/test")
+
+    message = str(exc_info.value)
+    assert "... (truncated)" in message
+    # Ensure the body portion embedded in the message was capped
+    truncated_segment = message.split("response: ")[1]
+    assert truncated_segment.startswith("x" * MAX_ERROR_BODY_LENGTH)
+    assert truncated_segment == f"{'x' * MAX_ERROR_BODY_LENGTH}... (truncated)"
+
+
+@pytest.mark.asyncio
+async def test_send_request_without_response_falls_back_to_str(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Regression guard: when the underlying exception has no `.response`
+    attribute (or it is None), send_request should still raise an
+    ItentialMcpException with the plain string of the original exception,
+    matching the pre-existing behavior."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    mock_ipsdk_client._send_request = AsyncMock(
+        side_effect=Exception("Connection failed")
+    )
+
+    client = PlatformClient()
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await client.send_request(method="GET", path="/test")
+
+    message = str(exc_info.value)
+    assert message == "Connection failed"
+    assert "response:" not in message
+
+
+@pytest.mark.asyncio
 async def test_send_request_timeout_error(
     patched_platform_factory, patched_config_get, mock_ipsdk_client
 ):
@@ -926,3 +1015,331 @@ async def test_send_request_timeout_error(
         await client.send_request(method="GET", path="/test", timeout=0.001)
 
     assert "timed out" in str(exc_info.value)
+
+
+def test_format_error_message_module_level_includes_response_body():
+    """Test that the module-level _format_error_message helper includes the
+    upstream response body when the exception carries a `.response`."""
+    mock_response = MagicMock()
+    mock_response.text = '{"error": "invalid device_type"}'
+
+    error = Exception("400 Bad Request")
+    error.response = mock_response
+
+    message = _format_error_message(error)
+
+    assert "400 Bad Request" in message
+    assert '{"error": "invalid device_type"}' in message
+
+
+def test_format_error_message_module_level_truncates_long_body():
+    """Test that the module-level _format_error_message helper truncates an
+    overly long response body."""
+    from itential_mcp.platform.client import MAX_ERROR_BODY_LENGTH
+
+    long_body = "x" * (MAX_ERROR_BODY_LENGTH + 500)
+
+    mock_response = MagicMock()
+    mock_response.text = long_body
+
+    error = Exception("500 Server Error")
+    error.response = mock_response
+
+    message = _format_error_message(error)
+
+    assert "... (truncated)" in message
+    truncated_segment = message.split("response: ")[1]
+    assert truncated_segment == f"{'x' * MAX_ERROR_BODY_LENGTH}... (truncated)"
+
+
+def test_format_error_message_module_level_without_response_falls_back():
+    """Test that the module-level _format_error_message helper falls back to
+    str(exc) when there is no `.response` attribute."""
+    error = Exception("Connection failed")
+
+    message = _format_error_message(error)
+
+    assert message == "Connection failed"
+    assert "response:" not in message
+
+
+def _make_http_status_error(body_text: str, message: str = "400 Bad Request"):
+    """Build a real ipsdk.exceptions.HTTPStatusError with a mock response body."""
+    mock_response = MagicMock()
+    mock_response.text = body_text
+
+    httpx_exc = MagicMock()
+    httpx_exc.args = (message,)
+    httpx_exc.response = mock_response
+    httpx_exc.request = MagicMock()
+
+    return ipsdk.exceptions.HTTPStatusError(httpx_exc)
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_get_returns_raw_response_on_success():
+    """Test that _ErrorFormattingClient.get returns the raw response object
+    unchanged (same identity) on success."""
+    raw_client = AsyncMock()
+    sentinel_response = MagicMock()
+    raw_client.get = AsyncMock(return_value=sentinel_response)
+
+    wrapper = _ErrorFormattingClient(raw_client)
+    result = await wrapper.get("/path", params={"a": 1})
+
+    raw_client.get.assert_called_once_with("/path", params={"a": 1})
+    assert result is sentinel_response
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_post_returns_raw_response_on_success():
+    """Test that _ErrorFormattingClient.post returns the raw response object
+    unchanged (same identity) on success."""
+    raw_client = AsyncMock()
+    sentinel_response = MagicMock()
+    raw_client.post = AsyncMock(return_value=sentinel_response)
+
+    wrapper = _ErrorFormattingClient(raw_client)
+    result = await wrapper.post("/path", params={"a": 1}, json={"b": 2})
+
+    raw_client.post.assert_called_once_with("/path", params={"a": 1}, json={"b": 2})
+    assert result is sentinel_response
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_put_returns_raw_response_on_success():
+    """Test that _ErrorFormattingClient.put returns the raw response object
+    unchanged (same identity) on success."""
+    raw_client = AsyncMock()
+    sentinel_response = MagicMock()
+    raw_client.put = AsyncMock(return_value=sentinel_response)
+
+    wrapper = _ErrorFormattingClient(raw_client)
+    result = await wrapper.put("/path", json={"b": 2})
+
+    raw_client.put.assert_called_once_with("/path", params=None, json={"b": 2})
+    assert result is sentinel_response
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_delete_returns_raw_response_on_success():
+    """Test that _ErrorFormattingClient.delete returns the raw response object
+    unchanged (same identity) on success."""
+    raw_client = AsyncMock()
+    sentinel_response = MagicMock()
+    raw_client.delete = AsyncMock(return_value=sentinel_response)
+
+    wrapper = _ErrorFormattingClient(raw_client)
+    result = await wrapper.delete("/path")
+
+    raw_client.delete.assert_called_once_with("/path", params=None)
+    assert result is sentinel_response
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_get_reformats_http_status_error():
+    """Test that _ErrorFormattingClient.get reformats HTTPStatusError to
+    include the upstream response body."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    raw_client = AsyncMock()
+    raw_client.get = AsyncMock(
+        side_effect=_make_http_status_error('{"error": "not found"}', "404 Not Found")
+    )
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await wrapper.get("/missing")
+
+    message = str(exc_info.value)
+    assert "404 Not Found" in message
+    assert '{"error": "not found"}' in message
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_post_reformats_http_status_error():
+    """Test that _ErrorFormattingClient.post reformats HTTPStatusError to
+    include the upstream response body."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    raw_client = AsyncMock()
+    raw_client.post = AsyncMock(
+        side_effect=_make_http_status_error(
+            '{"error": "invalid device_type"}', "400 Bad Request"
+        )
+    )
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await wrapper.post("/create", json={"foo": "bar"})
+
+    message = str(exc_info.value)
+    assert "400 Bad Request" in message
+    assert '{"error": "invalid device_type"}' in message
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_put_reformats_http_status_error():
+    """Test that _ErrorFormattingClient.put reformats HTTPStatusError to
+    include the upstream response body."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    raw_client = AsyncMock()
+    raw_client.put = AsyncMock(
+        side_effect=_make_http_status_error('{"error": "conflict"}', "409 Conflict")
+    )
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    with pytest.raises(ItentialMcpException):
+        await wrapper.put("/update/1", json={"foo": "bar"})
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_delete_reformats_http_status_error():
+    """Test that _ErrorFormattingClient.delete reformats HTTPStatusError to
+    include the upstream response body."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    raw_client = AsyncMock()
+    raw_client.delete = AsyncMock(
+        side_effect=_make_http_status_error('{"error": "forbidden"}', "403 Forbidden")
+    )
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await wrapper.delete("/resource/1")
+
+    message = str(exc_info.value)
+    assert "403 Forbidden" in message
+    assert '{"error": "forbidden"}' in message
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_propagates_non_http_status_exceptions():
+    """Test that exceptions other than ipsdk.exceptions.HTTPStatusError are
+    NOT caught or modified by _ErrorFormattingClient -- they propagate
+    completely unchanged."""
+    raw_client = AsyncMock()
+    raw_client.get = AsyncMock(side_effect=ValueError("boom"))
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    with pytest.raises(ValueError, match="boom"):
+        await wrapper.get("/path")
+
+
+@pytest.mark.asyncio
+async def test_error_formatting_client_propagates_ipsdk_request_error():
+    """Test that ipsdk.exceptions.RequestError (network-level errors) is not
+    caught by _ErrorFormattingClient and propagates unchanged."""
+    httpx_exc = MagicMock()
+    httpx_exc.args = ("Connection refused",)
+    httpx_exc.request = MagicMock()
+
+    request_error = ipsdk.exceptions.RequestError(httpx_exc)
+
+    raw_client = AsyncMock()
+    raw_client.post = AsyncMock(side_effect=request_error)
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    with pytest.raises(ipsdk.exceptions.RequestError):
+        await wrapper.post("/path", json={})
+
+
+def test_error_formatting_client_getattr_delegates_to_wrapped_client():
+    """Test that __getattr__ forwards arbitrary attribute access to the
+    wrapped raw client (needed so ServiceBase._paginate and similar helpers
+    keep working)."""
+    raw_client = MagicMock()
+    raw_client.some_arbitrary_attribute = "sentinel-value"
+
+    wrapper = _ErrorFormattingClient(raw_client)
+
+    assert wrapper.some_arbitrary_attribute == "sentinel-value"
+
+
+@pytest.mark.asyncio
+async def test_real_service_surfaces_response_body_through_wrapper():
+    """Load-bearing test: construct _ErrorFormattingClient around a mock raw
+    ipsdk client whose `post` raises a real ipsdk.exceptions.HTTPStatusError
+    with a response body, hand the wrapper to an actual
+    operations_manager.Service instance, and call a real service method.
+
+    This proves the fix reaches real tool call paths -- service plugins call
+    get/post/put/delete directly on the raw ipsdk client, bypassing
+    PlatformClient.send_request()/_format_error_message() entirely. Prior
+    test coverage always used AsyncMock() clients directly, which bypassed
+    the wrapper and gave false confidence.
+    """
+    from itential_mcp.core.exceptions import ItentialMcpException
+    from itential_mcp.platform.services import operations_manager
+
+    raw_client = AsyncMock()
+    raw_client.post = AsyncMock(
+        side_effect=_make_http_status_error(
+            '{"error": "invalid input for workflow trigger"}',
+            "400 Bad Request",
+        )
+    )
+
+    wrapper = _ErrorFormattingClient(raw_client)
+    service = operations_manager.Service(wrapper)
+
+    with pytest.raises(ItentialMcpException) as exc_info:
+        await service.start_workflow("my-workflow-route", {"device": "router1"})
+
+    message = str(exc_info.value)
+    assert "400 Bad Request" in message
+    assert '{"error": "invalid input for workflow trigger"}' in message
+
+
+@pytest.mark.asyncio
+async def test_init_plugins_wires_error_formatting_client_into_services(
+    patched_platform_factory, patched_config_get, mock_ipsdk_client
+):
+    """Test that _init_plugins passes an _ErrorFormattingClient (not the raw
+    ipsdk client) to service constructors, and that HTTP errors raised from
+    calls made through a loaded service surface the response body."""
+    from itential_mcp.core.exceptions import ItentialMcpException
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        services_dir = pathlib.Path(temp_dir) / "services"
+        services_dir.mkdir()
+
+        service_file = services_dir / "probe_service.py"
+        service_file.write_text(
+            textwrap.dedent("""
+            class Service:
+                def __init__(self, client):
+                    self.client = client
+                    self.name = "probe_service"
+
+                async def do_get(self, path):
+                    return await self.client.get(path)
+        """)
+        )
+
+        with patch("itential_mcp.platform.client.pathlib.Path.resolve") as resolve_mock:
+            resolve_mock.return_value.parent = pathlib.Path(temp_dir)
+
+            client = PlatformClient()
+
+            # The service should have been handed the wrapper, not the raw client
+            assert isinstance(client.probe_service.client, _ErrorFormattingClient)
+            assert client.probe_service.client._client is mock_ipsdk_client
+
+            mock_ipsdk_client.get = AsyncMock(
+                side_effect=_make_http_status_error('{"error": "gone"}', "410 Gone")
+            )
+
+            with pytest.raises(ItentialMcpException) as exc_info:
+                await client.probe_service.do_get("/resource")
+
+            message = str(exc_info.value)
+            assert "410 Gone" in message
+            assert '{"error": "gone"}' in message

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -361,3 +361,100 @@ password=mysecretpass"""
         assert "[REDACTED_PASSWORD]" in redacted
         assert "secret1234567890abcdef" not in redacted
         assert "mysecretpass" not in redacted
+
+    def test_json_quoted_key_detection(self):
+        """Test detection and redaction of sensitive data in JSON-formatted
+        content where the key name is quoted, e.g. `"api_key": "value"`.
+
+        This is the realistic shape of an upstream HTTP API error response
+        body (JSON), which is surfaced verbatim in exception messages by
+        `platform.client._format_error_message()`.
+        """
+        scanner = Scanner()
+
+        test_cases = [
+            (
+                '"api_key": "AKIA1234567890ABCDEF12"',
+                "api_key",
+                "AKIA1234567890ABCDEF12",
+            ),
+            (
+                '"password": "SuperSecretPass123"',
+                "password",
+                "SuperSecretPass123",
+            ),
+            (
+                '"secret": "topsecretvalue1234"',
+                "secret",
+                "topsecretvalue1234",
+            ),
+            (
+                '"access_token": "abcdefghij1234567890ABCD"',
+                "access_token",
+                "abcdefghij1234567890ABCD",
+            ),
+        ]
+
+        for text, pattern_name, secret_value in test_cases:
+            assert scanner.has_sensitive_data(text)
+            redacted = scanner.scan_and_redact(text)
+            assert f"[REDACTED_{pattern_name.upper()}]" in redacted
+            assert secret_value not in redacted
+
+    def test_json_single_quoted_key_detection(self):
+        """Test detection and redaction of sensitive data in JSON-like
+        content where the key name is single-quoted, e.g.
+        `'api_key': 'value'`.
+
+        Mirrors `test_json_quoted_key_detection` but for the single-quote
+        form, which is used by e.g. Python `repr()`-style dict output.
+        """
+        scanner = Scanner()
+
+        test_cases = [
+            (
+                "'api_key': 'AKIA1234567890ABCDEF12'",
+                "api_key",
+                "AKIA1234567890ABCDEF12",
+            ),
+            (
+                "'password': 'SuperSecretPass123'",
+                "password",
+                "SuperSecretPass123",
+            ),
+            (
+                "'secret': 'topsecretvalue1234'",
+                "secret",
+                "topsecretvalue1234",
+            ),
+            (
+                "'access_token': 'abcdefghij1234567890ABCD'",
+                "access_token",
+                "abcdefghij1234567890ABCD",
+            ),
+        ]
+
+        for text, pattern_name, secret_value in test_cases:
+            assert scanner.has_sensitive_data(text)
+            redacted = scanner.scan_and_redact(text)
+            assert f"[REDACTED_{pattern_name.upper()}]" in redacted
+            assert secret_value not in redacted
+
+    def test_json_quoted_key_nested_in_object(self):
+        """Test that sensitive JSON keys are redacted even when nested
+        inside a larger JSON object, without over-matching neighboring
+        fields.
+        """
+        scanner = Scanner()
+
+        text = (
+            '{"error": "unauthorized", "details": '
+            '{"api_key": "AKIA1234567890ABCDEF12", "reason": "invalid"}}'
+        )
+
+        redacted = scanner.scan_and_redact(text)
+        assert "[REDACTED_API_KEY]" in redacted
+        assert "AKIA1234567890ABCDEF12" not in redacted
+        # Sibling fields in the same JSON object must be left untouched.
+        assert '"error": "unauthorized"' in redacted
+        assert '"reason": "invalid"' in redacted

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,6 +9,8 @@ from io import StringIO
 from dataclasses import dataclass
 from typing import Any
 
+from fastmcp.exceptions import ToolError
+
 from itential_mcp.runtime import runner
 
 
@@ -529,6 +531,55 @@ class TestRun:
         assert '"name": "item1"' in output
         # Should have proper indentation (4 spaces)
         assert '    "result": "success"' in output
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.runtime.runner.Client")
+    @patch("itential_mcp.runtime.runner.Server")
+    @patch("itential_mcp.runtime.runner.config.get")
+    async def test_run_tool_error_not_swallowed(
+        self, mock_config_get, mock_server_class, mock_client_class
+    ):
+        """Test that a ToolError raised by call_tool propagates out of
+        runner.run instead of being silently swallowed. This mirrors the
+        real failure path where the platform returns an error status and
+        fastmcp surfaces it as a ToolError."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config_get.return_value = mock_config
+
+        # Setup server instance mock
+        mock_server_instance = MagicMock()
+        mock_server_instance.mcp = MagicMock()
+        mock_server_instance.__aenter__ = AsyncMock(return_value=mock_server_instance)
+        mock_server_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_server_class.return_value = mock_server_instance
+
+        mock_client = AsyncMock()
+        mock_client.ping.return_value = True
+
+        # Mock tool list response
+        mock_tool = MagicMock()
+        mock_tool.name = "test_tool"
+        mock_tool.inputSchema = {"properties": {}, "required": []}
+
+        mock_list_response = MagicMock()
+        mock_list_response.tools = [mock_tool]
+        mock_client.list_tools_mcp.return_value = mock_list_response
+
+        # Simulate call_tool raising a ToolError (e.g. platform returned 400)
+        mock_client.call_tool = AsyncMock(
+            side_effect=ToolError("platform returned an error")
+        )
+
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_client_class.return_value.__aexit__.return_value = None
+
+        # Execute and verify the ToolError is not swallowed -- it should
+        # propagate out of runner.run unchanged.
+        with pytest.raises(ToolError, match="platform returned an error"):
+            await runner.run("test_tool")
+
+        mock_client.call_tool.assert_called_once_with("test_tool", arguments=None)
 
 
 class TestRunEdgeCases:


### PR DESCRIPTION
## Summary
Fixes two related bugs (backlog item #28) in the CLI error path:

1. **Silent failures**: `itential-mcp call <tool>` on a failed tool call previously produced completely silent output (empty stdout/stderr, exit 1) unless `ITENTIAL_MCP_DEBUG=true` was set - the app logger is pinned above FATAL level, so the only visible error path was a debug-gated traceback. Now a clean `ERROR: ...` line always prints to stderr (passed through the existing sensitive-data redaction pipeline first); `ITENTIAL_MCP_DEBUG` additionally prints the full traceback on top.
2. **Missing response body**: error messages previously dropped the upstream HTTP response body when wrapping platform errors, showing only the URL and status code - making root-causing any live tool failure much harder than necessary.

## Changes
- `src/itential_mcp/app.py`: unconditional stderr error print, redacted via `heuristics.scan_and_redact()`.
- `src/itential_mcp/platform/client.py`: new `_format_error_message()` helper (module-level) includes the upstream response body (`.text`, truncated to 2048 chars). **Critically**, this is wired in via a new `_ErrorFormattingClient` wrapper inserted at the single `_init_plugins` call site, so it reaches all 14 service plugins - not just the `PlatformClient.send_request()`/CLI-bindings path, which was the only thing an earlier version of this fix actually covered (see Testing below). The wrapper intercepts only `ipsdk.exceptions.HTTPStatusError`; all other exceptions propagate completely unchanged, and successful calls return the raw response object unmodified.
- `src/itential_mcp/core/heuristics.py`: extended the sensitive-data redaction patterns (`api_key`, `access_token`, `password`, `secret`) to also match JSON-quoted-key form (both double- and single-quoted), since error messages can now carry JSON response bodies.

## Testing
- [x] `make ci` - 2544 passed, 99% coverage held, bandit 0 issues
- [x] New tests prove the fix reaches a REAL service call path (not just a mock that bypasses the wrapper) - constructed the wrapper around a real `operations_manager.Service` and confirmed the response body surfaces in the raised exception; also confirmed `_init_plugins` genuinely installs the wrapper for services.
- [x] Redaction verified directly against realistic JSON secret patterns (both quote styles), with regression checks confirming existing non-JSON redaction patterns still work, and a nested-JSON test confirming the fix isn't overly broad.
- [x] **Live integration testing, two rounds**: the first round of this fix passed all unit tests and three rounds of code review, but a live test found the response-body fix was **entirely dead code** for real tool calls - all 14 service plugins call the raw ipsdk client directly, bypassing the code path the original fix touched. This was redesigned (see the `_ErrorFormattingClient` wrapper above) and re-tested live: the response body now genuinely appears for real tool-call failures across two distinct services (`operations_manager` via an actual CLI call, `health` via a direct wrapper probe against the live platform), debug mode still shows both the clean error and full traceback together, and happy-path calls are unaffected.

### Related finding (not fixed in this PR)
This branch's live integration testing incidentally confirmed the root cause of #27 (agent-type `trigger_automation` calls returning a live 400) as a missing `device` field - the platform's validator requires it even though the tool's advertised `input_schema` doesn't mark it required. Including `device` in the payload succeeds. The actual payload/schema fix will land in its own PR; this is noted here since the improved error visibility from this PR is what made the root cause finally visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
