### PR TITLE
fix: declare devices parameter as list[str] in device group and command template tools

### DIFF
--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -91,7 +91,7 @@ async def run_command_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the command template to run")],
     devices: Annotated[
-        list,
+        list[str],
         Field(description="The list of devices to run the command template against"),
     ],
     project: Annotated[
@@ -111,7 +111,7 @@ async def run_command_template(
     Args:
         ctx (Context): The FastMCP Context object
         name (str): Name of the command template to run
-        devices (list): List of device names to run the template against. Use `get_devices` to see available devices.
+        devices (list[str]): List of device names to run the template against. Use `get_devices` to see available devices.
         project (str | None): Project containing the template (None for global templates)
 
     Returns:

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -56,7 +56,7 @@ async def create_device_group(
         Field(description="Short description of the device group", default=None),
     ],
     devices: Annotated[
-        list | None,
+        list[str] | None,
         Field(description="List of devices to add to the group", default=None),
     ],
 ) -> models.CreateDeviceGroupResponse:
@@ -70,7 +70,7 @@ async def create_device_group(
         ctx (Context): The FastMCP Context object
         name (str): Name of the device group to create
         description (str | None): Short description of the device group (optional)
-        devices (list | None): List of device names to include in the group. Use `get_devices` to see available devices. (optional)
+        devices (list[str] | None): List of device names to include in the group. Use `get_devices` to see available devices. (optional)
 
     Returns:
         CreateDeviceGroupResponse: Creation operation result with the following fields:
@@ -99,7 +99,7 @@ async def add_devices_to_group(
         str, Field(description="The name of the device group to add devices to")
     ],
     devices: Annotated[
-        list | None,
+        list[str] | None,
         Field(
             description="List of devices to add to the group",
         ),
@@ -122,7 +122,7 @@ async def add_devices_to_group(
 
         name (str): The name of the device group to add devices too
 
-        devices (list[str]): The list of device names to add to the
+        devices (list[str] | None): The list of device names to add to the
             device group
 
     Returns:

--- a/tests/test_tools_command_templates.py
+++ b/tests/test_tools_command_templates.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from fastmcp.tools import Tool
+
+from itential_mcp.tools import command_templates
+
+
+class TestToolSchemas:
+    """
+    Schema-assertion tests for the `devices` parameter.
+
+    These tests inspect the actual JSON schema FastMCP generates for the
+    tool, rather than only calling the tool function with a real Python
+    list. Calling with a real list never exercises the generated schema,
+    which is exactly why an underspecified `items: {}` schema (from a bare
+    `list` annotation) previously slipped through the test suite undetected.
+    """
+
+    def test_run_command_template_devices_schema(self):
+        """Test run_command_template's devices schema declares string items"""
+        tool = Tool.from_function(command_templates.run_command_template)
+
+        devices_schema = tool.parameters["properties"]["devices"]
+
+        assert devices_schema["type"] == "array"
+        assert devices_schema["items"] == {"type": "string"}
+        assert devices_schema["items"] != {}

--- a/tests/test_tools_device_groups.py
+++ b/tests/test_tools_device_groups.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from fastmcp import Context
+from fastmcp.tools import Tool
 
 from itential_mcp.tools import device_groups
 from itential_mcp.models.device_groups import (
@@ -15,6 +16,32 @@ from itential_mcp.models.device_groups import (
     AddDevicesToGroupResponse,
     RemoveDevicesFromGroupResponse,
 )
+
+
+def _find_array_schema(devices_schema: dict) -> dict:
+    """
+    Locate the array branch of a devices parameter's JSON schema.
+
+    Supports both a bare array schema and a `list[str] | None` schema, which
+    FastMCP represents as an `anyOf` of an array branch and a null branch.
+
+    Args:
+        devices_schema (dict): The JSON schema fragment for the devices property
+
+    Returns:
+        dict: The array branch of the schema (contains "type": "array" and "items")
+
+    Raises:
+        AssertionError: If no array branch is found in the schema
+    """
+    if devices_schema.get("type") == "array":
+        return devices_schema
+
+    for branch in devices_schema.get("anyOf", []):
+        if branch.get("type") == "array":
+            return branch
+
+    raise AssertionError(f"No array branch found in schema: {devices_schema}")
 
 
 class TestModule:
@@ -753,3 +780,49 @@ class TestToolsIntegration:
                 description="Should fail",
                 devices=[],
             )
+
+
+class TestToolSchemas:
+    """
+    Schema-assertion tests for the `devices` parameter.
+
+    These tests inspect the actual JSON schema FastMCP generates for each
+    tool, rather than only calling the tool functions with real Python
+    lists. Calling with real lists never exercises the generated schema,
+    which is exactly why an underspecified `items: {}` schema (from a bare
+    `list | None` annotation) previously slipped through the test suite
+    undetected.
+    """
+
+    def test_create_device_group_devices_schema(self):
+        """Test create_device_group's devices schema declares string items"""
+        tool = Tool.from_function(device_groups.create_device_group)
+
+        devices_schema = tool.parameters["properties"]["devices"]
+        array_schema = _find_array_schema(devices_schema)
+
+        assert array_schema["type"] == "array"
+        assert array_schema["items"] == {"type": "string"}
+        assert array_schema["items"] != {}
+
+    def test_add_devices_to_group_devices_schema(self):
+        """Test add_devices_to_group's devices schema declares string items"""
+        tool = Tool.from_function(device_groups.add_devices_to_group)
+
+        devices_schema = tool.parameters["properties"]["devices"]
+        array_schema = _find_array_schema(devices_schema)
+
+        assert array_schema["type"] == "array"
+        assert array_schema["items"] == {"type": "string"}
+        assert array_schema["items"] != {}
+
+    def test_remove_devices_from_group_devices_schema(self):
+        """Test remove_devices_from_group's devices schema declares string items"""
+        tool = Tool.from_function(device_groups.remove_devices_from_group)
+
+        devices_schema = tool.parameters["properties"]["devices"]
+        array_schema = _find_array_schema(devices_schema)
+
+        assert array_schema["type"] == "array"
+        assert array_schema["items"] == {"type": "string"}
+        assert array_schema["items"] != {}


### PR DESCRIPTION
## Summary
- `create_device_group`, `add_devices_to_group`, and `run_command_template` declared their `devices` parameter as a bare `list`/`list | None` with no item type, producing a JSON schema with untyped `items: {}` instead of `items: {"type": "string"}`. This underspecified schema caused some MCP clients to fall back to serializing the array as a JSON string rather than a real array, which then failed server-side Pydantic validation: `Input should be a valid list, input_value='["CISCO-APIC"]'`.
- Declaring `devices: list[str]` gives clients an unambiguous schema so they correctly send a real JSON array. `remove_devices_from_group` already declared this correctly and is unaffected/untouched.
- Adds schema-assertion tests (inspecting the actual generated JSON schema via `fastmcp.tools.Tool.from_function`) rather than only functional tests, since the existing test suite only ever called these tools with real Python lists and never exercised the schema that was actually broken.

## Test plan
- [x] `make ci` - 2561 passed, bandit 0 issues
- [x] New schema-assertion tests confirmed to genuinely fail on the pre-fix annotation (reverted and reproduced) and pass on the fix, for all 4 tools including `remove_devices_from_group` (locking in that it stays correct)
- [x] **Live integration test** via CLI: confirmed the corrected schema is served correctly, server-side validation works end-to-end with a real array, `run_command_template` has no regression. Found a separate, pre-existing bug (`IpsdkError: method must be of type HTTPMethod` in `add_devices_to_group`/`remove_devices_from_group`) - confirmed unrelated by reproducing it identically on unmodified `devel`, tracked separately (not in scope here).
- [x] **Live test via a real schema-sensitive MCP client (Claude Desktop)** against this exact branch: `create_device_group` with `devices=["CISCO-APIC"]` now succeeds through a real LLM-driven client, closing the one gap the CLI-based integration test couldn't prove (the CLI's own `json.loads()` step bypasses the exact client-side serialization step that caused the original bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
