### PR TITLE
fix: report itential-mcp's own version in MCP serverInfo.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   typo like `[profile prod]`), which previously discarded the section's
   values with zero warning and let affected settings silently fall back to
   their defaults (#388)
+- Report itential-mcp's own resolved version in the MCP `initialize`
+  handshake's `serverInfo.version` field instead of fastmcp's own package
+  version, which previously happened because `FastMCP()` was instantiated
+  without a `version=` argument (#390)
 
 ## [0.13.2] - 2026-08-03
 

--- a/src/itential_mcp/server/server.py
+++ b/src/itential_mcp/server/server.py
@@ -27,6 +27,7 @@ from ..platform import PlatformClient
 from .. import config
 from .. import bindings
 from ..core import logging
+from ..core import metadata
 from ..utilities import tool as toolutils
 from ..middleware.bindings import BindingsMiddleware
 from ..middleware.serialization import SerializationMiddleware
@@ -149,6 +150,7 @@ class Server:
         # Initialize FastMCP server
         self.mcp = FastMCP(
             name="Itential Platform MCP",
+            version=metadata.version,
             instructions=inspect.cleandoc(INSTRUCTIONS),
             lifespan=lifespan,
             auth=auth_provider,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,8 +6,13 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
+import fastmcp
+from fastmcp import Client
+
+import itential_mcp
 from itential_mcp import server
 from itential_mcp.server import server as server_module
+from itential_mcp.core import metadata
 from itential_mcp.platform import PlatformClient
 from itential_mcp.middleware.bindings import BindingsMiddleware
 
@@ -683,6 +688,7 @@ class TestIntegration:
             # Verify FastMCP was created with correct parameters
             mock_fastmcp_class.assert_called_once_with(
                 name="Itential Platform MCP",
+                version=server_module.metadata.version,
                 instructions=server_module.inspect.cleandoc(server_module.INSTRUCTIONS),
                 lifespan=server_module.lifespan,
                 auth=None,
@@ -1409,3 +1415,75 @@ class TestConnectionTest:
 
         # Verify server did NOT continue to run after failed test
         mock_mcp.run_async.assert_not_called()
+
+
+class TestServerInfoVersion:
+    """Test that the MCP serverInfo.version reports itential-mcp's own
+    resolved version rather than fastmcp's package version.
+
+    Regression coverage for a bug where FastMCP() was instantiated without
+    a version= kwarg, causing it to default to fastmcp.__version__ instead
+    of itential-mcp's own version.
+    """
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    async def test_init_server_sets_fastmcp_version(self, mock_auth_builder):
+        """Test __init_server__ passes itential-mcp's own version to FastMCP"""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        server_instance = server_module.Server(mock_config)
+        await server_instance.__init_server__()
+
+        assert server_instance.mcp.version == metadata.version
+        assert server_instance.mcp.version == itential_mcp.__version__
+        assert server_instance.mcp.version != fastmcp.__version__
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.bindings.iterbindings")
+    @patch("itential_mcp.server.server.toolutils.itertools")
+    async def test_live_client_reports_itential_mcp_version(
+        self, mock_itertools, mock_iterbindings, mock_auth_builder
+    ):
+        """Test that an in-memory FastMCP Client sees itential-mcp's version
+        in the MCP initialize handshake's serverInfo.version field, not
+        fastmcp's own package version.
+        """
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", tools_path=None, log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+        mock_itertools.return_value = []
+
+        async def empty_aiter():
+            return
+            yield  # unreachable but makes this an async generator
+
+        mock_iterbindings.return_value = empty_aiter()
+
+        server_instance = server_module.Server(mock_config)
+
+        async with server_instance:
+            async with Client(server_instance.mcp) as client:
+                server_info = client.initialize_result.serverInfo
+
+                # The fix: serverInfo.version must be itential-mcp's own
+                # resolved version.
+                assert server_info.version == itential_mcp.__version__
+
+                # Regression guard: catch a future refactor that drops the
+                # version= kwarg and silently falls back to fastmcp's own
+                # package version.
+                assert server_info.version != fastmcp.__version__


### PR DESCRIPTION
## Summary
- `Server.__init_server__()` instantiated FastMCP without a `version=` argument, so FastMCP fell back to reporting its own package version (e.g. `3.4.4`) as `serverInfo.version` in the MCP `initialize` handshake, instead of itential-mcp's actual version.
- Fixed by importing the existing internal `core/metadata` module (a leaf module with no circular-import risk, already used elsewhere in the codebase) and passing `version=metadata.version` into the `FastMCP(...)` constructor.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2581 unit tests), 100% coverage on the changed file
- [x] New unit test asserting `server.mcp.version == metadata.version`, distinct from `fastmcp.__version__`
- [x] New live-reproduction-style test using FastMCP's in-memory `Client` to directly assert `serverInfo.version` matches itential-mcp's own version
- [x] Live-tested against a real Itential Platform (`itential-se-poc-dev01.trial.itential.io`):
  - server starts cleanly
  - CLI `itential-mcp version` reports itential-mcp's own version (`0.13.3.dev5+e34abe0`)
  - the real MCP `initialize` handshake's `serverInfo.version` was directly confirmed to now match itential-mcp's version and differ from fastmcp's own version (`3.4.4`)
  - a live `get_health` tool call confirms normal operation is unaffected

PATCH-shaped change: reports correct identifying metadata, no new tools/config/public surface, no behavior change beyond the version string in the MCP handshake.
