### PR TITLE
fix: raise NotFoundError instead of TypeError for nonexistent device group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Merge supplied devices into a device group's existing device list instead
+  of replacing it, which previously caused `add_devices_to_group` to silently
+  delete every device not included in the current call (#383)
+- Raise `NotFoundError` instead of an unhandled `TypeError` from
+  `add_devices_to_group`/`remove_devices_from_group` when the target device
+  group name does not exist (#384)
+
 ## [0.13.2] - 2026-08-03
 
 ### Security

--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -332,7 +332,10 @@ class Service(ServiceBase):
             "/configuration_manager/name/devicegroups",
             json={"groupName": name},
         )
-        return res.json()
+        data = res.json()
+        if not data:
+            raise exceptions.NotFoundError(f"device group '{name}' not found")
+        return data
 
     async def get_device_groups(self) -> list[dict]:
         """

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -1333,11 +1333,60 @@ class TestConfigurationManagerDeviceGroups:
         # Reset side effect for other operations
         mock_client.get.side_effect = None
 
-        # Test client error in describe_device_group
+        # Test transport-level error in describe_device_group (e.g. connection
+        # failure or non-2xx response). Distinct from the 200-with-null "not
+        # found" path covered by test_describe_device_group_not_found below.
         mock_client._send_request.side_effect = Exception("Group not found")
 
         with pytest.raises(Exception, match="Group not found"):
             await service.describe_device_group("NonExistent Group")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("empty_body", [None, {}])
+    async def test_describe_device_group_not_found(
+        self, service, mock_client, empty_body
+    ):
+        """Test describe_device_group raises NotFoundError on a 200 response
+        with a null (or empty) body, which is how the platform signals a
+        nonexistent device group name."""
+        mock_response = Mock()
+        mock_response.json.return_value = empty_body
+        mock_client._send_request.return_value = mock_response
+
+        with pytest.raises(exceptions.NotFoundError, match="NonExistent Group"):
+            await service.describe_device_group("NonExistent Group")
+
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_group_not_found(self, service, mock_client):
+        """Test add_devices_to_group propagates NotFoundError unchanged when
+        the underlying device group lookup fails to find the group, and
+        never issues the PUT update call."""
+        service.describe_device_group = AsyncMock(
+            side_effect=exceptions.NotFoundError("device group 'Ghost Group' not found")
+        )
+
+        with pytest.raises(exceptions.NotFoundError, match="Ghost Group"):
+            await service.add_devices_to_group(name="Ghost Group", devices=["device1"])
+
+        mock_client.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_group_not_found(
+        self, service, mock_client
+    ):
+        """Test remove_devices_from_group propagates NotFoundError unchanged
+        when the underlying device group lookup fails to find the group, and
+        never issues the PUT update call."""
+        service.describe_device_group = AsyncMock(
+            side_effect=exceptions.NotFoundError("device group 'Ghost Group' not found")
+        )
+
+        with pytest.raises(exceptions.NotFoundError, match="Ghost Group"):
+            await service.remove_devices_from_group(
+                name="Ghost Group", devices=["device1"]
+            )
+
+        mock_client.put.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_device_group_integration_workflow(self, service, mock_client):

--- a/tests/test_tools_device_groups.py
+++ b/tests/test_tools_device_groups.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 from fastmcp import Context
 from fastmcp.tools import Tool
 
+from itential_mcp.core import exceptions
 from itential_mcp.tools import device_groups
 from itential_mcp.models.device_groups import (
     DeviceGroupElement,
@@ -465,6 +466,21 @@ class TestAddDevicesToGroup:
 
         mock_context.debug.assert_called_once_with("inside add_devices_to_group(...)")
 
+    @pytest.mark.asyncio
+    async def test_add_devices_to_group_not_found_propagates(self, mock_context):
+        """Test add_devices_to_group propagates NotFoundError from the
+        underlying service unchanged when the device group does not exist."""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.add_devices_to_group = AsyncMock(
+            side_effect=exceptions.NotFoundError("device group 'Ghost' not found")
+        )
+
+        with pytest.raises(exceptions.NotFoundError, match="Ghost"):
+            await device_groups.add_devices_to_group(
+                mock_context, name="Ghost", devices=["device1"]
+            )
+
 
 class TestRemoveDevicesFromGroup:
     """Test the remove_devices_from_group tool function"""
@@ -637,6 +653,21 @@ class TestRemoveDevicesFromGroup:
         mock_context.debug.assert_called_once_with(
             "inside remove_devices_from_group(...)"
         )
+
+    @pytest.mark.asyncio
+    async def test_remove_devices_from_group_not_found_propagates(self, mock_context):
+        """Test remove_devices_from_group propagates NotFoundError from the
+        underlying service unchanged when the device group does not exist."""
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.configuration_manager = MagicMock()
+        mock_client.configuration_manager.remove_devices_from_group = AsyncMock(
+            side_effect=exceptions.NotFoundError("device group 'Ghost' not found")
+        )
+
+        with pytest.raises(exceptions.NotFoundError, match="Ghost"):
+            await device_groups.remove_devices_from_group(
+                mock_context, name="Ghost", devices=["device1"]
+            )
 
 
 class TestToolsIntegration:


### PR DESCRIPTION
## Summary
- `describe_device_group` previously returned `None` unconditionally when the platform responded 200 with a null/empty body for a nonexistent device group name. `add_devices_to_group` and `remove_devices_from_group` (both call through `describe_device_group`) then crashed with a raw, confusing `TypeError: 'NoneType' object is not subscriptable` instead of a clean error.
- `describe_device_group` now raises `exceptions.NotFoundError(f"device group '{name}' not found")` when the platform response body is falsy, matching the method's own pre-existing (but previously untrue) docstring contract and the identical pattern already used elsewhere in this file (`describe_config_tree`).
- Also adds the CHANGELOG entry that PR #383 (item #42, devices merge-not-replace fix) was missing, plus this fix's own entry.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2572 unit tests)
- [x] New/updated tests: `test_describe_device_group_not_found` (parametrized `None`/`{}`), `test_add_devices_to_group_group_not_found`, `test_remove_devices_from_group_group_not_found`, plus tool-layer parity tests in `tests/test_tools_device_groups.py`
- [x] Verified regression coverage: reverted the source fix locally and confirmed the new tests fail without it (`DID NOT RAISE NotFoundError`)
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - `describe_device_group`/`add_devices_to_group`/`remove_devices_from_group` on a nonexistent group name all now raise/surface a clean `NotFoundError`, not a raw `TypeError`
  - Happy-path regressions confirmed unaffected: `add_devices_to_group` merge/dedupe (PR #383) and `describe_device_group` on a real existing group both still work correctly

PATCH-shaped change: reuses the existing `exceptions.NotFoundError` type, no new public surface.
