### PR TITLE
fix: replace broken StaticTokenVerifier fallback with JWTVerifier in oauth_proxy

### DIFF
--- a/docs/oauth-authentication.md
+++ b/docs/oauth-authentication.md
@@ -43,6 +43,8 @@ For OAuth proxy mode (`oauth_proxy`):
 | `ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL` | `--auth-oauth-token-url` | **Required** - Upstream token endpoint |
 | `ITENTIAL_MCP_SERVER_AUTH_OAUTH_USERINFO_URL` | `--auth-oauth-userinfo-url` | Optional - Upstream user info endpoint |
 | `ITENTIAL_MCP_SERVER_AUTH_OAUTH_PROVIDER_TYPE` | `--auth-oauth-provider-type` | Provider type: `google`, `azure`, `auth0`, `github`, `okta`, `generic` |
+| `ITENTIAL_MCP_SERVER_AUTH_JWKS_URI` | `--auth-jwks-uri` | **Required** (one of `jwks_uri` or `public_key`) - JWKS endpoint for verifying upstream tokens |
+| `ITENTIAL_MCP_SERVER_AUTH_PUBLIC_KEY` | `--auth-public-key` | **Required** (one of `jwks_uri` or `public_key`) - Static public key/secret for verifying upstream tokens |
 
 ## OAuth Provider Mode
 
@@ -84,6 +86,10 @@ The OAuth provider automatically derives the base URL from the redirect URI by r
 
 The OAuth proxy mode delegates authentication to external OAuth providers while maintaining control over token validation and user sessions.
 
+### Token Verification Requirement
+
+OAuth proxy mode validates tokens issued by the upstream provider using a `JWTVerifier`. Because the MCP server itself never issues these tokens, it needs a way to verify their signatures independently -- either by fetching signing keys dynamically from the provider's JWKS endpoint, or by checking against a static public key/secret. At least one of `ITENTIAL_MCP_SERVER_AUTH_JWKS_URI` (`--auth-jwks-uri`) or `ITENTIAL_MCP_SERVER_AUTH_PUBLIC_KEY` (`--auth-public-key`) is therefore **required** when `auth_type` is `oauth_proxy`. If neither is set, the server raises a `ConfigurationException` at startup rather than proceeding without a way to validate tokens.
+
 ### Supported Providers
 
 The MCP server includes predefined configurations for popular OAuth providers:
@@ -110,6 +116,8 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_SECRET="your-azure-client-secret"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL="https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://login.microsoftonline.com/common/oauth2/v2.0/token"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
+# Replace {tenant} with your Azure AD tenant ID, or "common" for multi-tenant apps
+export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys"
 ```
 
 **Default scopes for Azure:** `openid email profile`
@@ -125,6 +133,15 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://github.com/login/oauth/
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
 ```
 
+**Note:** GitHub OAuth access tokens are opaque strings, not JWTs, and GitHub does not
+publish a JWKS endpoint for verifying them. `oauth_proxy` mode requires a `JWTVerifier`
+(configured via `ITENTIAL_MCP_SERVER_AUTH_JWKS_URI` or `ITENTIAL_MCP_SERVER_AUTH_PUBLIC_KEY`),
+so GitHub's standard OAuth token flow is not directly compatible with this mode as
+documented here. If you need to front GitHub authentication with `oauth_proxy`, you must
+put an identity layer in front of it that issues verifiable JWTs (for example, GitHub
+Apps' OIDC-based flows or a third-party identity broker) and point `jwks_uri` at that
+layer's JWKS endpoint instead of a GitHub URL.
+
 **Default scopes for GitHub:** `user:email`
 
 #### Auth0 OAuth
@@ -136,6 +153,7 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_SECRET="your-auth0-client-secret"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL="https://your-domain.auth0.com/authorize"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://your-domain.auth0.com/oauth/token"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
+export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://your-domain.auth0.com/.well-known/jwks.json"
 ```
 
 **Default scopes for Auth0:** `openid email profile`
@@ -149,6 +167,7 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_SECRET="your-okta-client-secret"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL="https://your-domain.okta.com/oauth2/default/v1/authorize"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://your-domain.okta.com/oauth2/default/v1/token"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
+export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://your-domain.okta.com/oauth2/default/v1/keys"
 ```
 
 **Default scopes for Okta:** `openid email profile`
@@ -164,6 +183,8 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://provider.example.com/oa
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_USERINFO_URL="https://provider.example.com/oauth/userinfo"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_SCOPES="openid email profile"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
+# Replace with your provider's actual JWKS endpoint
+export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://provider.example.com/.well-known/jwks.json"
 ```
 
 **Note:** Generic providers require explicit scope configuration.
@@ -215,6 +236,7 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL="https://accounts.google
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://oauth2.googleapis.com/token"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_SCOPES="openid email profile"
+export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://www.googleapis.com/oauth2/v3/certs"
 
 # Start the server
 itential-mcp --transport sse --host 0.0.0.0 --port 8000
@@ -255,6 +277,7 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_AUTHORIZATION_URL="https://login.microsoft
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_TOKEN_URL="https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="https://your-domain.com/auth/callback"
 export ITENTIAL_MCP_SERVER_AUTH_OAUTH_SCOPES="https://graph.microsoft.com/User.Read openid email profile"
+export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://login.microsoftonline.com/your-tenant-id/discovery/v2.0/keys"
 
 itential-mcp --transport sse --host 0.0.0.0 --port 8000
 ```
@@ -275,6 +298,11 @@ itential-mcp --transport sse --host 0.0.0.0 --port 8000
 **Missing required fields:**
 ```
 ConfigurationException: OAuth proxy authentication requires the following fields: client_id, client_secret, authorization_url, token_url, redirect_uri
+```
+
+**Missing token verifier:**
+```
+ConfigurationException: OAuth proxy authentication requires a token verifier: set jwks_uri or public_key
 ```
 
 **Transport compatibility:**

--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -64,17 +64,17 @@ def build_auth_provider(cfg: Config) -> AuthProvider | None:
         )
 
 
-def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
-    """Build a JWT authentication provider.
+def _build_jwt_verifier(auth_config: dict[str, Any]) -> JWTVerifier:
+    """Build a JWTVerifier instance from shared JWT-related configuration.
 
     Args:
         auth_config (dict[str, Any]): Authentication configuration dictionary.
 
     Returns:
-        AuthProvider: Configured JWT authentication provider.
+        JWTVerifier: Configured JWT token verifier.
 
     Raises:
-        ConfigurationException: If JWT provider initialization fails.
+        ConfigurationException: If JWT verifier initialization fails.
     """
     jwt_kwargs = {}
     if auth_config.get("jwks_uri"):
@@ -91,13 +91,28 @@ def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
         jwt_kwargs["required_scopes"] = auth_config["required_scopes"]
 
     try:
-        provider = JWTVerifier(**jwt_kwargs)
+        return JWTVerifier(**jwt_kwargs)
     except ValueError as exc:
         raise ConfigurationException(str(exc)) from exc
     except Exception as exc:
         raise ConfigurationException(
             f"Failed to initialize JWT authentication provider: {exc}"
         ) from exc
+
+
+def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
+    """Build a JWT authentication provider.
+
+    Args:
+        auth_config (dict[str, Any]): Authentication configuration dictionary.
+
+    Returns:
+        AuthProvider: Configured JWT authentication provider.
+
+    Raises:
+        ConfigurationException: If JWT provider initialization fails.
+    """
+    provider = _build_jwt_verifier(auth_config)
 
     logging.info("Server authentication enabled using JWT provider")
     return provider
@@ -170,14 +185,13 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
             f"OAuth proxy authentication requires the following fields: {', '.join(missing_fields)}"
         )
 
-    # Create a token verifier (can use JWTVerifier or StaticTokenVerifier)
-    try:
-        from fastmcp.server.auth import StaticTokenVerifier
+    if not auth_config.get("jwks_uri") and not auth_config.get("public_key"):
+        raise ConfigurationException(
+            "OAuth proxy authentication requires a token verifier: "
+            "set jwks_uri or public_key"
+        )
 
-        token_verifier = StaticTokenVerifier()  # Basic token verifier
-    except ImportError:
-        # Fallback to JWT verifier if StaticTokenVerifier not available
-        token_verifier = JWTVerifier()
+    token_verifier = _build_jwt_verifier(auth_config)
 
     base_url = auth_config["redirect_uri"].removesuffix("/auth/callback")
 

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -198,9 +198,9 @@ class TestOAuthProviderBuilding:
         )
 
     @patch("itential_mcp.server.auth.OAuthProxy")
-    @patch("fastmcp.server.auth.StaticTokenVerifier")
+    @patch("itential_mcp.server.auth.JWTVerifier")
     def test_build_oauth_proxy_provider_success(
-        self, mock_token_verifier, mock_oauth_proxy
+        self, mock_jwt_verifier, mock_oauth_proxy
     ):
         """Test successful OAuth proxy provider building."""
         from itential_mcp.config.converters import auth_to_dict
@@ -213,11 +213,12 @@ class TestOAuthProviderBuilding:
                 oauth_authorization_url="https://accounts.google.com/oauth/authorize",
                 oauth_token_url="https://oauth2.googleapis.com/token",
                 oauth_redirect_uri="http://localhost:8000/auth/callback",
+                jwks_uri="https://accounts.google.com/.well-known/jwks.json",
             )
         )
 
         mock_verifier_instance = MagicMock()
-        mock_token_verifier.return_value = mock_verifier_instance
+        mock_jwt_verifier.return_value = mock_verifier_instance
 
         mock_provider = MagicMock()
         mock_oauth_proxy.return_value = mock_provider
@@ -225,6 +226,9 @@ class TestOAuthProviderBuilding:
         result = _build_oauth_proxy_provider(auth_config)
 
         assert result == mock_provider
+        mock_jwt_verifier.assert_called_once_with(
+            jwks_uri="https://accounts.google.com/.well-known/jwks.json"
+        )
         mock_oauth_proxy.assert_called_once_with(
             upstream_authorization_endpoint="https://accounts.google.com/oauth/authorize",
             upstream_token_endpoint="https://oauth2.googleapis.com/token",
@@ -235,9 +239,9 @@ class TestOAuthProviderBuilding:
         )
 
     @patch("itential_mcp.server.auth.OAuthProxy")
-    @patch("fastmcp.server.auth.StaticTokenVerifier")
+    @patch("itential_mcp.server.auth.JWTVerifier")
     def test_build_oauth_proxy_provider_base_url_suffix_removal_only(
-        self, mock_token_verifier, mock_oauth_proxy
+        self, mock_jwt_verifier, mock_oauth_proxy
     ):
         """Test that base_url derivation only strips the literal suffix.
 
@@ -261,11 +265,12 @@ class TestOAuthProviderBuilding:
                 oauth_authorization_url="https://accounts.google.com/oauth/authorize",
                 oauth_token_url="https://oauth2.googleapis.com/token",
                 oauth_redirect_uri="https://auth-host.example.uk/auth/callback",
+                jwks_uri="https://accounts.google.com/.well-known/jwks.json",
             )
         )
 
         mock_verifier_instance = MagicMock()
-        mock_token_verifier.return_value = mock_verifier_instance
+        mock_jwt_verifier.return_value = mock_verifier_instance
 
         mock_provider = MagicMock()
         mock_oauth_proxy.return_value = mock_provider
@@ -302,6 +307,68 @@ class TestOAuthProviderBuilding:
         assert "authorization_url" in str(exc_info.value)
         assert "token_url" in str(exc_info.value)
         assert "redirect_uri" in str(exc_info.value)
+
+    def test_build_oauth_proxy_provider_missing_token_verifier_config(self):
+        """Test OAuth proxy provider building without jwks_uri or public_key.
+
+        All other required fields are present, but neither jwks_uri nor
+        public_key is set, so there is no way to construct a token
+        verifier. This must raise a clear ConfigurationException rather
+        than crashing with a TypeError at OAuthProxy construction time.
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="http://localhost:8000/auth/callback",
+            )
+        )
+
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_proxy_provider(auth_config)
+
+        assert "token verifier" in str(exc_info.value)
+
+    def test_build_oauth_proxy_provider_real_jwt_verifier_no_mocking(self):
+        """Regression test: oauth_proxy must build a real, working JWTVerifier.
+
+        This test does not mock JWTVerifier or OAuthProxy at all. It
+        exercises the actual construction path end-to-end. On the old,
+        broken code this would fail with:
+
+            TypeError: StaticTokenVerifier.__init__() missing 1 required
+            positional argument: 'tokens'
+
+        because the fallback unconditionally constructed
+        ``StaticTokenVerifier()`` with no arguments. With the fix, a real
+        ``JWTVerifier`` is constructed from ``jwks_uri`` and the resulting
+        ``OAuthProxy`` provider is returned successfully.
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="http://localhost:8000/auth/callback",
+                jwks_uri="https://accounts.google.com/.well-known/jwks.json",
+            )
+        )
+
+        provider = _build_oauth_proxy_provider(auth_config)
+
+        assert isinstance(provider, OAuthProxy)
+        # OAuthProxy stores the token verifier internally as
+        # `_token_validator` (fastmcp does not expose a public accessor).
+        assert isinstance(provider._token_validator, JWTVerifier)
 
 
 class TestProviderConfiguration:
@@ -436,8 +503,8 @@ class TestFullAuthProviderFactory:
         assert provider == mock_provider
 
     @patch("itential_mcp.server.auth.OAuthProxy")
-    @patch("fastmcp.server.auth.StaticTokenVerifier")
-    def test_oauth_proxy_auth_provider(self, mock_token_verifier, mock_oauth_proxy):
+    @patch("itential_mcp.server.auth.JWTVerifier")
+    def test_oauth_proxy_auth_provider(self, mock_jwt_verifier, mock_oauth_proxy):
         """Test building OAuth proxy auth provider."""
         config = MagicMock(spec=Config)
         config.auth = AuthConfig(
@@ -447,10 +514,11 @@ class TestFullAuthProviderFactory:
             oauth_authorization_url="https://accounts.google.com/oauth/authorize",
             oauth_token_url="https://oauth2.googleapis.com/token",
             oauth_redirect_uri="http://localhost:8000/auth/callback",
+            jwks_uri="https://accounts.google.com/.well-known/jwks.json",
         )
 
         mock_verifier_instance = MagicMock()
-        mock_token_verifier.return_value = mock_verifier_instance
+        mock_jwt_verifier.return_value = mock_verifier_instance
 
         mock_provider = MagicMock()
         mock_oauth_proxy.return_value = mock_provider


### PR DESCRIPTION
## Summary
- Fixes `_build_oauth_proxy_provider` (`src/itential_mcp/server/auth.py`), which crashed at server startup with `TypeError: StaticTokenVerifier.__init__() missing 1 required positional argument: 'tokens'` whenever `type=oauth_proxy` was configured - meaning every real `oauth_proxy` startup crashed unconditionally, regardless of config.
- `StaticTokenVerifier` is fastmcp's dev/test-only verifier (its own docs: "Never use this in production - tokens are stored in plain text!") and was the wrong tool for this path in the first place. Replaced with a real `JWTVerifier`, built via a new shared `_build_jwt_verifier(auth_config)` helper (reused by both `_build_jwt_provider` and `_build_oauth_proxy_provider`) from the existing `jwks_uri`/`public_key` config fields.
- Raises a clean `ConfigurationException` when neither `jwks_uri` nor `public_key` is set, instead of crashing.
- No new config fields - stays PATCH-shaped. Removed the dead `try/except ImportError` StaticTokenVerifier/JWTVerifier fallback dance entirely (that fallback branch never executed and was itself broken).

### Why unit tests never caught a 100%-crash-rate bug
The existing tests for this path all mocked `@patch("fastmcp.server.auth.StaticTokenVerifier")` - this worked specifically because the original code did a *local* import inside the function body, so patching the module-level attribute intercepted it before the real broken constructor ever ran. Rewrote these tests to patch the correctly-scoped `JWTVerifier` import instead, and added a genuinely unmocked regression test that constructs a real provider end-to-end.

## Test plan
- [x] `make ci` - 2546 passed, 99% coverage held, bandit 0 issues
- [x] Independently reproduced the exact crash against the pre-fix code (via an isolated git worktree) to confirm the new regression test genuinely fails on old code and passes on the fix
- [x] Confirmed the JWT (`type=jwt`) path is byte-identical in behavior after the `_build_jwt_verifier` extraction - no regression
- [x] **Live integration test** against both a local `oauth2-mock-server` mock IdP and the real Itential Platform:
  - `oauth_proxy` now constructs successfully with a real JWKS-backed verifier (server starts, logs "OAuth proxy provider" enabled, zero errors)
  - Negative case (missing `jwks_uri`/`public_key`) produces a clean `ConfigurationException`, not a crash
  - `type=jwt` path confirmed unregressed via a **full live RS256 token handshake** (not just construction) - acquired a real token from the mock IdP, sent it, got a valid MCP `initialize` response
  - Normal live-platform tool calls (`get_health`) confirmed unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
