### PR TITLE
fix: fail fast on unsupported type=oauth (full authorization server mode)

### DIFF
--- a/docs/mcp.conf.example
+++ b/docs/mcp.conf.example
@@ -127,6 +127,12 @@
 # This setting controls which authentication method the server will use to
 # validate client requests.  Valid values are: none, jwt, oauth, oauth_proxy.
 #
+# NOTE: "oauth" (full OAuth authorization server mode) is not currently
+# supported -- it always raises a ConfigurationException at startup because
+# dynamic client registration cannot be persisted without a real storage
+# backend. Use "oauth_proxy" for IdP-backed OAuth (Google, Azure, Auth0,
+# GitHub, Okta, or a generic provider) instead.
+#
 # Default value: none
 # Environment variable: ITENTIAL_MCP_SERVER_AUTH_TYPE
 #

--- a/docs/oauth-authentication.md
+++ b/docs/oauth-authentication.md
@@ -4,10 +4,10 @@ The Itential MCP server supports OAuth authentication to secure access to the se
 
 ## Overview
 
-The MCP server supports two OAuth authentication modes:
+The MCP server's `server.auth.type` setting recognizes two OAuth-related modes:
 
-1. **OAuth Provider** - Acts as a full OAuth authorization server
-2. **OAuth Proxy** - Proxies authentication to upstream OAuth providers (Google, Azure, Auth0, GitHub, Okta)
+1. **OAuth Provider** (`oauth`) - Intended to act as a full OAuth authorization server. **Not currently supported** -- see [OAuth Provider Mode](#oauth-provider-mode-not-currently-supported) below. Setting `auth_type` to `oauth` always raises `ConfigurationException` at startup.
+2. **OAuth Proxy** (`oauth_proxy`) - Proxies authentication to upstream OAuth providers (Google, Azure, Auth0, GitHub, Okta). This is the supported, working OAuth mode.
 
 Both modes require HTTP-based transports (`sse` or `http`) and are incompatible with the `stdio` transport.
 
@@ -19,7 +19,7 @@ OAuth authentication is configured through environment variables, command line a
 
 | Environment Variable | CLI Option | Description |
 |---------------------|------------|-------------|
-| `ITENTIAL_MCP_SERVER_AUTH_TYPE` | `--auth-type` | Set to `oauth` or `oauth_proxy` |
+| `ITENTIAL_MCP_SERVER_AUTH_TYPE` | `--auth-type` | Set to `oauth_proxy` (supported) or `jwt`. `oauth` is also a recognized value but is **not currently supported** -- it always raises `ConfigurationException` at startup; see [OAuth Provider Mode](#oauth-provider-mode-not-currently-supported) |
 | `ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_ID` | `--auth-oauth-client-id` | OAuth client ID |
 | `ITENTIAL_MCP_SERVER_AUTH_OAUTH_CLIENT_SECRET` | `--auth-oauth-client-secret` | OAuth client secret |
 | `ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI` | `--auth-oauth-redirect-uri` | OAuth callback/redirect URI |
@@ -27,7 +27,7 @@ OAuth authentication is configured through environment variables, command line a
 
 ### OAuth Provider Settings
 
-For full OAuth server mode (`oauth`):
+> **Not currently supported.** Full OAuth server mode (`oauth`) always raises `ConfigurationException` at startup -- see [OAuth Provider Mode](#oauth-provider-mode-not-currently-supported). The settings below are documented only so that users encountering the exception understand what the (currently non-functional) mode would have configured. Use [OAuth Proxy Mode](#oauth-proxy-mode) instead.
 
 | Environment Variable | CLI Option | Description |
 |---------------------|------------|-------------|
@@ -46,41 +46,15 @@ For OAuth proxy mode (`oauth_proxy`):
 | `ITENTIAL_MCP_SERVER_AUTH_JWKS_URI` | `--auth-jwks-uri` | **Required** (one of `jwks_uri` or `public_key`) - JWKS endpoint for verifying upstream tokens |
 | `ITENTIAL_MCP_SERVER_AUTH_PUBLIC_KEY` | `--auth-public-key` | **Required** (one of `jwks_uri` or `public_key`) - Static public key/secret for verifying upstream tokens |
 
-## OAuth Provider Mode
+## OAuth Provider Mode (Not Currently Supported)
 
-The OAuth provider mode turns the MCP server into a full OAuth authorization server. This is useful when you want the MCP server to handle authentication directly.
+**`auth_type = oauth` (full OAuth authorization server mode) is not currently supported.** Setting `ITENTIAL_MCP_SERVER_AUTH_TYPE` (or `--auth-type`) to `oauth` always raises `ConfigurationException` at server startup.
 
-### Configuration
+The underlying `OAuthProvider` construction has no persistent storage backend for dynamically registered OAuth clients: a client can successfully `POST /register`, but the registration is never retrievable afterward, so every real authorization-code handshake fails. There is no built-in storage subclass suitable for production use (the only one available is explicitly testing-only and issues fake, unverified tokens), so rather than accept configuration that silently produces a confusing runtime failure during a real handshake, the server now fails fast at startup with a clear error.
 
-**Environment Variables:**
-```bash
-export ITENTIAL_MCP_SERVER_AUTH_TYPE="oauth"
-export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
-export ITENTIAL_MCP_SERVER_AUTH_OAUTH_SCOPES="openid email profile"
-```
+**If you need OAuth authentication today, use [OAuth Proxy Mode](#oauth-proxy-mode) instead**, which delegates authentication to a real upstream identity provider (Google, Azure, Auth0, GitHub, Okta, or a generic provider) and is fully supported.
 
-**Command Line:**
-```bash
-itential-mcp --transport sse \
-  --auth-type oauth \
-  --auth-oauth-redirect-uri "http://localhost:8000/auth/callback" \
-  --auth-oauth-scopes "openid email profile"
-```
-
-**Configuration File:**
-```ini
-[server]
-auth_type = oauth
-auth_oauth_redirect_uri = http://localhost:8000/auth/callback
-auth_oauth_scopes = openid email profile
-```
-
-### Base URL Derivation
-
-The OAuth provider automatically derives the base URL from the redirect URI by removing the `/auth/callback` suffix:
-
-- **Redirect URI:** `http://localhost:8000/auth/callback`
-- **Base URL:** `http://localhost:8000`
+Implementing real client/token storage for full OAuth provider mode is tracked as a future roadmap item.
 
 ## OAuth Proxy Mode
 
@@ -216,11 +190,11 @@ OAuth authentication modes have specific transport requirements:
 
 | Auth Type | stdio | sse | http |
 |-----------|-------|-----|------|
-| `oauth` | ❌ | ✅ | ✅ |
+| `oauth` (not currently supported) | ❌ | ❌ | ❌ |
 | `oauth_proxy` | ❌ | ✅ | ✅ |
 | `jwt` | ✅ | ✅ | ✅ |
 
-OAuth requires HTTP-based transports because it needs to handle redirect URLs and callback endpoints.
+OAuth requires HTTP-based transports because it needs to handle redirect URLs and callback endpoints. `oauth` is listed here for completeness only -- it always raises `ConfigurationException` at startup regardless of transport; see [OAuth Provider Mode](#oauth-provider-mode-not-currently-supported).
 
 ## Complete Examples
 
@@ -240,30 +214,6 @@ export ITENTIAL_MCP_SERVER_AUTH_JWKS_URI="https://www.googleapis.com/oauth2/v3/c
 
 # Start the server
 itential-mcp --transport sse --host 0.0.0.0 --port 8000
-```
-
-### OAuth Provider Mode with Configuration File
-
-**config.ini:**
-```ini
-[server]
-transport = sse
-host = 0.0.0.0
-port = 8000
-auth_type = oauth
-auth_oauth_redirect_uri = http://localhost:8000/auth/callback
-auth_oauth_scopes = openid email profile
-
-[platform]
-host = platform.example.com
-user = admin
-password = admin
-```
-
-**Start the server:**
-```bash
-export ITENTIAL_MCP_CONFIG="config.ini"
-itential-mcp
 ```
 
 ### Azure AD with Custom Scopes
@@ -294,6 +244,12 @@ itential-mcp --transport sse --host 0.0.0.0 --port 8000
 ## Troubleshooting
 
 ### Common Configuration Errors
+
+**`auth_type = oauth` is not supported:**
+```
+ConfigurationException: Full OAuth authorization server mode ('oauth') is not currently supported (dynamic client registration cannot persist registered clients). Use 'oauth_proxy' to delegate authentication to an upstream OAuth provider instead.
+```
+If you see this error, you set `ITENTIAL_MCP_SERVER_AUTH_TYPE` (or `--auth-type`) to `oauth`. This mode always fails at startup -- see [OAuth Provider Mode](#oauth-provider-mode-not-currently-supported). Switch to `oauth_proxy` and configure an upstream identity provider as shown in [OAuth Proxy Mode](#oauth-proxy-mode).
 
 **Missing required fields:**
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -569,7 +569,7 @@ export ITENTIAL_MCP_SERVER_AUTH_OAUTH_REDIRECT_URI=http://localhost:8000/auth/ca
 ```bash
 # OAuth requires HTTP-based transport
 export ITENTIAL_MCP_SERVER_TRANSPORT=sse  # or http
-export ITENTIAL_MCP_SERVER_AUTH_TYPE=oauth
+export ITENTIAL_MCP_SERVER_AUTH_TYPE=oauth_proxy
 
 # stdio transport should use no auth
 export ITENTIAL_MCP_SERVER_TRANSPORT=stdio

--- a/src/itential_mcp/config/models.py
+++ b/src/itential_mcp/config/models.py
@@ -283,12 +283,19 @@ class ServerConfig:
 class AuthConfig:
     """Authentication configuration for the MCP server.
 
-    Supports multiple authentication providers including JWT, OAuth, and OAuth Proxy.
+    Supports multiple authentication providers including JWT and OAuth Proxy.
+    The "oauth" type (full OAuth authorization server mode) is accepted here
+    for backward compatibility but always raises ConfigurationException at
+    startup -- dynamic client registration cannot be persisted without a
+    real storage backend. Use "oauth_proxy" for IdP-backed OAuth instead.
     """
 
     type: Literal["none", "jwt", "oauth", "oauth_proxy"] = _create_field_with_env(
         "ITENTIAL_MCP_SERVER_AUTH_TYPE",
-        "Authentication provider type used to secure the MCP server",
+        "Authentication provider type used to secure the MCP server. Note: "
+        "'oauth' (full authorization server mode) is not currently supported "
+        "and always raises ConfigurationException at startup; use "
+        "'oauth_proxy' instead.",
         default=defaults.ITENTIAL_MCP_SERVER_AUTH_TYPE,
         json_schema_extra={
             "x-itential-mcp-cli-enabled": True,

--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -119,41 +119,34 @@ def _build_jwt_provider(auth_config: dict[str, Any]) -> AuthProvider:
 
 
 def _build_oauth_provider(auth_config: dict[str, Any]) -> AuthProvider:
-    """Build a full OAuth 2.0 authorization server.
+    """Reject full OAuth 2.0 authorization server configuration.
+
+    Full authorization server mode (``type=oauth``) is not currently
+    supported: FastMCP's ``OAuthProvider`` has no built-in persistent
+    storage backend, so dynamic client registration silently fails to
+    persist registered clients. This results in a confusing runtime
+    failure ("Client ID not found") during a real authorization-code
+    handshake, well after startup. Implementing a real fix requires new
+    client/token storage and credential-verification capability, which is
+    tracked separately. Until then, this configuration fails fast at
+    startup instead.
 
     Args:
         auth_config (dict[str, Any]): Authentication configuration dictionary.
 
     Returns:
-        AuthProvider: Configured OAuth authorization server provider.
+        AuthProvider: Never returns; always raises.
 
     Raises:
-        ConfigurationException: If OAuth provider initialization fails.
+        ConfigurationException: Always raised. Full OAuth authorization
+            server mode is not currently supported.
     """
-    if not auth_config.get("redirect_uri"):
-        raise ConfigurationException(
-            "OAuth server requires the following fields: redirect_uri"
-        )
-
-    oauth_kwargs = {
-        "base_url": auth_config["redirect_uri"].removesuffix("/auth/callback"),
-    }
-
-    # Add optional parameters
-    if auth_config.get("scopes"):
-        oauth_kwargs["required_scopes"] = auth_config["scopes"]
-
-    try:
-        provider = OAuthProvider(**oauth_kwargs)
-    except ValueError as exc:
-        raise ConfigurationException(str(exc)) from exc
-    except Exception as exc:
-        raise ConfigurationException(
-            f"Failed to initialize OAuth authorization server: {exc}"
-        ) from exc
-
-    logging.info("Server authentication enabled using OAuth authorization server")
-    return provider
+    raise ConfigurationException(
+        "Full OAuth authorization server mode ('oauth') is not currently "
+        "supported (dynamic client registration cannot persist registered "
+        "clients). Use 'oauth_proxy' to delegate authentication to an "
+        "upstream OAuth provider instead."
+    )
 
 
 def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -16,32 +16,27 @@ from itential_mcp.core.exceptions import ConfigurationException
 
 
 class TestOAuthProviderExceptionHandling:
-    """Test exception handling in OAuth provider builders"""
+    """Test that _build_oauth_provider always fails fast, unconditionally."""
 
-    @patch("itential_mcp.server.auth.OAuthProvider")
-    def test_oauth_provider_value_error(self, mock_oauth_provider):
-        """Test _build_oauth_provider handles ValueError"""
-        mock_oauth_provider.side_effect = ValueError("Invalid base_url")
+    def test_oauth_provider_always_raises_configuration_exception(self):
+        """Test _build_oauth_provider raises regardless of config contents.
 
+        Full OAuth authorization server mode is not currently supported,
+        so this must raise a ConfigurationException without ever
+        attempting to construct OAuthProvider -- even when the supplied
+        config looks otherwise complete.
+        """
         auth_config = {"redirect_uri": "https://example.com/auth/callback"}
 
-        with pytest.raises(ConfigurationException) as exc_info:
-            _build_oauth_provider(auth_config)
+        with patch("itential_mcp.server.auth.OAuthProvider") as mock_oauth_provider:
+            with pytest.raises(ConfigurationException) as exc_info:
+                _build_oauth_provider(auth_config)
 
-        assert "Invalid base_url" in str(exc_info.value)
+            mock_oauth_provider.assert_not_called()
 
-    @patch("itential_mcp.server.auth.OAuthProvider")
-    def test_oauth_provider_general_exception(self, mock_oauth_provider):
-        """Test _build_oauth_provider handles general Exception"""
-        mock_oauth_provider.side_effect = RuntimeError("Unexpected error")
-
-        auth_config = {"redirect_uri": "https://example.com/auth/callback"}
-
-        with pytest.raises(ConfigurationException) as exc_info:
-            _build_oauth_provider(auth_config)
-
-        assert "Failed to initialize OAuth authorization server" in str(exc_info.value)
-        assert "Unexpected error" in str(exc_info.value)
+        message = str(exc_info.value)
+        assert "not currently supported" in message
+        assert "oauth_proxy" in message
 
 
 class TestOAuthProxyProviderCoverage:

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -109,75 +109,16 @@ class TestOAuthConfiguration:
 class TestOAuthProviderBuilding:
     """Test OAuth provider building logic."""
 
-    @patch("itential_mcp.server.auth.OAuthProvider")
-    def test_build_oauth_provider_success(self, mock_oauth_provider):
-        """Test successful OAuth provider building."""
-        from itential_mcp.config.converters import auth_to_dict
+    def test_build_oauth_provider_always_raises(self):
+        """Full OAuth authorization server mode is not currently supported.
 
-        auth_config = auth_to_dict(
-            make_auth_config(
-                type="oauth",
-                oauth_redirect_uri="http://localhost:8000/auth/callback",
-            )
-        )
-
-        mock_provider = MagicMock()
-        mock_oauth_provider.return_value = mock_provider
-
-        result = _build_oauth_provider(auth_config)
-
-        assert result == mock_provider
-        mock_oauth_provider.assert_called_once_with(base_url="http://localhost:8000")
-
-    @patch("itential_mcp.server.auth.OAuthProvider")
-    def test_build_oauth_provider_base_url_suffix_removal_only(
-        self, mock_oauth_provider
-    ):
-        """Test that base_url derivation only strips the literal suffix.
-
-        Regression test for a bug where ``str.rstrip("/auth/callback")`` was
-        used instead of ``str.removesuffix("/auth/callback")``. ``rstrip``
-        treats its argument as a set of characters to strip from the end of
-        the string, not a literal suffix, so a redirect URI whose host ends
-        in any of the characters in "/auth/callback" (e.g. "u" or "k" from a
-        ".uk" TLD) would have those trailing host characters incorrectly
-        eaten as well. Under the old ``rstrip`` behavior this would have
-        produced "https://auth-host.example." instead of the correct
-        "https://auth-host.example.uk".
+        ``_build_oauth_provider`` must fail fast with a clear
+        ``ConfigurationException`` explaining that dynamic client
+        registration cannot persist registered clients, and steering
+        users to ``oauth_proxy`` instead -- regardless of what fields are
+        present in the configuration. ``OAuthProvider`` must never be
+        constructed.
         """
-        from itential_mcp.config.converters import auth_to_dict
-
-        auth_config = auth_to_dict(
-            make_auth_config(
-                type="oauth",
-                oauth_redirect_uri="https://auth-host.example.uk/auth/callback",
-            )
-        )
-
-        mock_provider = MagicMock()
-        mock_oauth_provider.return_value = mock_provider
-
-        _build_oauth_provider(auth_config)
-
-        mock_oauth_provider.assert_called_once_with(
-            base_url="https://auth-host.example.uk"
-        )
-
-    def test_build_oauth_provider_missing_required_fields(self):
-        """Test OAuth provider building with missing required fields."""
-        from itential_mcp.config.converters import auth_to_dict
-
-        auth_config = auth_to_dict(make_auth_config(type="oauth"))
-
-        with pytest.raises(ConfigurationException) as exc_info:
-            _build_oauth_provider(auth_config)
-
-        assert "requires the following fields" in str(exc_info.value)
-        assert "redirect_uri" in str(exc_info.value)
-
-    @patch("itential_mcp.server.auth.OAuthProvider")
-    def test_build_oauth_provider_with_optional_fields(self, mock_oauth_provider):
-        """Test OAuth provider building with optional fields."""
         from itential_mcp.config.converters import auth_to_dict
 
         auth_config = auth_to_dict(
@@ -188,14 +129,28 @@ class TestOAuthProviderBuilding:
             )
         )
 
-        mock_provider = MagicMock()
-        mock_oauth_provider.return_value = mock_provider
+        with patch("itential_mcp.server.auth.OAuthProvider") as mock_oauth_provider:
+            with pytest.raises(ConfigurationException) as exc_info:
+                _build_oauth_provider(auth_config)
 
-        _build_oauth_provider(auth_config)
+            mock_oauth_provider.assert_not_called()
 
-        mock_oauth_provider.assert_called_once_with(
-            base_url="http://localhost:8000", required_scopes=["openid", "email"]
-        )
+        message = str(exc_info.value)
+        assert "not currently supported" in message
+        assert "oauth_proxy" in message
+
+    def test_build_oauth_provider_missing_required_fields_still_raises(self):
+        """Missing redirect_uri also raises the same unsupported-mode error."""
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(make_auth_config(type="oauth"))
+
+        with pytest.raises(ConfigurationException) as exc_info:
+            _build_oauth_provider(auth_config)
+
+        message = str(exc_info.value)
+        assert "not currently supported" in message
+        assert "oauth_proxy" in message
 
     @patch("itential_mcp.server.auth.OAuthProxy")
     @patch("itential_mcp.server.auth.JWTVerifier")
@@ -487,20 +442,20 @@ class TestFullAuthProviderFactory:
         provider = build_auth_provider(config)
         assert provider == mock_provider
 
-    @patch("itential_mcp.server.auth.OAuthProvider")
-    def test_oauth_auth_provider(self, mock_oauth_provider):
-        """Test building OAuth auth provider."""
+    def test_oauth_auth_provider_raises(self):
+        """Test that building type=oauth via the factory fails fast."""
         config = MagicMock(spec=Config)
         config.auth = AuthConfig(
             type="oauth",
             oauth_redirect_uri="http://localhost:8000/auth/callback",
         )
 
-        mock_provider = MagicMock()
-        mock_oauth_provider.return_value = mock_provider
+        with pytest.raises(ConfigurationException) as exc_info:
+            build_auth_provider(config)
 
-        provider = build_auth_provider(config)
-        assert provider == mock_provider
+        message = str(exc_info.value)
+        assert "not currently supported" in message
+        assert "oauth_proxy" in message
 
     @patch("itential_mcp.server.auth.OAuthProxy")
     @patch("itential_mcp.server.auth.JWTVerifier")


### PR DESCRIPTION
## Summary
- `_build_oauth_provider` (`type=oauth`, full OAuth authorization server mode) constructed `fastmcp.server.auth.OAuthProvider` with no storage backend, so dynamic client registration silently didn't work: `POST /register` succeeded (`201`) but the registered client was never retrievable, causing every real authorization-code handshake to fail with a confusing `"Client ID not found"` error well after startup. Confirmed at the library level: `OAuthProvider`'s `register_client`/`get_client` are Protocol stubs that persist nothing unless subclassed with a real storage implementation. fastmcp's only built-in storage subclass (`InMemoryOAuthProvider`) is explicitly testing-only and issues fake, unverified tokens - not usable as a real fix.
- A proper fix requires implementing real client/token storage and credential verification - genuinely new capability, deferred to its own roadmap item (nobody currently uses `type=oauth`).
- **Interim fix**: `type=oauth` now fails fast at startup with a clear `ConfigurationException` steering users to `oauth_proxy`, instead of silently accepting config that produces a confusing runtime failure during a real handshake attempt. No new config surface - stays PATCH-shaped. The `oauth` value remains in the `Literal`/CLI choices since removing it would be a breaking config-schema change and the exception must stay reachable via this value.
- Updated documentation that presented `type=oauth` as a working, fully-supported feature across `docs/oauth-authentication.md`, `docs/mcp.conf.example`, `docs/troubleshooting.md`, and `src/itential_mcp/config/models.py` - all now clearly mark it as not currently supported and point to `oauth_proxy`.

## Test plan
- [x] `make ci` - 2543 passed, 99% coverage held, bandit 0 issues
- [x] Replaced 3 old success-path tests + 2 exception-wrapping tests with 2 new always-raises tests (net -3, confirmed legitimate consolidation not coverage loss - the removed behavior no longer exists in source)
- [x] Two rounds of doc review found and fixed 3 separate stale references presenting `type=oauth` as a working choice; a final grep sweep confirmed no other live doc reference remains
- [x] **Live integration test**: confirmed `type=oauth` fails fast with the exact expected message and non-zero exit (not a hang, not silent success, not the old confusing runtime-only failure). Confirmed `oauth_proxy`, `jwt`, and `none` are all unaffected (each tested live, including a full `oauth_proxy` server startup and a `jwt` provider construction). Confirmed normal live-platform tool calls (`get_health`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
