### PR TITLE
fix: remove test-only response attribute mutation incompatible with ipsdk 0.8.0

### DIFF
--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -373,9 +373,6 @@ class TestConfigurationManagerService:
         # Create an HTTPStatusError without a response attribute (edge case)
         http_error = Exception("Network error")
         server_error = ipsdk.exceptions.HTTPStatusError(http_error)
-        # Ensure response attribute doesn't exist or is None
-        if hasattr(server_error, "response"):
-            object.__setattr__(server_error, "response", None)
         mock_client.post.side_effect = server_error
 
         with pytest.raises(exceptions.ServerException) as exc_info:
@@ -609,9 +606,6 @@ class TestConfigurationManagerService:
         # Create an HTTPStatusError without a response attribute (edge case)
         http_error = Exception("Network error")
         server_error = ipsdk.exceptions.HTTPStatusError(http_error)
-        # Ensure response attribute doesn't exist or is None
-        if hasattr(server_error, "response"):
-            object.__setattr__(server_error, "response", None)
         mock_client.post.side_effect = server_error
 
         with pytest.raises(exceptions.ServerException) as exc_info:

--- a/uv.lock
+++ b/uv.lock
@@ -700,14 +700,14 @@ wheels = [
 
 [[package]]
 name = "ipsdk"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/8b/c8b01a0a6d7320d6a7ce5795d0d638168de6446c445475467cc42545e1bc/ipsdk-0.7.0.tar.gz", hash = "sha256:93e4f37dcc70ec74b7e7939069512d0c73c80a25654500c7bb4871312b75d2f6", size = 80409, upload-time = "2025-12-16T23:18:55.074Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/df/7cf57ee93e6d76c631bf52603daa720d8af4f30af90d7e379255612413be/ipsdk-0.8.0.tar.gz", hash = "sha256:c3f39914019500853c93cbd0062c7a9139c0702c0df4d5a6faa310066e4420ae", size = 81487, upload-time = "2026-02-25T15:59:32.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d7/b9091a951267af5943fdb8bf14a6d3a133e104130606c240024352c4beca/ipsdk-0.7.0-py3-none-any.whl", hash = "sha256:ae26e360479d340dea0114adda525b30598750a6f5d4417b25bf48482dd341b6", size = 51424, upload-time = "2025-12-16T23:18:53.896Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1f/8142fd899ff8e831207212f9f6b8deaefb042f3eeb30e21dad72218d16a6/ipsdk-0.8.0-py3-none-any.whl", hash = "sha256:894856a6ba3ecfe05425efb683c0a12d236f01ec65d4c42e4006fcb6378be33b", size = 52283, upload-time = "2026-02-25T15:59:22.573Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `ipsdk` 0.8.0 changes `IpsdkError.request`/`IpsdkError.response` from writable instance attributes to read-only `@property`s that derive from the wrapped `httpx` exception, naturally returning `None` when no response exists.
- Two tests in `tests/test_services_configuration_manager.py` simulated a "no response" scenario via `object.__setattr__(server_error, "response", None)`, which raises `AttributeError` under 0.8.0's read-only property.
- Fixed by removing that block entirely — it was already dead/unnecessary, since the property naturally returns `None` for an exception with no wrapped response.
- No `src/` changes needed: every call site that touches `.response` on an ipsdk exception (`platform/client.py`, `platform/services/configuration_manager.py`) only ever reads it defensively (`hasattr(...) and exc.response is not None`), never writes it.
- `uv.lock` updated to resolve `ipsdk` to `0.8.0`.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2579 unit tests)
- [x] `make tox` — full matrix across Python 3.10/3.11/3.12/3.13, each resolving fresh from `pyproject.toml`, confirms ipsdk 0.8.0 compatibility independent of the lockfile
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - server starts cleanly with ipsdk 0.8.0 confirmed installed
  - a basic `get_health` call works end-to-end
  - a genuine platform HTTP 500 (duplicate golden config tree name) was caught and surfaced cleanly via the exact `.response`-reading code path this fix targets — confirming the read-only property change doesn't break real error handling
  - the specific "no response" edge case confirmed via direct ipsdk 0.8.0 introspection plus the full unit test pass

PATCH-shaped change: test-only fix + dependency lock bump, no production code changes, no new capability.
