### PR TITLE
fix: derive OAuth proxy redirect_path from redirect_uri instead of assuming /auth/callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handshake's `serverInfo.version` field instead of fastmcp's own package
   version, which previously happened because `FastMCP()` was instantiated
   without a `version=` argument (#390)
+- Derive OAuth proxy `base_url`/`redirect_path` from the configured
+  `redirect_uri` using proper URL parsing instead of a
+  `removesuffix("/auth/callback")` heuristic, which previously was a no-op
+  for any redirect URI not literally ending in that path (e.g. `/callback`,
+  `/sso/oauth/return`) and silently produced a callback URL that never
+  matched what was registered with the upstream IdP (#391)
 
 ## [0.13.2] - 2026-08-03
 

--- a/docs/oauth-authentication.md
+++ b/docs/oauth-authentication.md
@@ -266,11 +266,6 @@ ConfigurationException: OAuth proxy authentication requires a token verifier: se
 OAuth providers only support HTTP-based transports (sse, http), not stdio
 ```
 
-**Invalid redirect URI:**
-```
-The redirect URI must end with /auth/callback for automatic base URL derivation
-```
-
 ### Debugging OAuth Issues
 
 1. **Enable debug logging:**

--- a/src/itential_mcp/server/auth.py
+++ b/src/itential_mcp/server/auth.py
@@ -13,6 +13,7 @@ extended with additional providers in the future.
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlsplit
 
 from fastmcp.server.auth import (
     AuthProvider,
@@ -186,7 +187,15 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
 
     token_verifier = _build_jwt_verifier(auth_config)
 
-    base_url = auth_config["redirect_uri"].removesuffix("/auth/callback")
+    # Derive base_url and redirect_path from the configured redirect_uri using
+    # proper URL parsing rather than a suffix-based heuristic. A naive
+    # removesuffix("/auth/callback") is a no-op unless the redirect URI
+    # literally ends in that path, silently folding the entire path into
+    # base_url for any other callback path and producing a callback URL that
+    # never matches what's registered with the upstream IdP.
+    parsed_redirect_uri = urlsplit(auth_config["redirect_uri"])
+    base_url = f"{parsed_redirect_uri.scheme}://{parsed_redirect_uri.netloc}"
+    redirect_path = parsed_redirect_uri.path or "/auth/callback"
 
     oauth_kwargs = {
         "upstream_authorization_endpoint": auth_config["authorization_url"],
@@ -195,6 +204,7 @@ def _build_oauth_proxy_provider(auth_config: dict[str, Any]) -> AuthProvider:
         "upstream_client_secret": auth_config["client_secret"],
         "token_verifier": token_verifier,
         "base_url": base_url,
+        "redirect_path": redirect_path,
     }
 
     # Add optional parameters

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -191,6 +191,7 @@ class TestOAuthProviderBuilding:
             upstream_client_secret="test_secret",
             token_verifier=mock_verifier_instance,
             base_url="http://localhost:8000",
+            redirect_path="/auth/callback",
         )
 
     @patch("itential_mcp.server.auth.OAuthProxy")
@@ -209,6 +210,12 @@ class TestOAuthProviderBuilding:
         eaten as well. Under the old ``rstrip`` behavior this would have
         produced "https://auth-host.example." instead of the correct
         "https://auth-host.example.uk".
+
+        base_url/redirect_path derivation now uses ``urllib.parse.urlsplit``
+        instead of a suffix-stripping heuristic, so this scenario is handled
+        correctly by construction: base_url is always scheme+netloc only and
+        redirect_path is always the parsed path, independent of any
+        character overlap between host and path.
         """
         from itential_mcp.config.converters import auth_to_dict
 
@@ -239,6 +246,137 @@ class TestOAuthProviderBuilding:
             upstream_client_secret="test_secret",
             token_verifier=mock_verifier_instance,
             base_url="https://auth-host.example.uk",
+            redirect_path="/auth/callback",
+        )
+
+    @patch("itential_mcp.server.auth.OAuthProxy")
+    @patch("itential_mcp.server.auth.JWTVerifier")
+    def test_build_oauth_proxy_provider_non_default_redirect_path(
+        self, mock_jwt_verifier, mock_oauth_proxy
+    ):
+        """Redirect URIs at non-``/auth/callback`` paths must derive a
+        matching, non-default ``redirect_path`` instead of silently falling
+        back to ``OAuthProxy``'s default of ``/auth/callback``.
+
+        This is the exact scenario that was previously silently broken: a
+        suffix-based ``removesuffix("/auth/callback")`` was a no-op for any
+        redirect URI not ending in that literal suffix, causing the entire
+        redirect_uri (path included) to be treated as base_url and
+        ``OAuthProxy`` to append its own default ``/auth/callback`` on top,
+        producing a callback URL that never matched what was registered with
+        the upstream IdP.
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="https://example.com/callback",
+                jwks_uri="https://accounts.google.com/.well-known/jwks.json",
+            )
+        )
+
+        mock_verifier_instance = MagicMock()
+        mock_jwt_verifier.return_value = mock_verifier_instance
+
+        mock_provider = MagicMock()
+        mock_oauth_proxy.return_value = mock_provider
+
+        _build_oauth_proxy_provider(auth_config)
+
+        mock_oauth_proxy.assert_called_once_with(
+            upstream_authorization_endpoint="https://accounts.google.com/oauth/authorize",
+            upstream_token_endpoint="https://oauth2.googleapis.com/token",
+            upstream_client_id="test_client",
+            upstream_client_secret="test_secret",
+            token_verifier=mock_verifier_instance,
+            base_url="https://example.com",
+            redirect_path="/callback",
+        )
+
+    @patch("itential_mcp.server.auth.OAuthProxy")
+    @patch("itential_mcp.server.auth.JWTVerifier")
+    def test_build_oauth_proxy_provider_nested_redirect_path(
+        self, mock_jwt_verifier, mock_oauth_proxy
+    ):
+        """A deeply nested, non-default redirect path must be preserved in
+        full as redirect_path, with base_url containing only scheme+netloc.
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="https://example.com/sso/oauth/return",
+                jwks_uri="https://accounts.google.com/.well-known/jwks.json",
+            )
+        )
+
+        mock_verifier_instance = MagicMock()
+        mock_jwt_verifier.return_value = mock_verifier_instance
+
+        mock_provider = MagicMock()
+        mock_oauth_proxy.return_value = mock_provider
+
+        _build_oauth_proxy_provider(auth_config)
+
+        mock_oauth_proxy.assert_called_once_with(
+            upstream_authorization_endpoint="https://accounts.google.com/oauth/authorize",
+            upstream_token_endpoint="https://oauth2.googleapis.com/token",
+            upstream_client_id="test_client",
+            upstream_client_secret="test_secret",
+            token_verifier=mock_verifier_instance,
+            base_url="https://example.com",
+            redirect_path="/sso/oauth/return",
+        )
+
+    @patch("itential_mcp.server.auth.OAuthProxy")
+    @patch("itential_mcp.server.auth.JWTVerifier")
+    def test_build_oauth_proxy_provider_non_default_port_and_path(
+        self, mock_jwt_verifier, mock_oauth_proxy
+    ):
+        """A redirect URI with a non-default port and a non-default callback
+        path must derive a base_url that includes the port and a
+        redirect_path matching the actual configured path.
+        """
+        from itential_mcp.config.converters import auth_to_dict
+
+        auth_config = auth_to_dict(
+            make_auth_config(
+                type="oauth_proxy",
+                oauth_client_id="test_client",
+                oauth_client_secret="test_secret",
+                oauth_authorization_url="https://accounts.google.com/oauth/authorize",
+                oauth_token_url="https://oauth2.googleapis.com/token",
+                oauth_redirect_uri="https://example.com:8443/oauth2/idpresponse",
+                jwks_uri="https://accounts.google.com/.well-known/jwks.json",
+            )
+        )
+
+        mock_verifier_instance = MagicMock()
+        mock_jwt_verifier.return_value = mock_verifier_instance
+
+        mock_provider = MagicMock()
+        mock_oauth_proxy.return_value = mock_provider
+
+        _build_oauth_proxy_provider(auth_config)
+
+        mock_oauth_proxy.assert_called_once_with(
+            upstream_authorization_endpoint="https://accounts.google.com/oauth/authorize",
+            upstream_token_endpoint="https://oauth2.googleapis.com/token",
+            upstream_client_id="test_client",
+            upstream_client_secret="test_secret",
+            token_verifier=mock_verifier_instance,
+            base_url="https://example.com:8443",
+            redirect_path="/oauth2/idpresponse",
         )
 
     def test_build_oauth_proxy_provider_missing_fields(self):


### PR DESCRIPTION
## Summary
- `_build_oauth_proxy_provider` previously derived `base_url` via `redirect_uri.removesuffix("/auth/callback")`, without ever passing fastmcp's dedicated `redirect_path` parameter to `OAuthProxy`.
- `removesuffix` is a silent no-op unless the configured redirect URI literally ends in `/auth/callback`. For any other real-world callback path (e.g. `/callback`, `/sso/oauth/return`), `base_url` would silently become the entire redirect URI including its path, and `OAuthProxy` would then append its own default `/auth/callback` on top — producing a URL that never matches what's registered with the upstream IdP, breaking the OAuth handshake deep in the flow rather than at startup.
- Fixed using `urllib.parse.urlsplit` (stdlib) to correctly split the redirect URI into `base_url` (scheme+netloc) and `redirect_path` (the actual path), passing both explicitly to `OAuthProxy(...)`.
- Removed a stale troubleshooting doc entry (`docs/oauth-authentication.md`) that inaccurately implied this constraint was validated — no such validation ever existed.
- Originally filed in the roadmap as a "design smell," but investigation confirmed this is a genuine, real correctness bug affecting any `oauth_proxy` deployment whose IdP callback path isn't literally `/auth/callback`.

## Test plan
- [x] `make ci` green (format, check, headers, bandit, 2584 unit tests)
- [x] New/updated tests covering previously-broken paths (`/callback`, deeply nested `/sso/oauth/return`, non-default port + path) asserting correct `base_url`/`redirect_path` split
- [x] Verified byte-for-byte identical output for existing configs already ending in `/auth/callback` — no regression
- [x] Live-tested against a real OAuth2 mock IdP (`oauth2-mock-server`):
  - ran a full live authorization-code flow with a non-standard redirect path (`/sso/return`) — completed correctly, no `/callback/auth/callback`-style corruption
  - ran the same full flow with the previously-working `/auth/callback` path — completed identically, confirming no regression
  - directly reproduced the old bug's exact corruption pattern side-by-side with the fix's correct behavior for concrete proof

PATCH-shaped change: pure bugfix, no new public surface, config schema unchanged.
