### PR TITLE
fix: add missing defaults for nullable command template fields

### DIFF
--- a/src/itential_mcp/models/command_templates.py
+++ b/src/itential_mcp/models/command_templates.py
@@ -56,7 +56,8 @@ class CommandTemplate(BaseModel):
                 """
                 Brief description of what the template does (null if not provided)
                 """
-            )
+            ),
+            default=None,
         ),
     ]
 
@@ -67,7 +68,8 @@ class CommandTemplate(BaseModel):
                 """
                 Project namespace object (null for global templates)
                 """
-            )
+            ),
+            default=None,
         ),
     ]
 
@@ -161,7 +163,8 @@ class CommandTemplateDetail(BaseModel):
                 """
                 Project namespace object (null for global templates)
                 """
-            )
+            ),
+            default=None,
         ),
     ]
 

--- a/tests/test_models_command_templates.py
+++ b/tests/test_models_command_templates.py
@@ -56,6 +56,37 @@ class TestCommandTemplate:
                 # Missing required _id field
             )
 
+    def test_command_template_missing_namespace_global(self):
+        """Test CommandTemplate defaults namespace to None when the key is
+        absent entirely, as returned by the platform for global (non
+        project-scoped) command templates.
+        """
+        payload = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "description": "Global command template",
+            "passRule": True,
+        }
+
+        template = models.CommandTemplate(**payload)
+
+        assert template.namespace is None
+
+    def test_command_template_missing_description(self):
+        """Test CommandTemplate defaults description to None when the key
+        is absent entirely from the platform response.
+        """
+        payload = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "namespace": None,
+            "passRule": True,
+        }
+
+        template = models.CommandTemplate(**payload)
+
+        assert template.description is None
+
 
 class TestGetCommandTemplatesResponse:
     """Tests for GetCommandTemplatesResponse model."""
@@ -145,6 +176,23 @@ class TestCommandTemplateDetail:
         )
 
         assert detail.commands == []
+
+    def test_command_template_detail_missing_namespace_global(self):
+        """Test CommandTemplateDetail defaults namespace to None when the
+        key is absent entirely, reproducing the "Field required" error
+        raised by describe_command_template against global (non
+        project-scoped) command templates before this fix.
+        """
+        payload = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "commands": [],
+            "passRule": True,
+        }
+
+        detail = models.CommandTemplateDetail(**payload)
+
+        assert detail.namespace is None
 
 
 class TestDescribeCommandTemplateResponse:


### PR DESCRIPTION
## Summary
- `describe_command_template` failed with `Field required` on any global (non-project-scoped) command template. Root cause: `CommandTemplateDetail.namespace` was already typed `dict[str, Any] | None` but had no `default=None` - in Pydantic 2.x, a nullable type with no default is still required, so a *missing key* (not a null value) raises `Field required`. Global command templates omit the `namespace` key entirely; project-scoped templates include it.
- Added `default=None` to `CommandTemplateDetail.namespace`. Also fixed the same latent bug clustered on the sibling `CommandTemplate` model (backs `get_command_templates`): `.namespace` and `.description` had the identical gap, closed proactively before it surfaces as a separate bug report.
- No type-annotation changes, no tool code changes - purely adding the missing defaults.

## Test plan
- [x] `make ci` - 2551 passed, 99% coverage held, bandit 0 issues
- [x] New tests use dict-unpacking construction with the relevant key **absent** (not `None`-valued), genuinely exercising the missing-key path rather than the already-tested null-value path. Independently verified by swapping the pre-fix model back in - the new tests fail with the exact reported `Field required` error on old code, pass on the fix.
- [x] **Live integration test** against a platform that actually has global command templates (not just inferred): confirmed `describe_command_template` now succeeds on 4 different global templates (previously failing), confirmed project-scoped templates still work correctly with `namespace` fully populated (no regression), confirmed `get_command_templates` works correctly. Genuine before/after on the same platform - pre-fix HEAD fails on `linux-ping` with the exact reported error, post-fix succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
