### PR TITLE
fix: raise clear exception instead of IndexError in run_compliance_plan

### DIFF
--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -736,6 +736,9 @@ class Service(ServiceBase):
 
         Raises:
             ValueError: If the specified compliance plan name is not found
+            ComplianceException: If the compliance plan run produces no
+                instance, which typically indicates the plan has no devices
+                or checks configured
         """
         plans_list = await self.get_compliance_plans()
 
@@ -767,4 +770,11 @@ class Service(ServiceBase):
 
         json_data = res.json()
 
-        return json_data["plans"][0]
+        instances = json_data["plans"]
+        if not instances:
+            raise exceptions.ComplianceException(
+                f"compliance plan '{name}' produced no instance to run; "
+                f"it likely has no devices or checks configured"
+            )
+
+        return instances[0]

--- a/src/itential_mcp/tools/compliance_plans.py
+++ b/src/itential_mcp/tools/compliance_plans.py
@@ -58,6 +58,9 @@ async def run_compliance_plan(
 
     Raises:
         ValueError: If the specified compliance plan name is not found
+        ComplianceException: If the compliance plan run produces no
+            instance, which typically indicates the plan has no devices
+            or checks configured
     """
     await ctx.debug("inside run_compliance_plan(...)")
     client = ctx.request_context.lifespan_context.get("client")

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -1951,13 +1951,59 @@ class TestConfigurationManagerCompliancePlans:
 
     @pytest.mark.asyncio
     async def test_run_compliance_plan_empty_plans_list(self, service):
-        """Test run_compliance_plan with no available plans."""
+        """Test run_compliance_plan when get_compliance_plans returns no plans.
+
+        This covers the "plan not found" case: there are no compliance plans
+        at all, so no match is found for the requested name and a ValueError
+        is raised before any run/search API calls are made. This is distinct
+        from test_run_compliance_plan_empty_instances_raises below, where the
+        plan IS found and its run request succeeds, but the resulting
+        instance search returns an empty list.
+        """
         service.get_compliance_plans = AsyncMock(return_value=[])
 
         with pytest.raises(ValueError, match="compliance plan Any Plan not found"):
             await service.run_compliance_plan("Any Plan")
 
         service.get_compliance_plans.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_compliance_plan_empty_instances_raises(
+        self, service, mock_client
+    ):
+        """Test run_compliance_plan raises ComplianceException with no instances.
+
+        Reproduces the reported bug: the compliance plan exists and its run
+        request succeeds, but the plan has no devices or checks configured,
+        so the subsequent instance search returns an empty "plans" list. This
+        must raise a clear ComplianceException instead of an unguarded
+        IndexError.
+        """
+        plans_data = [
+            {
+                "id": "plan-1",
+                "name": "Probe",
+                "description": "No devices configured",
+                "throttle": 5,
+            }
+        ]
+        service.get_compliance_plans = AsyncMock(return_value=plans_data)
+
+        mock_run_response = Mock()
+        mock_run_response.json.return_value = {"status": "started"}
+
+        mock_search_response = Mock()
+        mock_search_response.json.return_value = {"plans": []}
+
+        mock_client.post.side_effect = [mock_run_response, mock_search_response]
+
+        with pytest.raises(
+            exceptions.ComplianceException, match="no devices or checks"
+        ):
+            await service.run_compliance_plan("Probe")
+
+        service.get_compliance_plans.assert_called_once()
+        assert mock_client.post.call_count == 2
 
     @pytest.mark.asyncio
     async def test_run_compliance_plan_case_sensitive(self, service):


### PR DESCRIPTION
## Summary
- `run_compliance_plan` crashed with an unhandled `IndexError` ("list index out of range") when a compliance plan exists and its run request succeeds, but the plan has no devices/checks configured - the subsequent instance search returns an empty list, which was indexed unconditionally.
- Added a length guard that raises a clear `ComplianceException` ("compliance plan '{name}' produced no instance to run; it likely has no devices or checks configured") instead.
- This is distinct from the existing "plan not found" check earlier in the same method, which already raises `ValueError` correctly and is untouched by this fix - the two empty-list conditions in this method mean different things and are now both clearly, separately handled.

## Test plan
- [x] `make ci` - 2562 passed, bandit 0 issues
- [x] New test reproduces the exact bug via mocked responses (matching plan found, run succeeds, instance search returns empty), independently verified to genuinely fail with `IndexError` against real pre-fix code and pass on the fix
- [x] Confirmed `ComplianceException` propagates correctly through FastMCP's `ErrorHandlingMiddleware` with no wiring changes needed (verified against the middleware's actual source, not assumed)
- [x] **Live integration test**: fully verified regression paths - 6 populated compliance plans (including the plan originally used to report this bug) all succeed correctly, and the "not found" error case still works and remains clearly distinct in wording from the new exception.

### Known gap (explicitly accepted)
The exact empty-instances condition could not be reproduced live in this pass, since the platform's plan originally used to report this bug has since had devices/checks added - none of the 7 compliance plans currently on the test platform are empty. This is a platform-state limitation, not a code gap: the fix is backstopped by a unit test proven to genuinely reproduce the failure against real pre-fix code, plus full code review of the guard logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
