### PR TITLE
fix: paginate get_integration_models to avoid silent truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously caused Pydantic to silently drop it from
   `describe_command_template`'s response even when the platform returned one
   (#385)
+- Paginate `get_integration_models` using the existing `_paginate` helper
+  (already used by `get_integrations`) instead of a single unpaginated
+  request, which previously silently truncated results to the platform's
+  default page size of 25 and made `create_integration_model`'s
+  duplicate-check unreliable (#386)
 
 ## [0.13.2] - 2026-08-03
 

--- a/src/itential_mcp/platform/services/integrations.py
+++ b/src/itential_mcp/platform/services/integrations.py
@@ -74,8 +74,12 @@ class Service(ServiceBase):
             ConnectionException: If there is an error connecting to the platform
             AuthenticationException: If authentication credentials are invalid
         """
-        res = await self.client.get("/integration-models")
-        return res.json()
+        results = await self._paginate(
+            "/integration-models",
+            data_key="integrationModels",
+            total_key="total",
+        )
+        return {"integrationModels": results}
 
     async def create_integration_model(self, model: dict) -> dict:
         """

--- a/tests/test_services_integrations.py
+++ b/tests/test_services_integrations.py
@@ -40,38 +40,86 @@ class TestService:
     @pytest.mark.asyncio
     async def test_get_integration_models_success(self, service, mock_client):
         """Test successful retrieval of integration models."""
-        expected_response = {
-            "integrationModels": [
-                {
-                    "versionId": "test-model:1.0.0",
-                    "properties": {"version": "1.0.0"},
-                    "description": "Test model",
-                }
-            ]
-        }
+        models = [
+            {
+                "versionId": "test-model:1.0.0",
+                "properties": {"version": "1.0.0"},
+                "description": "Test model",
+            }
+        ]
+        api_response = {"integrationModels": models, "total": len(models)}
 
         mock_response = Mock(spec=Response)
-        mock_response.json.return_value = expected_response
+        mock_response.json.return_value = api_response
         mock_client.get.return_value = mock_response
 
         result = await service.get_integration_models()
 
-        mock_client.get.assert_called_once_with("/integration-models")
-        assert result == expected_response
+        mock_client.get.assert_called_once_with(
+            "/integration-models", params={"limit": 100, "skip": 0}
+        )
+        assert result == {"integrationModels": models}
 
     @pytest.mark.asyncio
     async def test_get_integration_models_empty_response(self, service, mock_client):
         """Test get_integration_models with empty response."""
-        expected_response = {"integrationModels": []}
+        api_response = {"integrationModels": [], "total": 0}
 
         mock_response = Mock(spec=Response)
-        mock_response.json.return_value = expected_response
+        mock_response.json.return_value = api_response
         mock_client.get.return_value = mock_response
 
         result = await service.get_integration_models()
 
-        mock_client.get.assert_called_once_with("/integration-models")
-        assert result == expected_response
+        mock_client.get.assert_called_once_with(
+            "/integration-models", params={"limit": 100, "skip": 0}
+        )
+        assert result == {"integrationModels": []}
+
+    @pytest.mark.asyncio
+    async def test_get_integration_models_pagination(self):
+        """Test get_integration_models paginates across multiple pages."""
+        fresh_mock_client = Mock()
+        fresh_mock_client.get = AsyncMock()
+        fresh_service = Service(fresh_mock_client)
+
+        first_page_models = [
+            {"versionId": f"model-{i}:1.0.0", "properties": {"version": "1.0.0"}}
+            for i in range(100)
+        ]
+        second_page_models = [
+            {"versionId": f"model-{i}:1.0.0", "properties": {"version": "1.0.0"}}
+            for i in range(100, 128)
+        ]
+
+        first_response = {
+            "integrationModels": first_page_models,
+            "total": 128,
+        }
+        second_response = {
+            "integrationModels": second_page_models,
+            "total": 128,
+        }
+
+        mock_response_1 = Mock(spec=Response)
+        mock_response_1.json.return_value = first_response
+
+        mock_response_2 = Mock(spec=Response)
+        mock_response_2.json.return_value = second_response
+
+        fresh_mock_client.get.side_effect = [mock_response_1, mock_response_2]
+
+        result = await fresh_service.get_integration_models()
+
+        assert fresh_mock_client.get.call_count == 2
+
+        calls = fresh_mock_client.get.call_args_list
+        for call in calls:
+            assert call[0][0] == "/integration-models"
+            assert "params" in call[1]
+            assert call[1]["params"]["limit"] == 100
+
+        assert result == {"integrationModels": first_page_models + second_page_models}
 
     @pytest.mark.asyncio
     async def test_create_integration_model_success(self, service, mock_client):
@@ -107,7 +155,9 @@ class TestService:
         result = await service.create_integration_model(model)
 
         # Verify all calls were made
-        mock_client.get.assert_called_once_with("/integration-models")
+        mock_client.get.assert_called_once_with(
+            "/integration-models", params={"limit": 100, "skip": 0}
+        )
         mock_client.put.assert_called_once_with(
             "/integration-models/validation", json={"model": model}
         )
@@ -140,7 +190,9 @@ class TestService:
             await service.create_integration_model(model)
 
         assert "model existing-api:1.0.0 already exists" in str(exc_info.value)
-        mock_client.get.assert_called_once_with("/integration-models")
+        mock_client.get.assert_called_once_with(
+            "/integration-models", params={"limit": 100, "skip": 0}
+        )
         # Validation and creation should not be called
         mock_client.put.assert_not_called()
         mock_client.post.assert_not_called()
@@ -189,7 +241,9 @@ class TestService:
         result = await service.create_integration_model(model)
 
         # Verify all calls were made
-        mock_client.get.assert_called_once_with("/integration-models")
+        mock_client.get.assert_called_once_with(
+            "/integration-models", params={"limit": 100, "skip": 0}
+        )
         mock_client.put.assert_called_once_with(
             "/integration-models/validation", json={"model": model}
         )


### PR DESCRIPTION
## Summary
- `get_integration_models` made a single unpaginated `client.get("/integration-models")` call, silently relying on the platform's default page size (confirmed 25 via live curl testing). Any models past the first page were dropped from the result without error.
- Fixed to use the existing `_paginate` helper — already used by the sibling `get_integrations` method in the same file — with `data_key="integrationModels"`, `total_key="total"`, matching the platform's confirmed response shape `{"integrationModels": [...], "total": N}`.
- This bug was originally tracked in the roadmap as a platform-side listing issue, but live curl testing against the real platform proved it was client-side pagination truncation, not a server bug — reclassified and fixed directly.
- `create_integration_model`'s duplicate-detection logic depends on this method internally and is now more reliable as a direct consequence.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2577 unit tests, 100% coverage on the changed file)
- [x] New test: `test_get_integration_models_pagination` — 128 items across 2 pages, verifies correct multi-request assembly
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - confirmed all 28 real integration models now returned (previously truncated at 25)
  - spot-checked 3 previously-missing models are now present in the tool's output
  - `create_integration_model`'s duplicate-detection regression check passes correctly
  - no performance/timeout regression from the added pagination (~1.5s total, well under the configured timeout)

PATCH-shaped change: reuses an existing pagination helper, no new public surface, no signature changes.
