### PR TITLE
chore: prepare CHANGELOG for v0.13.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-08-05
+
 ### Security
 - Constrain pydantic-settings to >=2.14.2, resolving GHSA-4xgf-cpjx-pc3j
   (medium severity, `NestedSecretsSettingsSource` issue with
@@ -56,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   notes) is still deliberately held at the 46.x line pending evaluation of
   47.x/48.x breaking API changes; not yet re-assessed against the new
   high-severity findings.
-
 ## [0.13.2] - 2026-08-03
 
 ### Security


### PR DESCRIPTION
Moves the completed [Unreleased] section (PRs #383-#391, plus #393 which itself added the missing #389 entry and the dependabot advisory note) into a new `[0.13.3] - 2026-08-05` section per Keep a Changelog convention. [Unreleased] is left empty at the top.

No functional/source changes — CHANGELOG.md only.

Part of cutting the v0.13.3 patch release (all 10 commits in `v0.13.2..devel` confirmed patch-shaped by prior release-manager semver audit).