### PR TITLE
fix: fail fast on unrecognized config file section names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request, which previously silently truncated results to the platform's
   default page size of 25 and made `create_integration_model`'s
   duplicate-check unreliable (#386)
+- Raise `ConfigurationException` naming the invalid section instead of
+  silently dropping any unrecognized top-level config file section (e.g. a
+  typo like `[profile prod]`), which previously discarded the section's
+  values with zero warning and let affected settings silently fall back to
+  their defaults (#388)
 
 ## [0.13.2] - 2026-08-03
 

--- a/docs/mcp.conf.example
+++ b/docs/mcp.conf.example
@@ -3,6 +3,10 @@
 # sections. For each configuration option, there is a description of the option
 # along with the application default setting and name of the environment
 # varilable that can be used to override the value.
+#
+# Only `server`, `platform`, `auth`, and `tool:<name>` are valid top-level
+# section names. Any other section name will cause the server to fail to
+# start with a configuration error.
 
 # The server section handles configuration options for running the MCP server.
 # All configuration options in this section are optional and can be overridden

--- a/src/itential_mcp/config/loaders.py
+++ b/src/itential_mcp/config/loaders.py
@@ -17,6 +17,7 @@ import configparser
 from pathlib import Path
 from typing import Any
 
+from ..core.exceptions import ConfigurationException
 from .models import (
     Config,
     ServerConfig,
@@ -26,6 +27,10 @@ from .models import (
     EndpointTool,
     ServiceTool,
 )
+
+# Top-level section names recognized in config files, in addition to any
+# section matching the "tool:<name>" pattern.
+_RECOGNIZED_SECTIONS = frozenset({"server", "auth", "platform"})
 
 
 def _parse_tool_env_variables() -> dict[str, dict[str, str]]:
@@ -126,6 +131,9 @@ def _parse_config_file(file_path: Path) -> tuple[dict[str, Any], list[Tool]]:
 
     Raises:
         FileNotFoundError: If the config file does not exist.
+        ConfigurationException: If the config file contains a top-level
+            section name that is not recognized (not one of "server",
+            "auth", "platform", or "tool:<name>").
     """
     if not file_path.is_file():
         raise FileNotFoundError(f"Config file not found: {file_path}")
@@ -152,11 +160,18 @@ def _parse_config_file(file_path: Path) -> tuple[dict[str, Any], list[Tool]]:
 
             tools.append(_create_tool_from_dict(tool_data))
 
-        else:
+        elif section in _RECOGNIZED_SECTIONS:
             # Parse regular configuration sections
             for key, value in parser.items(section):
                 config_key = f"{section}_{key}"
                 config_data[config_key] = value
+
+        else:
+            valid_sections = ", ".join(sorted(_RECOGNIZED_SECTIONS) + ["tool:<name>"])
+            raise ConfigurationException(
+                f"Invalid config file section: [{section}]. "
+                f"Valid section names are: {valid_sections}."
+            )
 
     # Add any remaining environment tools not found in config file
     for tool_name, tool_data in tool_env_config.items():

--- a/tests/test_config_coverage.py
+++ b/tests/test_config_coverage.py
@@ -435,9 +435,7 @@ class TestLoaderFunctions:
         assert tools[0].tool_name == "ENV_ONLY"
         assert tools[0].type == "service"
 
-    def test_parse_config_file_with_unrecognized_section_raises(
-        self, tmp_path, monkeypatch
-    ):
+    def test_parse_config_file_with_unrecognized_section_raises(self, tmp_path):
         """Test _parse_config_file raises ConfigurationException on an
         unrecognized top-level section name instead of silently flattening
         it and dropping the values.
@@ -456,9 +454,7 @@ class TestLoaderFunctions:
         with pytest.raises(ConfigurationException):
             _parse_config_file(config_path)
 
-    def test_parse_config_file_with_capitalized_section_raises(
-        self, tmp_path, monkeypatch
-    ):
+    def test_parse_config_file_with_capitalized_section_raises(self, tmp_path):
         """Test _parse_config_file rejects any unrecognized top-level
         section name generically, not just "profile" (e.g. wrong casing
         or pluralization of an otherwise-valid section name).

--- a/tests/test_config_coverage.py
+++ b/tests/test_config_coverage.py
@@ -435,6 +435,48 @@ class TestLoaderFunctions:
         assert tools[0].tool_name == "ENV_ONLY"
         assert tools[0].type == "service"
 
+    def test_parse_config_file_with_unrecognized_section_raises(
+        self, tmp_path, monkeypatch
+    ):
+        """Test _parse_config_file raises ConfigurationException on an
+        unrecognized top-level section name instead of silently flattening
+        it and dropping the values.
+        """
+        from itential_mcp.config.loaders import _parse_config_file
+        from itential_mcp.core.exceptions import ConfigurationException
+
+        config_path = tmp_path / "test.ini"
+
+        cp = configparser.ConfigParser()
+        cp["profile prod"] = {"host": "foo"}
+
+        with open(config_path, "w") as f:
+            cp.write(f)
+
+        with pytest.raises(ConfigurationException):
+            _parse_config_file(config_path)
+
+    def test_parse_config_file_with_capitalized_section_raises(
+        self, tmp_path, monkeypatch
+    ):
+        """Test _parse_config_file rejects any unrecognized top-level
+        section name generically, not just "profile" (e.g. wrong casing
+        or pluralization of an otherwise-valid section name).
+        """
+        from itential_mcp.config.loaders import _parse_config_file
+        from itential_mcp.core.exceptions import ConfigurationException
+
+        config_path = tmp_path / "test.ini"
+
+        cp = configparser.ConfigParser()
+        cp["Platform"] = {"host": "platform.example.com"}
+
+        with open(config_path, "w") as f:
+            cp.write(f)
+
+        with pytest.raises(ConfigurationException):
+            _parse_config_file(config_path)
+
     def test_split_comma_separated_in_loaders(self):
         """Test _split_comma_separated function in loaders module."""
         from itential_mcp.config.loaders import _split_comma_separated


### PR DESCRIPTION
## Summary
- `_parse_config_file` previously silently dropped any config-file section that wasn't `[server]`/`[auth]`/`[platform]`/`[tool:<name>]` (e.g. a typo like `[profile prod]`), discarding all values in it and letting the resulting config silently fall back to defaults (`platform.host = "localhost"`) — leading to a confusing "All connection attempts failed" error with no indication the config file itself was misread.
- Fixed to raise `ConfigurationException` (existing exception type, already the established idiom for this class of config-validation problem elsewhere in the codebase) naming the invalid section and listing valid options when an unrecognized top-level section is encountered.
- There is no "named profiles" concept implemented anywhere in this codebase today — building one would be net-new MINOR capability, out of scope for this patch queue. This fix is the correct PATCH-shaped option: turning a silent misconfiguration into a clear, immediate startup error.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2579 unit tests)
- [x] New tests: unrecognized section (`[profile prod]`) and a case-variant (`[Platform]`) both correctly raise `ConfigurationException`
- [x] Confirmed the recognized section set (`server`, `auth`, `platform`, `tool:<name>`) matches every legitimate section name documented/used anywhere in the repo — no existing workflow broken
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - existing `itential-mcp.conf` still loads/connects correctly, no false-positive rejection
  - a deliberately unrecognized `[profile prod]` section now fails fast with the exact new `ConfigurationException` message instead of silently falling back to `localhost` defaults
  - a constructed `[auth]` section config still loads correctly
  - a live `get_health` tool call confirms normal operation is completely unaffected

PATCH-shaped change: pure fail-fast behavior, no new config options, no new public surface.
