### PR TITLE
fix: device group tools missing default and wrong HTTPMethod type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `run_compliance_plan` when a compliance plan's run history is empty (#379)
 - Use the correct HTTP method and path for `update_command_template`, which
   previously 404'd on every real call (#380)
+- Add missing `default=None` to the `devices` parameter in
+  `add_devices_to_group` and `remove_devices_from_group`, which caused these
+  tools to still fail with a stringified-array validation error even after
+  the item-type fix above, since the parameter's JSON schema incorrectly
+  marked it as required
 
 ### Note
 - The two dependency bumps above (#369, #371) touch the ASGI/transport layer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tools to still fail with a stringified-array validation error even after
   the item-type fix above, since the parameter's JSON schema incorrectly
   marked it as required
+- Fix `add_devices_to_group` and `remove_devices_from_group` failing with
+  `method must be of type \`HTTPMethod\`` -- `describe_device_group` (called
+  internally by both tools) passed a raw string instead of the required
+  `HTTPMethod` enum to the underlying platform client
 
 ### Note
 - The two dependency bumps above (#369, #371) touch the ASGI/transport layer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `add_devices_to_group` and `remove_devices_from_group`, which caused these
   tools to still fail with a stringified-array validation error even after
   the item-type fix above, since the parameter's JSON schema incorrectly
-  marked it as required
+  marked it as required (#382)
 - Fix `add_devices_to_group` and `remove_devices_from_group` failing with
   `method must be of type \`HTTPMethod\`` -- `describe_device_group` (called
   internally by both tools) passed a raw string instead of the required
-  `HTTPMethod` enum to the underlying platform client
+  `HTTPMethod` enum to the underlying platform client (#382)
 
 ### Note
 - The two dependency bumps above (#369, #371) touch the ASGI/transport layer

--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -4,6 +4,8 @@
 
 import ipsdk
 
+from ipsdk.http import HTTPMethod
+
 from itential_mcp.core import exceptions
 
 from itential_mcp.platform.services import ServiceBase
@@ -324,7 +326,9 @@ class Service(ServiceBase):
             ServerException: If there is an error communicating with the server
         """
         res = await self.client._send_request(
-            "GET", "/configuration_manager/name/devicegroups", json={"groupName": name}
+            HTTPMethod.GET,
+            "/configuration_manager/name/devicegroups",
+            json={"groupName": name},
         )
         return res.json()
 

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -102,6 +102,7 @@ async def add_devices_to_group(
         list[str] | None,
         Field(
             description="List of devices to add to the group",
+            default=None,
         ),
     ],
 ) -> models.AddDevicesToGroupResponse:
@@ -152,7 +153,11 @@ async def remove_devices_from_group(
         str, Field(description="The name of the device group to remove devices from")
     ],
     devices: Annotated[
-        list[str] | None, Field(description="List of devices to remove from the group")
+        list[str] | None,
+        Field(
+            description="List of devices to remove from the group",
+            default=None,
+        ),
     ],
 ) -> models.RemoveDevicesFromGroupResponse:
     """

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, Mock
 import httpx
 import ipsdk
 
+from ipsdk.http import HTTPMethod
+
 from itential_mcp.core import exceptions
 from itential_mcp.platform.services.configuration_manager import Service
 from itential_mcp.platform.services import ServiceBase
@@ -790,10 +792,13 @@ class TestConfigurationManagerDeviceGroups:
         result = await service.describe_device_group("Production Routers")
 
         mock_client._send_request.assert_called_once_with(
-            "GET",
+            HTTPMethod.GET,
             "/configuration_manager/name/devicegroups",
             json={"groupName": "Production Routers"},
         )
+        called_method = mock_client._send_request.call_args[0][0]
+        assert isinstance(called_method, HTTPMethod)
+        assert called_method == HTTPMethod.GET
         assert result == expected_data
 
     @pytest.mark.asyncio
@@ -813,7 +818,7 @@ class TestConfigurationManagerDeviceGroups:
         result = await service.describe_device_group("Empty Group")
 
         mock_client._send_request.assert_called_once_with(
-            "GET",
+            HTTPMethod.GET,
             "/configuration_manager/name/devicegroups",
             json={"groupName": "Empty Group"},
         )

--- a/tests/test_tools_device_groups.py
+++ b/tests/test_tools_device_groups.py
@@ -805,6 +805,10 @@ class TestToolSchemas:
         assert array_schema["items"] == {"type": "string"}
         assert array_schema["items"] != {}
 
+        assert "default" in devices_schema
+        assert devices_schema["default"] is None
+        assert "devices" not in tool.parameters.get("required", [])
+
     def test_add_devices_to_group_devices_schema(self):
         """Test add_devices_to_group's devices schema declares string items"""
         tool = Tool.from_function(device_groups.add_devices_to_group)
@@ -816,6 +820,10 @@ class TestToolSchemas:
         assert array_schema["items"] == {"type": "string"}
         assert array_schema["items"] != {}
 
+        assert "default" in devices_schema
+        assert devices_schema["default"] is None
+        assert "devices" not in tool.parameters.get("required", [])
+
     def test_remove_devices_from_group_devices_schema(self):
         """Test remove_devices_from_group's devices schema declares string items"""
         tool = Tool.from_function(device_groups.remove_devices_from_group)
@@ -826,3 +834,7 @@ class TestToolSchemas:
         assert array_schema["type"] == "array"
         assert array_schema["items"] == {"type": "string"}
         assert array_schema["items"] != {}
+
+        assert "default" in devices_schema
+        assert devices_schema["default"] is None
+        assert "devices" not in tool.parameters.get("required", [])


### PR DESCRIPTION
## Summary
Two bugs, together needed to make `add_devices_to_group`/`remove_devices_from_group` actually usable via a real MCP client for the first time - both are folded into the 0.13.2 release before tagging.

**Commit 1 (`2fdad38`)**: `add_devices_to_group`/`remove_devices_from_group`'s `devices` parameter was missing `default=None` on its `Field(...)`, unlike `create_device_group`'s identical parameter. This made the JSON schema mark `devices` as required rather than optional. A live retest with Claude Desktop AFTER an earlier item-type fix (#378) merged confirmed this alone was enough to reproduce the exact stringified-array symptom that fix was supposed to resolve. Fixed to match `create_device_group`'s schema exactly.

**Commit 2 (`6ccfb3d`)**: `describe_device_group` (called internally by both tools before their actual add/remove operation) passed a raw string `"GET"` instead of the required `HTTPMethod` enum to the underlying platform client, causing both tools to fail with `method must be of type \`HTTPMethod\`` before ever reaching their real operation. Fixed to pass the enum. Confirmed the only raw `_send_request` call in the entire services tree.

## Test plan
- [x] `make ci` - 2562 passed, bandit 0 issues
- [x] New/extended tests independently verified to genuinely fail on the pre-fix code for both commits (schema tests for commit 1, enum-value assertion for commit 2)
- [x] **Live integration test, both bugs together**: confirmed end-to-end via CLI AND a full real MCP client protocol round-trip (FastMCP `Client` over stdio - `initialize` -> `tools/list` -> `tools/call`). Devices were genuinely added then removed, verified via independent follow-up reads, not just trusted success responses. `create_device_group` confirmed unaffected.
- [x] **Live Claude Desktop retest** confirmed the schema fix specifically resolves the stringified-array symptom (a real JSON array now arrives instead of a string).

### Related findings (not caused by this PR, tracked separately, do not block)
Found two separate, pre-existing bugs during live testing, both confirmed via reproduction on unmodified `devel`:
- A data-loss risk: `add_devices_to_group`'s underlying PUT does a full replace, not a merge, silently dropping any devices already in the group - contradicts the tool's own name/docstring.
- An unhandled `TypeError` instead of the documented `NotFoundError` when the target group doesn't exist - previously masked entirely by the `HTTPMethod` bug fixed in this PR, now reachable for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
