### PR TITLE
fix: declare missing description field on CommandTemplateDetail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raise `NotFoundError` instead of an unhandled `TypeError` from
   `add_devices_to_group`/`remove_devices_from_group` when the target device
   group name does not exist (#384)
+- Declare the missing `description` field on `CommandTemplateDetail`, which
+  previously caused Pydantic to silently drop it from
+  `describe_command_template`'s response even when the platform returned one
+  (#385)
 
 ## [0.13.2] - 2026-08-03
 

--- a/src/itential_mcp/models/command_templates.py
+++ b/src/itential_mcp/models/command_templates.py
@@ -117,6 +117,7 @@ class CommandTemplateDetail(BaseModel):
     Attributes:
         id: Unique identifier for the command template.
         name: Human-readable template name.
+        description: Brief description of what the template does.
         commands: List of commands and associated validation rules.
         namespace: Project namespace (null for global templates).
         passRule: Pass rule configuration for template evaluation.
@@ -142,6 +143,18 @@ class CommandTemplateDetail(BaseModel):
                 Human-readable name of the command template
                 """
             )
+        ),
+    ]
+
+    description: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Brief description of what the template does (null if not provided)
+                """
+            ),
+            default=None,
         ),
     ]
 

--- a/tests/test_models_command_templates.py
+++ b/tests/test_models_command_templates.py
@@ -154,6 +154,7 @@ class TestCommandTemplateDetail:
         detail = models.CommandTemplateDetail(
             _id="detail_123",
             name="detailed_template",
+            description="Detailed test template",
             commands=commands,
             namespace={"type": "project", "_id": "project1", "name": "Project 1"},
             passRule=True,
@@ -161,6 +162,7 @@ class TestCommandTemplateDetail:
 
         assert detail.id == "detail_123"
         assert detail.name == "detailed_template"
+        assert detail.description == "Detailed test template"
         assert detail.commands == commands
         assert detail.namespace["_id"] == "project1"
         assert detail.passRule is True
@@ -193,6 +195,40 @@ class TestCommandTemplateDetail:
         detail = models.CommandTemplateDetail(**payload)
 
         assert detail.namespace is None
+
+    def test_command_template_detail_missing_description(self):
+        """Test CommandTemplateDetail defaults description to None when the
+        key is absent entirely from the platform response.
+        """
+        payload = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "commands": [],
+            "namespace": None,
+            "passRule": True,
+        }
+
+        detail = models.CommandTemplateDetail(**payload)
+
+        assert detail.description is None
+
+    def test_command_template_detail_with_description(self):
+        """Test CommandTemplateDetail round-trips description correctly
+        when the platform response includes it, guarding against the
+        silent data loss that occurred when this field was undeclared.
+        """
+        payload = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "description": "Runs curl against the device",
+            "commands": [],
+            "namespace": None,
+            "passRule": True,
+        }
+
+        detail = models.CommandTemplateDetail(**payload)
+
+        assert detail.description == "Runs curl against the device"
 
 
 class TestDescribeCommandTemplateResponse:

--- a/tests/test_tools_command_templates.py
+++ b/tests/test_tools_command_templates.py
@@ -2,9 +2,85 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from fastmcp import Context
 from fastmcp.tools import Tool
 
+from itential_mcp.models.command_templates import DescribeCommandTemplateResponse
 from itential_mcp.tools import command_templates
+
+
+class TestDescribeCommandTemplate:
+    """Tests for the describe_command_template tool function"""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock Context object"""
+        context = AsyncMock(spec=Context)
+        context.debug = AsyncMock()
+
+        mock_client = MagicMock()
+        context.request_context = MagicMock()
+        context.request_context.lifespan_context = MagicMock()
+        context.request_context.lifespan_context.get.return_value = mock_client
+
+        return context
+
+    @pytest.mark.asyncio
+    async def test_describe_command_template_includes_description(self, mock_context):
+        """Test describe_command_template surfaces the description field
+        from the platform response, guarding against the silent data loss
+        that occurred when CommandTemplateDetail had no description field
+        declared.
+        """
+        mock_data = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "description": "Runs curl against the device",
+            "commands": [{"command": "show version", "rules": []}],
+            "namespace": None,
+            "passRule": True,
+        }
+
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.mop = MagicMock()
+        mock_client.mop.describe_command_template = AsyncMock(return_value=mock_data)
+
+        result = await command_templates.describe_command_template(
+            mock_context, name="linux-curl-http", project=None
+        )
+
+        mock_client.mop.describe_command_template.assert_called_once_with(
+            name="linux-curl-http", project=None
+        )
+
+        assert isinstance(result, DescribeCommandTemplateResponse)
+        assert result.template.description == "Runs curl against the device"
+
+    @pytest.mark.asyncio
+    async def test_describe_command_template_missing_description(self, mock_context):
+        """Test describe_command_template defaults description to None when
+        the platform response does not include the key.
+        """
+        mock_data = {
+            "_id": "linux-curl-http",
+            "name": "linux-curl-http",
+            "commands": [],
+            "namespace": None,
+            "passRule": True,
+        }
+
+        mock_client = mock_context.request_context.lifespan_context.get.return_value
+        mock_client.mop = MagicMock()
+        mock_client.mop.describe_command_template = AsyncMock(return_value=mock_data)
+
+        result = await command_templates.describe_command_template(
+            mock_context, name="linux-curl-http", project=None
+        )
+
+        assert result.template.description is None
 
 
 class TestToolSchemas:


### PR DESCRIPTION
## Summary
- `CommandTemplateDetail` (the response model backing `describe_command_template`) had no `description` field declared at all — unlike its sibling `CommandTemplate` (used by `get_command_templates`), which already declares one. Pydantic was silently dropping the platform's `description` value whenever it was present in the raw response.
- Added `description: str | None = None` to `CommandTemplateDetail`, matching `CommandTemplate`'s existing field definition.
- The original bug report for this item also claimed `namespace: null` for project-scoped templates, but that was live-verified against a real platform and did **not** reproduce — both `/mop/listTemplates` and `/mop/listATemplate/{name}` return `namespace` correctly and identically for genuine project-scoped templates. That half of the report is being closed as not-reproduced; this PR intentionally does not touch anything namespace-related.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2576 unit tests)
- [x] New tests: `CommandTemplateDetail` description round-trip (present/absent) in `tests/test_models_command_templates.py`; new `TestDescribeCommandTemplate` coverage in `tests/test_tools_command_templates.py` (previously had no functional coverage of this tool)
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - `description` now surfaces correctly for a template with a known non-null description
  - null-description case handled cleanly, no crash
  - both global and project-scoped templates work end-to-end, no regressions to `namespace`/`commands`/other fields
  - `update_command_template` regression smoke check (unaffected, operates on raw dict not the Pydantic model)

PATCH-shaped change: additive nullable field only, no new public surface, no tool signature changes.
