### PR TITLE
chore: bump pydantic-settings to patched version (GHSA-4xgf-cpjx-pc3j)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Constrain pydantic-settings to >=2.14.2, resolving GHSA-4xgf-cpjx-pc3j
+  (medium severity, `NestedSecretsSettingsSource` issue with
+  `secrets_nested_subdir=True`, a feature not used anywhere in this
+  codebase); transitive dependency via fastmcp/mcp with no direct usage,
+  re-resolved via uv lock with no cascading version changes (#387)
+
 ### Fixed
 - Merge supplied devices into a device group's existing device list instead
   of replacing it, which previously caused `add_devices_to_group` to silently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Documentation = "https://github.com/itential/itential-mcp"
 itential-mcp = "itential_mcp.app:run"
 
 [tool.uv]
-constraint-dependencies = ["cryptography>=46.0.7,<47", "mcp>=1.28.1,<2"]
+constraint-dependencies = ["cryptography>=46.0.7,<47", "mcp>=1.28.1,<2", "pydantic-settings>=2.14.2"]
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ resolution-markers = [
 constraints = [
     { name = "cryptography", specifier = ">=46.0.7,<47" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
 ]
 
 [[package]]
@@ -1168,16 +1169,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `pydantic-settings` is a transitive dependency (via fastmcp/mcp — itential-mcp has zero direct usage anywhere in `src/`) that was locked at `2.13.1`, vulnerable to GHSA-4xgf-cpjx-pc3j (medium severity, affects `NestedSecretsSettingsSource` with `secrets_nested_subdir=True`, a feature itential-mcp does not use).
- Added `"pydantic-settings>=2.14.2"` to the existing `constraint-dependencies` list in `pyproject.toml` (alongside the existing `cryptography` and `mcp` constraint entries) and regenerated `uv.lock`.
- Confirmed no breaking changes between 2.13.1 and 2.14.2 (all bug-fix/security patch releases within the same 2.x line); the lockfile diff is scoped to exactly this one package, nothing else drifted.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2577 unit tests)
- [x] No new tests needed (pure dependency-constraint bump, zero code touches the affected package)
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - server starts cleanly with no import errors
  - config loading verified correct (both config-file and env-var precedence)
  - a real `get_health` tool call round-tripped successfully end-to-end
  - no deprecation warnings surfaced from the new pydantic-settings version

PATCH-shaped change: dependency-constraint bump only, no source code changes, no new public surface.
