### PR TITLE
fix: merge devices instead of replacing in add_devices_to_group

### DIFF
--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -2,6 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import ipsdk
 
 from ipsdk.http import HTTPMethod
@@ -403,17 +405,24 @@ class Service(ServiceBase):
         """
         Add one or more devices to an existing device group.
 
-        This method adds a list of devices to the specified device group.
-        The method first retrieves the device group ID by name, then updates
-        the group to include the new devices. The devices list replaces any
-        existing devices in the group.
+        This method merges the supplied devices into the specified device
+        group's existing device list. The method first retrieves the device
+        group's current devices, then computes the union of the existing
+        devices and the supplied devices, preserving order and removing
+        duplicates (both against devices already in the group and within
+        the caller's own supplied list). Devices already present in the
+        group are not duplicated. Passing an empty list or None is a no-op
+        that leaves the group unchanged.
 
         Args:
             name (str): Name of the device group to add devices to
             devices (list): List of device names to add to the group
 
         Returns:
-            dict: Operation result containing status and details of the update
+            dict: Operation result containing status and details of the
+                update. If the merged device list is unchanged from the
+                group's existing devices, no update is performed and a
+                synthetic no-op success result is returned instead.
 
         Raises:
             NotFoundError: If the specified device group name cannot be found
@@ -421,14 +430,40 @@ class Service(ServiceBase):
         """
         device_group = await self.describe_device_group(name)
         device_group_id = device_group["id"]
+        existing = device_group.get("devices", [])
 
-        body = {"details": {"devices": devices}}
+        merged = self._dedup_preserve_order(list(existing) + list(devices or []))
+
+        if merged == list(existing):
+            return {"status": "success", "message": "no new devices to add"}
+
+        body = {"details": {"devices": merged}}
 
         res = await self.client.put(
             f"/configuration_manager/deviceGroups/{device_group_id}", json=body
         )
 
         return res.json()
+
+    @staticmethod
+    def _dedup_preserve_order(items: list[str]) -> list[str]:
+        """
+        Deduplicate a list of strings while preserving first-seen order.
+
+        Args:
+            items (list[str]): List of strings that may contain duplicates
+
+        Returns:
+            list[str]: A new list containing only the first occurrence of
+                each item, in the order it was first seen
+        """
+        seen = set()
+        result = []
+        for item in items:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
 
     async def remove_devices_from_group(self, name: str, devices: list) -> dict:
         """
@@ -455,7 +490,7 @@ class Service(ServiceBase):
         device_group_id = data["id"]
 
         remaining_devices = []
-        for device in data["devices"]:
+        for device in data.get("devices", []):
             if device not in devices:
                 remaining_devices.append(device)
 

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -116,7 +116,11 @@ async def add_devices_to_group(
     get_device_groups tool.
 
     The devices argument provides the list of devices to be added to the
-    named device group.
+    named device group.  This operation is additive and idempotent: it
+    merges the supplied devices into the group's existing device list
+    rather than replacing it, and devices already present in the group are
+    not duplicated.  Passing an empty list or None is a no-op that leaves
+    the group's devices unchanged.
 
     Args:
         ctx (Context): The FastMCP Context object

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -1004,7 +1004,7 @@ class TestConfigurationManagerDeviceGroups:
 
     @pytest.mark.asyncio
     async def test_add_devices_to_group_success(self, service, mock_client):
-        """Test successfully adding devices to a group."""
+        """Test successfully adding new devices merges with existing devices."""
         # Mock describe_device_group response
         mock_group_data = {
             "id": "group-123",
@@ -1021,13 +1021,13 @@ class TestConfigurationManagerDeviceGroups:
         mock_client.put.return_value = mock_response
 
         result = await service.add_devices_to_group(
-            name="Test Group", devices=["device1", "device2", "device3"]
+            name="Test Group", devices=["device2", "device3"]
         )
 
         # Verify describe_device_group was called
         service.describe_device_group.assert_called_once_with("Test Group")
 
-        # Verify API call
+        # Verify API call contains the union of existing + new devices
         expected_body = {"details": {"devices": ["device1", "device2", "device3"]}}
         mock_client.put.assert_called_once_with(
             "/configuration_manager/deviceGroups/group-123", json=expected_body
@@ -1037,7 +1037,7 @@ class TestConfigurationManagerDeviceGroups:
 
     @pytest.mark.asyncio
     async def test_add_devices_to_group_empty_list(self, service, mock_client):
-        """Test adding empty devices list to a group."""
+        """Test adding an empty devices list leaves the group unchanged."""
         mock_group_data = {
             "id": "group-789",
             "name": "Empty Add Group",
@@ -1047,20 +1047,114 @@ class TestConfigurationManagerDeviceGroups:
 
         service.describe_device_group = AsyncMock(return_value=mock_group_data)
 
+        result = await service.add_devices_to_group(name="Empty Add Group", devices=[])
+
+        # Verify no PUT call was made since the resulting list is unchanged
+        mock_client.put.assert_not_called()
+
+        # Verify the no-op result indicates no devices were added
+        assert result == {"status": "success", "message": "no new devices to add"}
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_merges_not_replaces_regression(
+        self, service, mock_client
+    ):
+        """Regression test: adding devices must merge, not replace.
+
+        Confirmed live bug: a group with [CPE-1, CPE-2] became [CISCO-APIC]
+        after calling add_devices_to_group(devices=["CISCO-APIC"]).
+        """
+        mock_group_data = {
+            "id": "group-live-repro",
+            "name": "TestGroup",
+            "devices": ["CPE-1", "CPE-2"],
+            "description": "Live repro group",
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
         expected_response = {"status": "success"}
         mock_response = Mock()
         mock_response.json.return_value = expected_response
         mock_client.put.return_value = mock_response
 
-        result = await service.add_devices_to_group(name="Empty Add Group", devices=[])
+        await service.add_devices_to_group(name="TestGroup", devices=["CISCO-APIC"])
 
-        # Verify empty devices list was handled
-        expected_body = {"details": {"devices": []}}
+        expected_body = {"details": {"devices": ["CPE-1", "CPE-2", "CISCO-APIC"]}}
         mock_client.put.assert_called_once_with(
-            "/configuration_manager/deviceGroups/group-789", json=expected_body
+            "/configuration_manager/deviceGroups/group-live-repro", json=expected_body
         )
 
-        assert result == expected_response
+        put_devices = mock_client.put.call_args.kwargs["json"]["details"]["devices"]
+        assert "CPE-1" in put_devices
+        assert "CPE-2" in put_devices
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_idempotent_already_present(
+        self, service, mock_client
+    ):
+        """Test adding a device already present in the group is a no-op."""
+        mock_group_data = {
+            "id": "group-idempotent",
+            "name": "Idempotent Group",
+            "devices": ["CPE-1"],
+            "description": "Idempotent group",
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        result = await service.add_devices_to_group(
+            name="Idempotent Group", devices=["CPE-1"]
+        )
+
+        # No duplicate should be created and no PUT call should be made
+        mock_client.put.assert_not_called()
+        assert result == {"status": "success", "message": "no new devices to add"}
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_dedups_supplied_list(
+        self, service, mock_client
+    ):
+        """Test duplicate devices within the caller's own list are deduped."""
+        mock_group_data = {
+            "id": "group-dedup",
+            "name": "Dedup Group",
+            "devices": [],
+            "description": "Dedup group",
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        expected_response = {"status": "success"}
+        mock_response = Mock()
+        mock_response.json.return_value = expected_response
+        mock_client.put.return_value = mock_response
+
+        await service.add_devices_to_group(name="Dedup Group", devices=["A", "A", "B"])
+
+        expected_body = {"details": {"devices": ["A", "B"]}}
+        mock_client.put.assert_called_once_with(
+            "/configuration_manager/deviceGroups/group-dedup", json=expected_body
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_none_devices_is_noop(
+        self, service, mock_client
+    ):
+        """Test passing devices=None is a no-op that leaves the group unchanged."""
+        mock_group_data = {
+            "id": "group-none",
+            "name": "None Group",
+            "devices": ["CPE-1"],
+            "description": "None group",
+        }
+
+        service.describe_device_group = AsyncMock(return_value=mock_group_data)
+
+        result = await service.add_devices_to_group(name="None Group", devices=None)
+
+        mock_client.put.assert_not_called()
+        assert result == {"status": "success", "message": "no new devices to add"}
 
     @pytest.mark.asyncio
     async def test_remove_devices_from_group_success(self, service, mock_client):


### PR DESCRIPTION
## Summary
`add_devices_to_group` previously fetched the device group only to get its `id`, then PUT ONLY the caller-supplied `devices` list - silently discarding any devices already in the group. Confirmed live: a group with `[CPE-1, CPE-2]` became `[CISCO-APIC]` after a single "add" call. Real data-loss risk for anyone using the tool as its name suggests ("add one or more devices").

- Now fetches and merges with the group's current device list, deduplicating (both against existing devices and within the caller's own supplied list), preserving order.
- If the merged result is unchanged (empty/None input, or all supplied devices already present), skips the PUT entirely as a safe no-op instead of an unnecessary/risky round-trip write.
- `remove_devices_from_group` was already correct (it inherently needs the current list to know what to filter out) - hardened its device-list access to use `.get()` defensively, no logic change.
- Fixed a docstring that previously described the replace behavior as intended, rather than as the bug it was.

Existing tests encoded the bug directly - one asserted an empty `devices=[]` input wipes the group's device list to `[]`. Rewrote both affected tests and added regression coverage for the merge behavior, idempotency, intra-list dedup, and the no-op skip-PUT path.

## Test plan
- [x] `make ci` - 2566 passed, bandit 0 issues
- [x] Independently reverted the fix and confirmed all 6 new/rewritten tests genuinely fail against the pre-fix buggy code
- [x] **Live integration test against the exact platform/group where this bug was originally discovered**: reproduced the exact original scenario and confirmed it's resolved - existing devices now survive an add call. Also verified idempotency (re-adding an existing device is a no-op), no-op behavior on empty/None input, and no regression in `remove_devices_from_group`. Live platform test group restored to its original state after testing.

### Related finding (not caused by this PR, tracked separately)
Found a separate, pre-existing bug during live testing: calling `add_devices_to_group`/`remove_devices_from_group` on a nonexistent group name raises an unhandled `TypeError` instead of the documented `NotFoundError`. Confirmed identical on unmodified `devel` - tracked separately, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
