### PR TITLE
feat: add agent token-usage analytics tools to agent_session_manager

### DIFF
--- a/src/itential_mcp/models/agent_session_manager.py
+++ b/src/itential_mcp/models/agent_session_manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import inspect
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -95,6 +95,9 @@ class SessionElement(BaseModel):
         started_at: ISO 8601 start timestamp.
         end_time: ISO 8601 end timestamp (None if still running).
         duration_ms: Total session duration in milliseconds.
+        total_input_tokens: Total input (prompt) tokens consumed by the session.
+        total_output_tokens: Total output (completion) tokens produced by the
+            session.
     """
 
     session_id: Annotated[
@@ -162,6 +165,32 @@ class SessionElement(BaseModel):
             description=inspect.cleandoc(
                 """
                 Total session duration in milliseconds
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    total_input_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total input (prompt) tokens consumed by the session; None if
+                not reported by the platform
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    total_output_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total output (completion) tokens produced by the session;
+                None if not reported by the platform
                 """
             ),
             default=None,
@@ -304,6 +333,651 @@ class DescribeSessionResponse(BaseModel):
             description=inspect.cleandoc(
                 """
                 Ordered list of session event messages captured during agent execution
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+
+class AgentTokenUsageStats(BaseModel):
+    """
+    Aggregated token usage statistics for a single agent.
+
+    Summarizes token consumption across all agent sessions grouped by agent
+    name, including totals, averages, and min/max values for both input and
+    output tokens. Sessions with missing token data are still counted toward
+    session_count but contribute 0 to the token sums, averages, and min/max
+    calculations.
+
+    Attributes:
+        agent_name: Agent display name; None if the underlying sessions had
+            no agentSnapshot.name.
+        session_count: Number of sessions included in this group.
+        total_input_tokens: Sum of input tokens across all sessions in the group.
+        total_output_tokens: Sum of output tokens across all sessions in the group.
+        total_tokens: Sum of total_input_tokens and total_output_tokens.
+        avg_input_tokens: Average input tokens per session in the group.
+        min_input_tokens: Minimum input tokens across sessions in the group.
+        max_input_tokens: Maximum input tokens across sessions in the group.
+        avg_output_tokens: Average output tokens per session in the group.
+        min_output_tokens: Minimum output tokens across sessions in the group.
+        max_output_tokens: Maximum output tokens across sessions in the group.
+        total_duration_ms: Sum of session durations across the group.
+        avg_duration_ms: Average session duration in the group.
+        min_duration_ms: Minimum session duration in the group.
+        max_duration_ms: Maximum session duration in the group.
+    """
+
+    agent_name: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Agent display name; None if the underlying sessions had no
+                agentSnapshot.name
+                """
+            )
+        ),
+    ]
+
+    session_count: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of sessions included in this group
+                """
+            )
+        ),
+    ]
+
+    total_input_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of input tokens across all sessions in the group; missing
+                or null values are treated as 0
+                """
+            )
+        ),
+    ]
+
+    total_output_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of output tokens across all sessions in the group; missing
+                or null values are treated as 0
+                """
+            )
+        ),
+    ]
+
+    total_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of total_input_tokens and total_output_tokens
+                """
+            )
+        ),
+    ]
+
+    avg_input_tokens: Annotated[
+        float,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Average input tokens per session in the group
+                """
+            )
+        ),
+    ]
+
+    min_input_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Minimum input tokens across sessions in the group
+                """
+            )
+        ),
+    ]
+
+    max_input_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Maximum input tokens across sessions in the group
+                """
+            )
+        ),
+    ]
+
+    avg_output_tokens: Annotated[
+        float,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Average output tokens per session in the group
+                """
+            )
+        ),
+    ]
+
+    min_output_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Minimum output tokens across sessions in the group
+                """
+            )
+        ),
+    ]
+
+    max_output_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Maximum output tokens across sessions in the group
+                """
+            )
+        ),
+    ]
+
+    total_duration_ms: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of session durations across the group; missing or null
+                values are treated as 0
+                """
+            )
+        ),
+    ]
+
+    avg_duration_ms: Annotated[
+        float,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Average session duration in milliseconds across the group
+                """
+            )
+        ),
+    ]
+
+    min_duration_ms: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Minimum session duration in milliseconds across the group
+                """
+            )
+        ),
+    ]
+
+    max_duration_ms: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Maximum session duration in milliseconds across the group
+                """
+            )
+        ),
+    ]
+
+
+class GetAgentTokenUsageResponse(RootModel):
+    """
+    Response model for the agent token usage aggregation endpoint.
+
+    Wraps a list of AgentTokenUsageStats objects, one per distinct agent name
+    (including a None-keyed entry for sessions with no agent name), sorted by
+    total_tokens descending.
+
+    Attributes:
+        root: List of AgentTokenUsageStats objects with aggregated token
+            usage metrics per agent.
+    """
+
+    root: Annotated[
+        list[AgentTokenUsageStats],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of per-agent token usage aggregation objects, sorted by
+                total_tokens descending
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+
+class AgentSessionTokenUsageElement(BaseModel):
+    """
+    Represents per-session token usage for a single agent session.
+
+    Provides a time-series-friendly, non-aggregated view of one session's
+    token consumption and timing, for use alongside get_agent_token_usage's
+    aggregate statistics.
+
+    Attributes:
+        session_id: Unique session identifier.
+        status: Session status (RUNNING, COMPLETE, FAILED).
+        started_at: ISO 8601 start timestamp.
+        end_time: ISO 8601 end timestamp (None if still running).
+        duration_ms: Total session duration in milliseconds.
+        total_input_tokens: Total input (prompt) tokens consumed.
+        total_output_tokens: Total output (completion) tokens produced.
+        total_tokens: Sum of total_input_tokens and total_output_tokens.
+    """
+
+    session_id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique session identifier
+                """
+            )
+        ),
+    ]
+
+    status: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Session status (RUNNING, COMPLETE, FAILED)
+                """
+            )
+        ),
+    ]
+
+    started_at: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 start timestamp
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    end_time: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 end timestamp; None if the session is still RUNNING
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    duration_ms: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total session duration in milliseconds
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    total_input_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total input (prompt) tokens consumed by the session; None if
+                not reported by the platform
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    total_output_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total output (completion) tokens produced by the session;
+                None if not reported by the platform
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    total_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of total_input_tokens and total_output_tokens; missing or
+                null values are treated as 0
+                """
+            )
+        ),
+    ]
+
+
+class GetAgentSessionTokenUsageResponse(RootModel):
+    """
+    Response model for the per-session agent token usage endpoint.
+
+    Wraps a list of AgentSessionTokenUsageElement objects for a single agent,
+    sorted by started_at ascending.
+
+    Attributes:
+        root: List of AgentSessionTokenUsageElement objects with per-session
+            token usage and timing metadata.
+    """
+
+    root: Annotated[
+        list[AgentSessionTokenUsageElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of per-session token usage objects for a single agent,
+                sorted by started_at ascending
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+
+class SessionTurnTokenUsage(BaseModel):
+    """
+    Token usage figures for a single agent inference turn.
+
+    tokenUsage's exact field names are unconfirmed against a live platform
+    (no schema exists in the swagger beyond a prose mention), so this model
+    is populated defensively via candidate-key extraction with a raw dict
+    passthrough as a safety net.
+
+    Attributes:
+        input_tokens: Input (prompt) tokens for the turn, if present under
+            any recognized key.
+        output_tokens: Output (completion) tokens for the turn, if present
+            under any recognized key.
+        total_tokens: Total tokens for the turn, if present under any
+            recognized key, else derived from input_tokens + output_tokens.
+        raw: The untouched original tokenUsage dict, for cases where the
+            real key names differ from the recognized candidates.
+    """
+
+    input_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Input (prompt) tokens for this turn; None if not present
+                under any recognized key
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    output_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Output (completion) tokens for this turn; None if not
+                present under any recognized key
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    total_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Total tokens for this turn; None if not present under any
+                recognized key and not derivable from input/output tokens
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    raw: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Untouched original tokenUsage dict; safety net if the real
+                platform key names differ from the recognized candidates
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+
+class SessionTurnUsageElement(BaseModel):
+    """
+    Represents a single inference turn (succeeded or failed) within a session.
+
+    Attributes:
+        sequence_number: Ordering number for the turn within the session.
+        timestamp: ISO 8601 timestamp when the turn was emitted.
+        event_type: Turn outcome, "succeeded" or "failed".
+        duration_ms: Duration of the inference call in milliseconds.
+        token_usage: Token usage for succeeded turns; None for failed turns.
+        error: Error text for failed turns; None for succeeded turns.
+    """
+
+    sequence_number: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Ordering number for this turn within the session
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    timestamp: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO 8601 timestamp when this turn was emitted
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    event_type: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Turn outcome, "succeeded" or "failed"
+                """
+            )
+        ),
+    ]
+
+    duration_ms: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Duration of the inference call in milliseconds
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    token_usage: Annotated[
+        SessionTurnTokenUsage | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Token usage for succeeded turns; None for failed turns
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    error: Annotated[
+        str | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Error text for failed turns; None for succeeded turns
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+
+class SessionTurnUsageSummary(BaseModel):
+    """
+    Aggregated summary across all inference turns in a session.
+
+    Attributes:
+        session_id: Unique session identifier.
+        turn_count: Number of inference turns (succeeded and failed).
+        total_duration_ms: Sum of turn durations; missing treated as 0.
+        total_input_tokens: Sum of input tokens across succeeded turns;
+            missing treated as 0.
+        total_output_tokens: Sum of output tokens across succeeded turns;
+            missing treated as 0.
+        total_tokens: Sum of total_input_tokens and total_output_tokens.
+    """
+
+    session_id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique session identifier
+                """
+            )
+        ),
+    ]
+
+    turn_count: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of inference turns (succeeded and failed) in the
+                session
+                """
+            )
+        ),
+    ]
+
+    total_duration_ms: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of turn durations in milliseconds; missing or null
+                values are treated as 0
+                """
+            )
+        ),
+    ]
+
+    total_input_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of input tokens across succeeded turns; missing or null
+                values are treated as 0
+                """
+            )
+        ),
+    ]
+
+    total_output_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of output tokens across succeeded turns; missing or null
+                values are treated as 0
+                """
+            )
+        ),
+    ]
+
+    total_tokens: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Sum of total_input_tokens and total_output_tokens
+                """
+            )
+        ),
+    ]
+
+
+class DescribeSessionTokenUsageResponse(BaseModel):
+    """
+    Response model for the per-turn session token usage breakdown endpoint.
+
+    Attributes:
+        summary: Aggregated totals across all inference turns in the session.
+        turns: Ordered list of per-turn usage details.
+    """
+
+    summary: Annotated[
+        SessionTurnUsageSummary,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Aggregated totals across all inference turns in the session
+                """
+            )
+        ),
+    ]
+
+    turns: Annotated[
+        list[SessionTurnUsageElement],
+        Field(
+            description=inspect.cleandoc(
+                """
+                Ordered list of per-turn usage details
                 """
             ),
             default_factory=list,

--- a/src/itential_mcp/models/agent_session_manager.py
+++ b/src/itential_mcp/models/agent_session_manager.py
@@ -712,16 +712,18 @@ class SessionTurnTokenUsage(BaseModel):
     """
     Token usage figures for a single agent inference turn.
 
-    tokenUsage's exact field names are unconfirmed against a live platform
-    (no schema exists in the swagger beyond a prose mention), so this model
-    is populated defensively via candidate-key extraction with a raw dict
-    passthrough as a safety net.
+    Confirmed live against a real inference-succeeded event: the platform's
+    tokenUsage keys are inputTokens, outputTokens, cacheReadTokens, and
+    cacheCreationTokens. Extraction still checks a couple of alternate key
+    spellings defensively, with a raw dict passthrough as a safety net in
+    case a different provider/model uses different names.
 
     Attributes:
-        input_tokens: Input (prompt) tokens for the turn, if present under
-            any recognized key.
-        output_tokens: Output (completion) tokens for the turn, if present
-            under any recognized key.
+        input_tokens: Input (prompt) tokens for the turn.
+        output_tokens: Output (completion) tokens for the turn.
+        cache_read_tokens: Tokens served from prompt cache (cheaper than
+            fresh input tokens).
+        cache_creation_tokens: Tokens written to prompt cache on this turn.
         total_tokens: Total tokens for the turn, if present under any
             recognized key, else derived from input_tokens + output_tokens.
         raw: The untouched original tokenUsage dict, for cases where the
@@ -748,6 +750,32 @@ class SessionTurnTokenUsage(BaseModel):
                 """
                 Output (completion) tokens for this turn; None if not
                 present under any recognized key
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    cache_read_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Tokens served from prompt cache on this turn; None if not
+                reported
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+    cache_creation_tokens: Annotated[
+        int | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Tokens written to prompt cache on this turn; None if not
+                reported
                 """
             ),
             default=None,

--- a/src/itential_mcp/platform/services/agent_session_manager.py
+++ b/src/itential_mcp/platform/services/agent_session_manager.py
@@ -41,7 +41,8 @@ class Service(ServiceBase):
         Returns:
             list[dict]: A list of dictionaries containing session data with
                 normalized field names: session_id, agent_name, status,
-                started_at, end_time, duration_ms.
+                started_at, end_time, duration_ms, total_input_tokens,
+                total_output_tokens.
 
         Raises:
             Exception: If there is an error communicating with the Itential
@@ -74,6 +75,8 @@ class Service(ServiceBase):
                         "started_at": item.get("startedAt"),
                         "end_time": item.get("endTime"),
                         "duration_ms": item.get("durationMs"),
+                        "total_input_tokens": item.get("totalInputTokens"),
+                        "total_output_tokens": item.get("totalOutputTokens"),
                     }
                 )
 

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -240,6 +240,8 @@ async def get_sessions(
             started_at=started_at,
             end_time=end_time,
             duration_ms=item.get("duration_ms"),
+            total_input_tokens=item.get("total_input_tokens"),
+            total_output_tokens=item.get("total_output_tokens"),
         )
         session_elements.append(session_element)
 
@@ -559,6 +561,14 @@ async def get_agent_session_token_usage(
         - agent_name filtering here is a substring match; the underlying
           service call is made without a filter so that all sessions are
           fetched first.
+        - total_input_tokens/total_output_tokens are the platform's own
+          session-level totals, not a sum of describe_session_token_usage's
+          per-turn figures — the two can diverge substantially (observed up
+          to ~12x on multi-turn sessions), likely due to growing
+          conversation-context tokens being counted per turn on the platform
+          side. Don't expect them to reconcile; use this tool for
+          session-to-session comparison and describe_session_token_usage for
+          turn-level detail within one session.
     """
     await ctx.debug("inside get_agent_session_token_usage(...)")
 
@@ -638,6 +648,11 @@ async def describe_session_token_usage(
     Notes:
         - A session with zero inference turns returns a zeroed summary and
           an empty turns list, not an error.
+        - summary.total_tokens is a sum of each turn's own reported figures
+          and can diverge substantially from the session-level total
+          reported by get_agent_session_token_usage/get_sessions (observed
+          up to ~12x on multi-turn sessions) — the two are not expected to
+          reconcile. Use this tool for turn-level detail within one session.
     """
     await ctx.debug("inside describe_session_token_usage(...)")
 
@@ -664,10 +679,9 @@ async def describe_session_token_usage(
             token_usage = _extract_token_usage(data.get("tokenUsage") or {})
         else:
             # The swagger's data object for inference-failed events only
-            # documents durationMs (no errorMessage) — the error is assumed
-            # to be in the message's text field per its "text content or
-            # error message" description. Confirm against a live
-            # inference-failed event before merge.
+            # documents durationMs (no errorMessage); confirmed live against
+            # 3 real inference-failed events that the error text lands in
+            # the message's own text field instead.
             error = raw.get("text")
 
         turns.append(

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -94,9 +94,11 @@ def _extract_token_usage(raw: dict) -> models.SessionTurnTokenUsage | None:
     """
     Extract token usage figures from a raw inference-succeeded tokenUsage dict.
 
-    # tokenUsage key names are inferred from the swagger's prose description
-    # only — no schema exists. Confirm actual key names against a live
-    # inference-succeeded event before merge.
+    Confirmed live against a real inference-succeeded event: the platform
+    uses inputTokens/outputTokens/cacheReadTokens/cacheCreationTokens. A few
+    alternate key spellings are still checked defensively in case a
+    different provider/model reports differently; raw is always kept as a
+    passthrough safety net.
 
     Args:
         raw (dict): The raw tokenUsage dict from a session message's
@@ -126,6 +128,18 @@ def _extract_token_usage(raw: dict) -> models.SessionTurnTokenUsage | None:
             output_tokens = raw[key]
             break
 
+    cache_read_tokens = None
+    for key in ("cacheReadTokens", "cache_read_tokens"):
+        if key in raw:
+            cache_read_tokens = raw[key]
+            break
+
+    cache_creation_tokens = None
+    for key in ("cacheCreationTokens", "cache_creation_tokens"):
+        if key in raw:
+            cache_creation_tokens = raw[key]
+            break
+
     total_tokens = None
     for key in ("totalTokens", "total_tokens"):
         if key in raw:
@@ -137,6 +151,8 @@ def _extract_token_usage(raw: dict) -> models.SessionTurnTokenUsage | None:
     return models.SessionTurnTokenUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
         total_tokens=total_tokens,
         raw=raw,
     )
@@ -620,8 +636,6 @@ async def describe_session_token_usage(
             uncaught.
 
     Notes:
-        - tokenUsage field names are unconfirmed against a live platform;
-          see _extract_token_usage for the candidate-key extraction logic.
         - A session with zero inference turns returns a zeroed summary and
           an empty turns list, not an error.
     """

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -6,17 +6,163 @@ from __future__ import annotations
 
 import asyncio
 
+from datetime import datetime
 from typing import Annotated
 
 from pydantic import Field
 
 from fastmcp import Context
 
+from itential_mcp.core.exceptions import ValidationException
 from itential_mcp.utilities import time as timeutils
 from itential_mcp.models import agent_session_manager as models
 
 
 __tags__ = ("agent_session_manager",)
+
+
+def _filter_sessions(
+    sessions: list[dict],
+    *,
+    agent_name: str | None,
+    include_failed: bool,
+    after_dt: datetime | None,
+    before_dt: datetime | None,
+) -> list[dict]:
+    """
+    Filter session dicts by agent name, status, and started_at window.
+
+    Args:
+        sessions (list[dict]): Normalized session dicts as returned by
+            client.agent_session_manager.get_sessions.
+        agent_name (str | None): Filter to agent names containing this
+            substring (case-insensitive). When None, no name filtering is
+            applied.
+        include_failed (bool): Also allow FAILED sessions alongside
+            COMPLETE ones.
+        after_dt (datetime | None): When provided, only sessions started at
+            or after this time are kept.
+        before_dt (datetime | None): When provided, only sessions started at
+            or before this time are kept.
+
+    Returns:
+        list[dict]: The subset of sessions matching all provided filters.
+
+    Raises:
+        ValidationException: If a session's started_at value is not a valid
+            ISO 8601 timestamp.
+    """
+    filtered = []
+    for item in sessions:
+        item_agent_name = item.get("agent_name")
+
+        if agent_name is not None:
+            if item_agent_name is None:
+                continue
+            if agent_name.lower() not in item_agent_name.lower():
+                continue
+
+        item_status = item.get("status")
+        allowed_statuses = ("COMPLETE", "FAILED") if include_failed else ("COMPLETE",)
+        if item_status not in allowed_statuses:
+            continue
+
+        if after_dt is not None or before_dt is not None:
+            raw_started_at = item.get("started_at")
+            if isinstance(raw_started_at, int):
+                started_at_dt = _parse_timestamp(
+                    timeutils.epoch_to_timestamp(raw_started_at)
+                )
+            elif raw_started_at is not None:
+                started_at_dt = _parse_timestamp(raw_started_at)
+            else:
+                started_at_dt = None
+
+            if started_at_dt is None:
+                continue
+            if after_dt is not None and started_at_dt < after_dt:
+                continue
+            if before_dt is not None and started_at_dt > before_dt:
+                continue
+
+        filtered.append(item)
+
+    return filtered
+
+
+def _extract_token_usage(raw: dict) -> models.SessionTurnTokenUsage | None:
+    """
+    Extract token usage figures from a raw inference-succeeded tokenUsage dict.
+
+    # tokenUsage key names are inferred from the swagger's prose description
+    # only — no schema exists. Confirm actual key names against a live
+    # inference-succeeded event before merge.
+
+    Args:
+        raw (dict): The raw tokenUsage dict from a session message's
+            data field.
+
+    Returns:
+        models.SessionTurnTokenUsage | None: The extracted token usage, or
+            None if raw is falsy.
+    """
+    if not raw:
+        return None
+
+    input_tokens = None
+    for key in ("inputTokens", "input_tokens", "promptTokens", "prompt_tokens"):
+        if key in raw:
+            input_tokens = raw[key]
+            break
+
+    output_tokens = None
+    for key in (
+        "outputTokens",
+        "output_tokens",
+        "completionTokens",
+        "completion_tokens",
+    ):
+        if key in raw:
+            output_tokens = raw[key]
+            break
+
+    total_tokens = None
+    for key in ("totalTokens", "total_tokens"):
+        if key in raw:
+            total_tokens = raw[key]
+            break
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+
+    return models.SessionTurnTokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        raw=raw,
+    )
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """
+    Parse an ISO 8601 / RFC3339 timestamp string into a timezone-aware datetime.
+
+    Accepts a trailing "Z" designator (converted to "+00:00" for compatibility
+    with datetime.fromisoformat).
+
+    Args:
+        value (str): The timestamp string to parse.
+
+    Returns:
+        datetime: The parsed timezone-aware datetime object.
+
+    Raises:
+        ValidationException: If the value is not a valid ISO 8601 timestamp.
+    """
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValidationException(f"Invalid ISO 8601 timestamp: {value!r}") from exc
 
 
 async def get_sessions(
@@ -166,3 +312,376 @@ async def describe_session(
         duration_ms=session.get("durationMs"),
         messages=messages,
     )
+
+
+async def get_agent_token_usage(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    agent_name: Annotated[
+        str | None,
+        Field(
+            description="Filter to agent names containing this substring (case-insensitive)",
+            default=None,
+        ),
+    ],
+    include_failed: Annotated[
+        bool,
+        Field(
+            description=(
+                "By default only COMPLETE sessions count toward usage "
+                "(finished, billable work). Set true to also include FAILED "
+                "sessions, which can still have consumed real tokens. "
+                "Non-terminal statuses (PENDING, RUNNING, PAUSED, ...) are "
+                "always excluded either way, since their totals aren't final."
+            ),
+            default=False,
+        ),
+    ],
+    started_after: Annotated[
+        str | None,
+        Field(
+            description=(
+                "ISO 8601 timestamp — only include sessions started at or "
+                "after this time"
+            ),
+            default=None,
+        ),
+    ],
+    started_before: Annotated[
+        str | None,
+        Field(
+            description=(
+                "ISO 8601 timestamp — only include sessions started at or "
+                "before this time"
+            ),
+            default=None,
+        ),
+    ],
+) -> models.GetAgentTokenUsageResponse:
+    """
+    Aggregate agent session token usage grouped by agent name.
+
+    Fetches agent sessions and groups them by agent name, computing token
+    consumption statistics (sum, average, min, max) for both input and output
+    tokens per agent. Sessions with missing or null token values are still
+    counted toward session_count but contribute 0 to sum, average, and
+    min/max calculations. Sessions with no agent name are grouped under a
+    None-keyed entry rather than dropped. Only COMPLETE sessions are included
+    by default — see include_failed to also include FAILED sessions.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        agent_name (str | None): Filter to agent names containing this
+            substring (case-insensitive). When omitted, all agents are
+            included.
+        include_failed (bool): Also include FAILED sessions alongside
+            COMPLETE ones. See parameter description for the default
+            rationale.
+        started_after (str | None): ISO 8601 timestamp. When provided, only
+            sessions started at or after this time are included.
+        started_before (str | None): ISO 8601 timestamp. When provided, only
+            sessions started at or before this time are included.
+
+    Returns:
+        models.GetAgentTokenUsageResponse: List of per-agent token usage
+            aggregation objects, sorted by total_tokens descending. Each
+            entry has the following fields:
+            - agent_name: Agent display name (None if sessions had no name)
+            - session_count: Number of sessions in the group
+            - total_input_tokens: Sum of input tokens (missing treated as 0)
+            - total_output_tokens: Sum of output tokens (missing treated as 0)
+            - total_tokens: total_input_tokens + total_output_tokens
+            - avg_input_tokens, min_input_tokens, max_input_tokens
+            - avg_output_tokens, min_output_tokens, max_output_tokens
+            - total_duration_ms, avg_duration_ms, min_duration_ms, max_duration_ms
+
+    Raises:
+        ValidationException: If started_after, started_before, or a
+            session's started_at value is not a valid ISO 8601 timestamp.
+
+    Notes:
+        - The underlying session fetch is unbounded — all pages are
+          retrieved before filtering and aggregation.
+        - agent_name filtering here is a substring match; the underlying
+          service call is made without a filter so that all sessions are
+          fetched first.
+    """
+    await ctx.debug("inside get_agent_token_usage(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    data = await client.agent_session_manager.get_sessions(None)
+
+    after_dt = _parse_timestamp(started_after) if started_after is not None else None
+    before_dt = _parse_timestamp(started_before) if started_before is not None else None
+
+    filtered = _filter_sessions(
+        data,
+        agent_name=agent_name,
+        include_failed=include_failed,
+        after_dt=after_dt,
+        before_dt=before_dt,
+    )
+
+    groups: dict[str | None, list[dict]] = {}
+    for item in filtered:
+        groups.setdefault(item.get("agent_name"), []).append(item)
+
+    stats = []
+    for group_agent_name, sessions in groups.items():
+        input_tokens = [s.get("total_input_tokens") or 0 for s in sessions]
+        output_tokens = [s.get("total_output_tokens") or 0 for s in sessions]
+        durations = [s.get("duration_ms") or 0 for s in sessions]
+
+        total_input = sum(input_tokens)
+        total_output = sum(output_tokens)
+        total_duration = sum(durations)
+        session_count = len(sessions)
+
+        stats.append(
+            models.AgentTokenUsageStats(
+                agent_name=group_agent_name,
+                session_count=session_count,
+                total_input_tokens=total_input,
+                total_output_tokens=total_output,
+                total_tokens=total_input + total_output,
+                avg_input_tokens=total_input / session_count,
+                min_input_tokens=min(input_tokens),
+                max_input_tokens=max(input_tokens),
+                avg_output_tokens=total_output / session_count,
+                min_output_tokens=min(output_tokens),
+                max_output_tokens=max(output_tokens),
+                total_duration_ms=total_duration,
+                avg_duration_ms=total_duration / session_count,
+                min_duration_ms=min(durations),
+                max_duration_ms=max(durations),
+            )
+        )
+
+    stats.sort(key=lambda s: s.total_tokens, reverse=True)
+
+    return models.GetAgentTokenUsageResponse(root=stats)
+
+
+async def get_agent_session_token_usage(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    agent_name: Annotated[
+        str,
+        Field(
+            description="Filter to agent names containing this substring (case-insensitive)"
+        ),
+    ],
+    include_failed: Annotated[
+        bool,
+        Field(
+            description=(
+                "By default only COMPLETE sessions count toward usage "
+                "(finished, billable work). Set true to also include FAILED "
+                "sessions, which can still have consumed real tokens. "
+                "Non-terminal statuses (PENDING, RUNNING, PAUSED, ...) are "
+                "always excluded either way, since their totals aren't final."
+            ),
+            default=False,
+        ),
+    ],
+    started_after: Annotated[
+        str | None,
+        Field(
+            description=(
+                "ISO 8601 timestamp — only include sessions started at or "
+                "after this time"
+            ),
+            default=None,
+        ),
+    ],
+    started_before: Annotated[
+        str | None,
+        Field(
+            description=(
+                "ISO 8601 timestamp — only include sessions started at or "
+                "before this time"
+            ),
+            default=None,
+        ),
+    ],
+) -> models.GetAgentSessionTokenUsageResponse:
+    """
+    List per-session token usage for a single agent, sorted chronologically.
+
+    Fetches agent sessions filtered to the given agent name and returns one
+    row per matching session (no aggregation), useful for time-series
+    inspection of an agent's usage. Only COMPLETE sessions are included by
+    default — see include_failed to also include FAILED sessions.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        agent_name (str): Filter to agent names containing this substring
+            (case-insensitive). Required — this tool is single-agent scoped.
+        include_failed (bool): Also include FAILED sessions alongside
+            COMPLETE ones. See parameter description for the default
+            rationale.
+        started_after (str | None): ISO 8601 timestamp. When provided, only
+            sessions started at or after this time are included.
+        started_before (str | None): ISO 8601 timestamp. When provided, only
+            sessions started at or before this time are included.
+
+    Returns:
+        models.GetAgentSessionTokenUsageResponse: List of per-session token
+            usage objects, sorted by started_at ascending (sessions with no
+            started_at sort last). Each entry has the following fields:
+            - session_id, status, started_at, end_time, duration_ms
+            - total_input_tokens, total_output_tokens
+            - total_tokens: total_input_tokens + total_output_tokens
+              (missing treated as 0)
+
+    Raises:
+        ValidationException: If started_after, started_before, or a
+            session's started_at value is not a valid ISO 8601 timestamp.
+
+    Notes:
+        - The underlying session fetch is unbounded — all pages are
+          retrieved before filtering.
+        - agent_name filtering here is a substring match; the underlying
+          service call is made without a filter so that all sessions are
+          fetched first.
+    """
+    await ctx.debug("inside get_agent_session_token_usage(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    data = await client.agent_session_manager.get_sessions(None)
+
+    after_dt = _parse_timestamp(started_after) if started_after is not None else None
+    before_dt = _parse_timestamp(started_before) if started_before is not None else None
+
+    filtered = _filter_sessions(
+        data,
+        agent_name=agent_name,
+        include_failed=include_failed,
+        after_dt=after_dt,
+        before_dt=before_dt,
+    )
+
+    elements = []
+    for item in filtered:
+        input_tokens = item.get("total_input_tokens")
+        output_tokens = item.get("total_output_tokens")
+
+        elements.append(
+            models.AgentSessionTokenUsageElement(
+                session_id=item["session_id"],
+                status=item["status"],
+                started_at=item.get("started_at"),
+                end_time=item.get("end_time"),
+                duration_ms=item.get("duration_ms"),
+                total_input_tokens=input_tokens,
+                total_output_tokens=output_tokens,
+                total_tokens=(input_tokens or 0) + (output_tokens or 0),
+            )
+        )
+
+    elements.sort(key=lambda e: (e.started_at is None, e.started_at))
+
+    return models.GetAgentSessionTokenUsageResponse(root=elements)
+
+
+async def describe_session_token_usage(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    session_id: Annotated[
+        str,
+        Field(description="The session ID to break down per inference turn"),
+    ],
+) -> models.DescribeSessionTokenUsageResponse:
+    """
+    Break down a single agent session's token usage per inference turn.
+
+    Fetches the session's raw event messages and filters to inference turns
+    (inference-succeeded, inference-failed), returning one entry per turn
+    along with an aggregated summary. Non-inference events (tool calls,
+    status transitions) are excluded from the breakdown.
+
+    Args:
+        ctx (Context): The FastMCP Context object.
+        session_id (str): The session ID to break down per inference turn.
+
+    Returns:
+        models.DescribeSessionTokenUsageResponse: Summary and per-turn
+            breakdown with the following fields:
+            - summary.session_id, summary.turn_count
+            - summary.total_duration_ms, summary.total_input_tokens,
+              summary.total_output_tokens, summary.total_tokens (all
+              missing values treated as 0)
+            - turns[].sequence_number, turns[].timestamp,
+              turns[].event_type ("succeeded" or "failed"),
+              turns[].duration_ms, turns[].token_usage (succeeded only),
+              turns[].error (failed only)
+
+    Raises:
+        Exception: Service-layer errors from get_session_messages propagate
+            uncaught.
+
+    Notes:
+        - tokenUsage field names are unconfirmed against a live platform;
+          see _extract_token_usage for the candidate-key extraction logic.
+        - A session with zero inference turns returns a zeroed summary and
+          an empty turns list, not an error.
+    """
+    await ctx.debug("inside describe_session_token_usage(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    raw_messages = await client.agent_session_manager.get_session_messages(session_id)
+
+    turns = []
+    for raw in raw_messages:
+        raw_type = raw.get("type")
+        if raw_type not in ("inference-succeeded", "inference-failed"):
+            continue
+
+        timestamp = raw.get("timestamp")
+        if isinstance(timestamp, int):
+            timestamp = timeutils.epoch_to_timestamp(timestamp)
+
+        data = raw.get("data") or {}
+        event_type = raw_type.removeprefix("inference-")
+
+        token_usage = None
+        error = None
+        if raw_type == "inference-succeeded":
+            token_usage = _extract_token_usage(data.get("tokenUsage") or {})
+        else:
+            # The swagger's data object for inference-failed events only
+            # documents durationMs (no errorMessage) — the error is assumed
+            # to be in the message's text field per its "text content or
+            # error message" description. Confirm against a live
+            # inference-failed event before merge.
+            error = raw.get("text")
+
+        turns.append(
+            models.SessionTurnUsageElement(
+                sequence_number=raw.get("sequenceNumber"),
+                timestamp=timestamp,
+                event_type=event_type,
+                duration_ms=data.get("durationMs"),
+                token_usage=token_usage,
+                error=error,
+            )
+        )
+
+    total_duration = sum(t.duration_ms or 0 for t in turns)
+    total_input = sum(
+        (t.token_usage.input_tokens or 0) if t.token_usage else 0 for t in turns
+    )
+    total_output = sum(
+        (t.token_usage.output_tokens or 0) if t.token_usage else 0 for t in turns
+    )
+
+    summary = models.SessionTurnUsageSummary(
+        session_id=session_id,
+        turn_count=len(turns),
+        total_duration_ms=total_duration,
+        total_input_tokens=total_input,
+        total_output_tokens=total_output,
+        total_tokens=total_input + total_output,
+    )
+
+    return models.DescribeSessionTokenUsageResponse(summary=summary, turns=turns)

--- a/tests/test_models_agent_session_manager.py
+++ b/tests/test_models_agent_session_manager.py
@@ -516,12 +516,16 @@ class TestSessionTurnTokenUsage:
         usage = SessionTurnTokenUsage(
             input_tokens=100,
             output_tokens=50,
+            cache_read_tokens=20,
+            cache_creation_tokens=5,
             total_tokens=150,
             raw={"inputTokens": 100, "outputTokens": 50},
         )
 
         assert usage.input_tokens == 100
         assert usage.output_tokens == 50
+        assert usage.cache_read_tokens == 20
+        assert usage.cache_creation_tokens == 5
         assert usage.total_tokens == 150
         assert usage.raw == {"inputTokens": 100, "outputTokens": 50}
 
@@ -531,6 +535,8 @@ class TestSessionTurnTokenUsage:
 
         assert usage.input_tokens is None
         assert usage.output_tokens is None
+        assert usage.cache_read_tokens is None
+        assert usage.cache_creation_tokens is None
         assert usage.total_tokens is None
         assert usage.raw is None
 

--- a/tests/test_models_agent_session_manager.py
+++ b/tests/test_models_agent_session_manager.py
@@ -10,6 +10,14 @@ from itential_mcp.models.agent_session_manager import (
     SessionElement,
     GetSessionsResponse,
     DescribeSessionResponse,
+    AgentTokenUsageStats,
+    GetAgentTokenUsageResponse,
+    AgentSessionTokenUsageElement,
+    GetAgentSessionTokenUsageResponse,
+    SessionTurnTokenUsage,
+    SessionTurnUsageElement,
+    SessionTurnUsageSummary,
+    DescribeSessionTokenUsageResponse,
 )
 
 
@@ -82,6 +90,8 @@ class TestSessionElement:
         assert element.started_at is None
         assert element.end_time is None
         assert element.duration_ms is None
+        assert element.total_input_tokens is None
+        assert element.total_output_tokens is None
 
     def test_session_element_all_fields(self):
         """Test SessionElement creation with all fields"""
@@ -92,6 +102,8 @@ class TestSessionElement:
             started_at="2025-06-01T10:00:00Z",
             end_time="2025-06-01T10:01:30Z",
             duration_ms=90000,
+            total_input_tokens=200,
+            total_output_tokens=100,
         )
 
         assert element.session_id == "sess-002"
@@ -100,6 +112,20 @@ class TestSessionElement:
         assert element.started_at == "2025-06-01T10:00:00Z"
         assert element.end_time == "2025-06-01T10:01:30Z"
         assert element.duration_ms == 90000
+        assert element.total_input_tokens == 200
+        assert element.total_output_tokens == 100
+
+    def test_session_element_token_fields_explicit_none(self):
+        """Test SessionElement accepts explicit None for token fields"""
+        element = SessionElement(
+            session_id="sess-002b",
+            status="COMPLETE",
+            total_input_tokens=None,
+            total_output_tokens=None,
+        )
+
+        assert element.total_input_tokens is None
+        assert element.total_output_tokens is None
 
     def test_session_element_running_no_end_time(self):
         """Test SessionElement for a running session with no end time"""
@@ -264,3 +290,379 @@ class TestDescribeSessionResponse:
         assert response.started_at is None
         assert response.end_time is None
         assert response.duration_ms is None
+
+
+class TestAgentTokenUsageStats:
+    """Test the AgentTokenUsageStats model"""
+
+    def test_agent_token_usage_stats_all_fields(self):
+        """Test AgentTokenUsageStats creation with all fields populated"""
+        stats = AgentTokenUsageStats(
+            agent_name="network-agent",
+            session_count=3,
+            total_input_tokens=300,
+            total_output_tokens=150,
+            total_tokens=450,
+            avg_input_tokens=100.0,
+            min_input_tokens=50,
+            max_input_tokens=150,
+            avg_output_tokens=50.0,
+            min_output_tokens=25,
+            max_output_tokens=75,
+            total_duration_ms=9000,
+            avg_duration_ms=3000.0,
+            min_duration_ms=1000,
+            max_duration_ms=5000,
+        )
+
+        assert stats.agent_name == "network-agent"
+        assert stats.session_count == 3
+        assert stats.total_input_tokens == 300
+        assert stats.total_output_tokens == 150
+        assert stats.total_tokens == 450
+        assert stats.avg_input_tokens == 100.0
+        assert stats.min_input_tokens == 50
+        assert stats.max_input_tokens == 150
+        assert stats.avg_output_tokens == 50.0
+        assert stats.min_output_tokens == 25
+        assert stats.max_output_tokens == 75
+        assert stats.total_duration_ms == 9000
+        assert stats.avg_duration_ms == 3000.0
+        assert stats.min_duration_ms == 1000
+        assert stats.max_duration_ms == 5000
+
+    def test_agent_token_usage_stats_none_agent_name(self):
+        """Test AgentTokenUsageStats accepts a None agent_name (unnamed group)"""
+        stats = AgentTokenUsageStats(
+            agent_name=None,
+            session_count=1,
+            total_input_tokens=0,
+            total_output_tokens=0,
+            total_tokens=0,
+            avg_input_tokens=0.0,
+            min_input_tokens=0,
+            max_input_tokens=0,
+            avg_output_tokens=0.0,
+            min_output_tokens=0,
+            max_output_tokens=0,
+            total_duration_ms=0,
+            avg_duration_ms=0.0,
+            min_duration_ms=0,
+            max_duration_ms=0,
+        )
+
+        assert stats.agent_name is None
+        assert stats.session_count == 1
+
+    def test_agent_token_usage_stats_missing_required_raises(self):
+        """Test AgentTokenUsageStats validation fails when required fields are absent"""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentTokenUsageStats()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "session_count" in error_locs
+        assert "total_input_tokens" in error_locs
+        assert "total_duration_ms" in error_locs
+
+
+class TestGetAgentTokenUsageResponse:
+    """Test the GetAgentTokenUsageResponse model"""
+
+    def test_get_agent_token_usage_response_empty_default(self):
+        """Test GetAgentTokenUsageResponse default factory produces empty list"""
+        response = GetAgentTokenUsageResponse()
+
+        assert response.root == []
+        assert len(response.root) == 0
+
+    def test_get_agent_token_usage_response_empty_explicit(self):
+        """Test GetAgentTokenUsageResponse with an explicitly empty list"""
+        response = GetAgentTokenUsageResponse(root=[])
+
+        assert response.root == []
+
+    def test_get_agent_token_usage_response_with_stats(self):
+        """Test GetAgentTokenUsageResponse with multiple stats entries"""
+        stat1 = AgentTokenUsageStats(
+            agent_name="agent-a",
+            session_count=2,
+            total_input_tokens=200,
+            total_output_tokens=100,
+            total_tokens=300,
+            avg_input_tokens=100.0,
+            min_input_tokens=50,
+            max_input_tokens=150,
+            avg_output_tokens=50.0,
+            min_output_tokens=25,
+            max_output_tokens=75,
+            total_duration_ms=2000,
+            avg_duration_ms=1000.0,
+            min_duration_ms=500,
+            max_duration_ms=1500,
+        )
+        stat2 = AgentTokenUsageStats(
+            agent_name="agent-b",
+            session_count=1,
+            total_input_tokens=10,
+            total_output_tokens=5,
+            total_tokens=15,
+            avg_input_tokens=10.0,
+            min_input_tokens=10,
+            max_input_tokens=10,
+            avg_output_tokens=5.0,
+            min_output_tokens=5,
+            max_output_tokens=5,
+            total_duration_ms=200,
+            avg_duration_ms=200.0,
+            min_duration_ms=200,
+            max_duration_ms=200,
+        )
+
+        response = GetAgentTokenUsageResponse(root=[stat1, stat2])
+
+        assert len(response.root) == 2
+        assert response.root[0].agent_name == "agent-a"
+        assert response.root[1].agent_name == "agent-b"
+
+
+class TestAgentSessionTokenUsageElement:
+    """Test the AgentSessionTokenUsageElement model"""
+
+    def test_all_fields(self):
+        """Test AgentSessionTokenUsageElement creation with all fields populated"""
+        element = AgentSessionTokenUsageElement(
+            session_id="sess-001",
+            status="COMPLETE",
+            started_at="2025-06-01T10:00:00Z",
+            end_time="2025-06-01T10:01:00Z",
+            duration_ms=60000,
+            total_input_tokens=200,
+            total_output_tokens=100,
+            total_tokens=300,
+        )
+
+        assert element.session_id == "sess-001"
+        assert element.status == "COMPLETE"
+        assert element.started_at == "2025-06-01T10:00:00Z"
+        assert element.end_time == "2025-06-01T10:01:00Z"
+        assert element.duration_ms == 60000
+        assert element.total_input_tokens == 200
+        assert element.total_output_tokens == 100
+        assert element.total_tokens == 300
+
+    def test_optional_fields_default_none(self):
+        """Test optional fields default to None while total_tokens is required"""
+        element = AgentSessionTokenUsageElement(
+            session_id="sess-002",
+            status="RUNNING",
+            total_tokens=0,
+        )
+
+        assert element.started_at is None
+        assert element.end_time is None
+        assert element.duration_ms is None
+        assert element.total_input_tokens is None
+        assert element.total_output_tokens is None
+
+    def test_missing_required_raises(self):
+        """Test validation fails when required fields are absent"""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentSessionTokenUsageElement()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "session_id" in error_locs
+        assert "status" in error_locs
+        assert "total_tokens" in error_locs
+
+
+class TestGetAgentSessionTokenUsageResponse:
+    """Test the GetAgentSessionTokenUsageResponse model"""
+
+    def test_empty_default(self):
+        """Test default factory produces an empty list"""
+        response = GetAgentSessionTokenUsageResponse()
+
+        assert response.root == []
+
+    def test_empty_explicit(self):
+        """Test an explicitly empty list is accepted"""
+        response = GetAgentSessionTokenUsageResponse(root=[])
+
+        assert response.root == []
+
+    def test_with_elements(self):
+        """Test response wraps multiple elements in order"""
+        elem1 = AgentSessionTokenUsageElement(
+            session_id="sess-001", status="COMPLETE", total_tokens=10
+        )
+        elem2 = AgentSessionTokenUsageElement(
+            session_id="sess-002", status="COMPLETE", total_tokens=20
+        )
+
+        response = GetAgentSessionTokenUsageResponse(root=[elem1, elem2])
+
+        assert len(response.root) == 2
+        assert response.root[0].session_id == "sess-001"
+        assert response.root[1].session_id == "sess-002"
+
+
+class TestSessionTurnTokenUsage:
+    """Test the SessionTurnTokenUsage model"""
+
+    def test_all_fields(self):
+        """Test SessionTurnTokenUsage creation with all fields populated"""
+        usage = SessionTurnTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=150,
+            raw={"inputTokens": 100, "outputTokens": 50},
+        )
+
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.total_tokens == 150
+        assert usage.raw == {"inputTokens": 100, "outputTokens": 50}
+
+    def test_all_fields_default_none(self):
+        """Test all fields default to None"""
+        usage = SessionTurnTokenUsage()
+
+        assert usage.input_tokens is None
+        assert usage.output_tokens is None
+        assert usage.total_tokens is None
+        assert usage.raw is None
+
+
+class TestSessionTurnUsageElement:
+    """Test the SessionTurnUsageElement model"""
+
+    def test_succeeded_turn_all_fields(self):
+        """Test a succeeded turn with all fields populated"""
+        usage = SessionTurnTokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        turn = SessionTurnUsageElement(
+            sequence_number=1,
+            timestamp="2025-06-01T10:00:00Z",
+            event_type="succeeded",
+            duration_ms=500,
+            token_usage=usage,
+            error=None,
+        )
+
+        assert turn.sequence_number == 1
+        assert turn.timestamp == "2025-06-01T10:00:00Z"
+        assert turn.event_type == "succeeded"
+        assert turn.duration_ms == 500
+        assert turn.token_usage.input_tokens == 10
+        assert turn.error is None
+
+    def test_failed_turn_has_error_no_token_usage(self):
+        """Test a failed turn has error populated and token_usage None"""
+        turn = SessionTurnUsageElement(
+            sequence_number=2,
+            event_type="failed",
+            duration_ms=200,
+            error="model timeout",
+        )
+
+        assert turn.event_type == "failed"
+        assert turn.token_usage is None
+        assert turn.error == "model timeout"
+
+    def test_missing_required_raises(self):
+        """Test validation fails when event_type is absent"""
+        with pytest.raises(ValidationError) as exc_info:
+            SessionTurnUsageElement()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "event_type" in error_locs
+
+    def test_optional_fields_default_none(self):
+        """Test optional fields default to None"""
+        turn = SessionTurnUsageElement(event_type="succeeded")
+
+        assert turn.sequence_number is None
+        assert turn.timestamp is None
+        assert turn.duration_ms is None
+        assert turn.token_usage is None
+        assert turn.error is None
+
+
+class TestSessionTurnUsageSummary:
+    """Test the SessionTurnUsageSummary model"""
+
+    def test_all_fields(self):
+        """Test SessionTurnUsageSummary creation with all fields populated"""
+        summary = SessionTurnUsageSummary(
+            session_id="sess-001",
+            turn_count=3,
+            total_duration_ms=900,
+            total_input_tokens=100,
+            total_output_tokens=50,
+            total_tokens=150,
+        )
+
+        assert summary.session_id == "sess-001"
+        assert summary.turn_count == 3
+        assert summary.total_duration_ms == 900
+        assert summary.total_input_tokens == 100
+        assert summary.total_output_tokens == 50
+        assert summary.total_tokens == 150
+
+    def test_missing_required_raises(self):
+        """Test validation fails when required fields are absent"""
+        with pytest.raises(ValidationError) as exc_info:
+            SessionTurnUsageSummary()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "session_id" in error_locs
+        assert "turn_count" in error_locs
+
+
+class TestDescribeSessionTokenUsageResponse:
+    """Test the DescribeSessionTokenUsageResponse model"""
+
+    def test_full_response(self):
+        """Test DescribeSessionTokenUsageResponse with summary and turns populated"""
+        summary = SessionTurnUsageSummary(
+            session_id="sess-001",
+            turn_count=1,
+            total_duration_ms=500,
+            total_input_tokens=10,
+            total_output_tokens=5,
+            total_tokens=15,
+        )
+        turn = SessionTurnUsageElement(event_type="succeeded", duration_ms=500)
+
+        response = DescribeSessionTokenUsageResponse(summary=summary, turns=[turn])
+
+        assert response.summary.session_id == "sess-001"
+        assert len(response.turns) == 1
+        assert response.turns[0].event_type == "succeeded"
+
+    def test_turns_default_empty(self):
+        """Test turns defaults to an empty list"""
+        summary = SessionTurnUsageSummary(
+            session_id="sess-002",
+            turn_count=0,
+            total_duration_ms=0,
+            total_input_tokens=0,
+            total_output_tokens=0,
+            total_tokens=0,
+        )
+
+        response = DescribeSessionTokenUsageResponse(summary=summary)
+
+        assert response.turns == []
+
+    def test_missing_summary_raises(self):
+        """Test validation fails when summary is absent"""
+        with pytest.raises(ValidationError) as exc_info:
+            DescribeSessionTokenUsageResponse()
+
+        errors = exc_info.value.errors()
+        error_locs = {e["loc"][0] for e in errors}
+        assert "summary" in error_locs

--- a/tests/test_services_agent_session_manager.py
+++ b/tests/test_services_agent_session_manager.py
@@ -65,6 +65,8 @@ class TestGetSessions:
                     "startedAt": "2025-06-01T10:00:00Z",
                     "endTime": "2025-06-01T10:01:00Z",
                     "durationMs": 60000,
+                    "totalInputTokens": 150,
+                    "totalOutputTokens": 75,
                 },
                 {
                     "sessionId": "sess-002",
@@ -84,8 +86,14 @@ class TestGetSessions:
         assert result[0]["agent_name"] == "agent-a"
         assert result[0]["status"] == "COMPLETE"
         assert result[0]["duration_ms"] == 60000
+        assert result[0]["total_input_tokens"] == 150
+        assert result[0]["total_output_tokens"] == 75
         assert result[1]["session_id"] == "sess-002"
         assert result[1]["end_time"] is None
+        # Second item's raw payload omits token fields entirely; should
+        # come through as None rather than raising.
+        assert result[1]["total_input_tokens"] is None
+        assert result[1]["total_output_tokens"] is None
 
     @pytest.mark.asyncio
     async def test_get_sessions_agent_name_filter_client_side(

--- a/tests/test_tools_agent_session_manager.py
+++ b/tests/test_tools_agent_session_manager.py
@@ -119,6 +119,53 @@ class TestGetSessionsTool:
         assert len(result.root) == 0
 
     @pytest.mark.asyncio
+    async def test_get_sessions_surfaces_token_fields(self):
+        """Regression test: get_sessions must populate total_input_tokens/
+        total_output_tokens from the service layer, not silently drop them
+        (live-caught 2026-08-05 by integration-tester — the tool constructor
+        call omitted these kwargs despite SessionElement declaring them)"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            {
+                "session_id": "sess-001",
+                "agent_name": "network-agent",
+                "status": "COMPLETE",
+                "started_at": "2025-06-01T10:00:00Z",
+                "end_time": "2025-06-01T10:01:00Z",
+                "duration_ms": 60000,
+                "total_input_tokens": 12345,
+                "total_output_tokens": 678,
+            }
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_sessions(ctx, None)
+
+        assert result.root[0].total_input_tokens == 12345
+        assert result.root[0].total_output_tokens == 678
+
+    @pytest.mark.asyncio
+    async def test_get_sessions_missing_token_fields_default_none(self):
+        """Test get_sessions tolerates a service payload without token fields"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            {
+                "session_id": "sess-001",
+                "agent_name": "network-agent",
+                "status": "COMPLETE",
+                "started_at": "2025-06-01T10:00:00Z",
+                "end_time": "2025-06-01T10:01:00Z",
+                "duration_ms": 60000,
+            }
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_sessions(ctx, None)
+
+        assert result.root[0].total_input_tokens is None
+        assert result.root[0].total_output_tokens is None
+
+    @pytest.mark.asyncio
     async def test_get_sessions_passes_agent_name_filter(self):
         """Test get_sessions passes agent_name through to the service"""
         mock_service = AsyncMock()

--- a/tests/test_tools_agent_session_manager.py
+++ b/tests/test_tools_agent_session_manager.py
@@ -953,6 +953,41 @@ class TestDescribeSessionTokenUsageTool:
         assert turn.sequence_number == 1
 
     @pytest.mark.asyncio
+    async def test_token_usage_extracts_cache_fields_from_live_shape(self):
+        """Test tokenUsage extraction against the confirmed live platform shape,
+        including cacheReadTokens/cacheCreationTokens"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 3,
+                "timestamp": None,
+                "text": "...",
+                "data": {
+                    "durationMs": 6747,
+                    "stopReason": "tool_use",
+                    "tokenUsage": {
+                        "inputTokens": 8606,
+                        "outputTokens": 296,
+                        "cacheReadTokens": 120,
+                        "cacheCreationTokens": 40,
+                    },
+                },
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        turn = result.turns[0]
+        assert turn.token_usage.input_tokens == 8606
+        assert turn.token_usage.output_tokens == 296
+        assert turn.token_usage.cache_read_tokens == 120
+        assert turn.token_usage.cache_creation_tokens == 40
+        assert turn.token_usage.total_tokens == 8902
+
+    @pytest.mark.asyncio
     async def test_token_usage_candidate_key_variant_prompt_completion(self):
         """Test tokenUsage extraction handles promptTokens/completionTokens spelling"""
         mock_service = AsyncMock()

--- a/tests/test_tools_agent_session_manager.py
+++ b/tests/test_tools_agent_session_manager.py
@@ -9,10 +9,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastmcp import Context
 
+from itential_mcp.core.exceptions import ValidationException
 from itential_mcp.tools import agent_session_manager
 from itential_mcp.models.agent_session_manager import (
     GetSessionsResponse,
     DescribeSessionResponse,
+    GetAgentTokenUsageResponse,
+    GetAgentSessionTokenUsageResponse,
+    DescribeSessionTokenUsageResponse,
 )
 
 
@@ -46,7 +50,13 @@ class TestModule:
 
     def test_module_functions_exist(self):
         """Test all expected public functions are present in the module"""
-        expected = ["get_sessions", "describe_session"]
+        expected = [
+            "get_sessions",
+            "describe_session",
+            "get_agent_token_usage",
+            "get_agent_session_token_usage",
+            "describe_session_token_usage",
+        ]
         for func_name in expected:
             assert hasattr(agent_session_manager, func_name), (
                 f"missing function: {func_name}"
@@ -58,6 +68,9 @@ class TestModule:
         functions = [
             agent_session_manager.get_sessions,
             agent_session_manager.describe_session,
+            agent_session_manager.get_agent_token_usage,
+            agent_session_manager.get_agent_session_token_usage,
+            agent_session_manager.describe_session_token_usage,
         ]
         for func in functions:
             assert inspect.iscoroutinefunction(func), (
@@ -378,3 +391,786 @@ class TestDescribeSessionTool:
 
         with pytest.raises(Exception, match="session not found"):
             await agent_session_manager.describe_session(ctx, "sess-missing")
+
+
+class TestGetAgentTokenUsageTool:
+    """Test the get_agent_token_usage tool function"""
+
+    @staticmethod
+    def _session(
+        agent_name="CVE Assessment",
+        status="COMPLETE",
+        started_at="2026-01-01T00:00:00Z",
+        input_tokens=100,
+        output_tokens=50,
+        duration_ms=1000,
+    ):
+        return {
+            "session_id": "sess-x",
+            "agent_name": agent_name,
+            "status": status,
+            "started_at": started_at,
+            "end_time": None,
+            "duration_ms": duration_ms,
+            "total_input_tokens": input_tokens,
+            "total_output_tokens": output_tokens,
+        }
+
+    @pytest.mark.asyncio
+    async def test_groups_by_agent_name_with_correct_math(self):
+        """Test aggregation computes sum/avg/min/max correctly per agent"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(
+                agent_name="CVE Assessment",
+                input_tokens=100,
+                output_tokens=50,
+                duration_ms=1000,
+            ),
+            self._session(
+                agent_name="CVE Assessment",
+                input_tokens=300,
+                output_tokens=150,
+                duration_ms=3000,
+            ),
+            self._session(
+                agent_name="Compliance Bot", input_tokens=10, output_tokens=5
+            ),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, None
+        )
+
+        assert isinstance(result, GetAgentTokenUsageResponse)
+        by_name = {s.agent_name: s for s in result.root}
+
+        cve = by_name["CVE Assessment"]
+        assert cve.session_count == 2
+        assert cve.total_input_tokens == 400
+        assert cve.total_output_tokens == 200
+        assert cve.total_tokens == 600
+        assert cve.avg_input_tokens == 200
+        assert cve.min_input_tokens == 100
+        assert cve.max_input_tokens == 300
+        assert cve.avg_output_tokens == 100
+        assert cve.min_output_tokens == 50
+        assert cve.max_output_tokens == 150
+        assert cve.total_duration_ms == 4000
+        assert cve.avg_duration_ms == 2000
+        assert cve.min_duration_ms == 1000
+        assert cve.max_duration_ms == 3000
+
+        compliance = by_name["Compliance Bot"]
+        assert compliance.session_count == 1
+        assert compliance.total_tokens == 15
+
+    @pytest.mark.asyncio
+    async def test_sorted_by_total_tokens_descending(self):
+        """Test results are sorted by total_tokens descending"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(agent_name="Small Agent", input_tokens=1, output_tokens=1),
+            self._session(
+                agent_name="Big Agent", input_tokens=1000, output_tokens=1000
+            ),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, None
+        )
+
+        assert [s.agent_name for s in result.root] == ["Big Agent", "Small Agent"]
+
+    @pytest.mark.asyncio
+    async def test_default_only_includes_complete_sessions(self):
+        """Test that by default, only COMPLETE sessions contribute to usage"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(status="COMPLETE", input_tokens=100, output_tokens=50),
+            self._session(status="FAILED", input_tokens=999, output_tokens=999),
+            self._session(status="RUNNING", input_tokens=999, output_tokens=999),
+            self._session(status="PAUSED", input_tokens=999, output_tokens=999),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].session_count == 1
+        assert result.root[0].total_input_tokens == 100
+        assert result.root[0].total_output_tokens == 50
+
+    @pytest.mark.asyncio
+    async def test_include_failed_adds_failed_sessions_only(self):
+        """Test include_failed=True folds in FAILED but not other non-terminal statuses"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(status="COMPLETE", input_tokens=100, output_tokens=50),
+            self._session(status="FAILED", input_tokens=10, output_tokens=5),
+            self._session(status="RUNNING", input_tokens=999, output_tokens=999),
+            self._session(status="PENDING", input_tokens=999, output_tokens=999),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, True, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].session_count == 2
+        assert result.root[0].total_input_tokens == 110
+        assert result.root[0].total_output_tokens == 55
+
+    @pytest.mark.asyncio
+    async def test_missing_token_values_count_session_as_zero(self):
+        """Test a session with null token fields still counts toward session_count"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(input_tokens=100, output_tokens=50),
+            self._session(input_tokens=None, output_tokens=None),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, None
+        )
+
+        assert len(result.root) == 1
+        stats = result.root[0]
+        assert stats.session_count == 2
+        assert stats.total_input_tokens == 100
+        assert stats.total_output_tokens == 50
+        assert stats.min_input_tokens == 0
+        assert stats.min_output_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_duration_counts_as_zero(self):
+        """Test a session with a null duration_ms still counts toward session_count"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(duration_ms=1000),
+            self._session(duration_ms=None),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, None
+        )
+
+        assert len(result.root) == 1
+        stats = result.root[0]
+        assert stats.session_count == 2
+        assert stats.total_duration_ms == 1000
+        assert stats.avg_duration_ms == 500
+        assert stats.min_duration_ms == 0
+        assert stats.max_duration_ms == 1000
+
+    @pytest.mark.asyncio
+    async def test_agent_name_substring_filter_case_insensitive(self):
+        """Test agent_name filter matches substrings case-insensitively"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(agent_name="CVE Assessment"),
+            self._session(agent_name="Compliance Bot"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, "cve", False, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].agent_name == "CVE Assessment"
+
+    @pytest.mark.asyncio
+    async def test_agent_name_none_sessions_excluded_from_name_filter(self):
+        """Test sessions with no agent name are excluded when a name filter is set"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(agent_name=None),
+            self._session(agent_name="CVE Assessment"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, "cve", False, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].agent_name == "CVE Assessment"
+
+    @pytest.mark.asyncio
+    async def test_agent_name_none_sessions_grouped_when_unfiltered(self):
+        """Test sessions with no agent name land in a None-keyed group, not dropped"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(agent_name=None, input_tokens=7, output_tokens=3),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].agent_name is None
+        assert result.root[0].total_tokens == 10
+
+    @pytest.mark.asyncio
+    async def test_started_after_filter_excludes_earlier_sessions(self):
+        """Test started_after excludes sessions started before the given time"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(started_at="2026-01-01T00:00:00Z"),
+            self._session(started_at="2026-02-01T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, "2026-01-15T00:00:00Z", None
+        )
+
+        assert result.root[0].session_count == 1
+
+    @pytest.mark.asyncio
+    async def test_started_before_filter_excludes_later_sessions(self):
+        """Test started_before excludes sessions started after the given time"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(started_at="2026-01-01T00:00:00Z"),
+            self._session(started_at="2026-02-01T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, "2026-01-15T00:00:00Z"
+        )
+
+        assert result.root[0].session_count == 1
+
+    @pytest.mark.asyncio
+    async def test_started_at_boundary_is_inclusive(self):
+        """Test a session started exactly at the boundary is included on both ends"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(started_at="2026-01-15T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result_after = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, "2026-01-15T00:00:00Z", None
+        )
+        result_before = await agent_session_manager.get_agent_token_usage(
+            ctx, None, False, None, "2026-01-15T00:00:00Z"
+        )
+
+        assert result_after.root[0].session_count == 1
+        assert result_before.root[0].session_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_matching_sessions_returns_empty_response(self):
+        """Test that no matches returns an empty response, not an error"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(agent_name="Other Agent"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_token_usage(
+            ctx, "nonexistent", False, None, None
+        )
+
+        assert isinstance(result, GetAgentTokenUsageResponse)
+        assert result.root == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_started_after_raises_validation_exception(self):
+        """Test a malformed started_after timestamp raises ValidationException"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = []
+        ctx = _make_context(mock_service)
+
+        with pytest.raises(ValidationException):
+            await agent_session_manager.get_agent_token_usage(
+                ctx, None, False, "not-a-timestamp", None
+            )
+
+    @pytest.mark.asyncio
+    async def test_fetches_sessions_without_server_side_filter(self):
+        """Test the service is called unfiltered so name-substring matching can happen locally"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = []
+        ctx = _make_context(mock_service)
+
+        await agent_session_manager.get_agent_token_usage(
+            ctx, "some-agent", False, None, None
+        )
+
+        mock_service.get_sessions.assert_called_once_with(None)
+
+
+class TestGetAgentSessionTokenUsageTool:
+    """Test the get_agent_session_token_usage tool function"""
+
+    @staticmethod
+    def _session(
+        session_id="sess-x",
+        agent_name="CVE Assessment",
+        status="COMPLETE",
+        started_at="2026-01-01T00:00:00Z",
+        end_time=None,
+        duration_ms=1000,
+        input_tokens=100,
+        output_tokens=50,
+    ):
+        return {
+            "session_id": session_id,
+            "agent_name": agent_name,
+            "status": status,
+            "started_at": started_at,
+            "end_time": end_time,
+            "duration_ms": duration_ms,
+            "total_input_tokens": input_tokens,
+            "total_output_tokens": output_tokens,
+        }
+
+    @pytest.mark.asyncio
+    async def test_one_row_per_session_no_aggregation(self):
+        """Test each session produces its own row, not a grouped aggregate"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(session_id="sess-1", started_at="2026-01-01T00:00:00Z"),
+            self._session(session_id="sess-2", started_at="2026-01-02T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, None, None
+        )
+
+        assert isinstance(result, GetAgentSessionTokenUsageResponse)
+        assert len(result.root) == 2
+        ids = {e.session_id for e in result.root}
+        assert ids == {"sess-1", "sess-2"}
+
+    @pytest.mark.asyncio
+    async def test_total_tokens_computed_with_nulls_as_zero(self):
+        """Test total_tokens sums input/output, treating null as 0"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(input_tokens=None, output_tokens=None),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, None, None
+        )
+
+        assert result.root[0].total_tokens == 0
+        assert result.root[0].total_input_tokens is None
+        assert result.root[0].total_output_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_results_sorted_by_started_at_ascending(self):
+        """Test results are sorted by started_at ascending"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(session_id="sess-late", started_at="2026-03-01T00:00:00Z"),
+            self._session(session_id="sess-early", started_at="2026-01-01T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, None, None
+        )
+
+        assert [e.session_id for e in result.root] == ["sess-early", "sess-late"]
+
+    @pytest.mark.asyncio
+    async def test_session_with_none_started_at_sorts_last(self):
+        """Test a session with started_at=None sorts after all real timestamps"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(session_id="sess-none", started_at=None),
+            self._session(session_id="sess-real", started_at="2026-01-01T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, None, None
+        )
+
+        assert [e.session_id for e in result.root] == ["sess-real", "sess-none"]
+
+    @pytest.mark.asyncio
+    async def test_agent_name_substring_filter_case_insensitive(self):
+        """Test agent_name filter matches substrings case-insensitively"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(session_id="sess-1", agent_name="CVE Assessment"),
+            self._session(session_id="sess-2", agent_name="Compliance Bot"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "cve", False, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_default_only_includes_complete_sessions(self):
+        """Test that by default, only COMPLETE sessions are returned"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(session_id="sess-1", status="COMPLETE"),
+            self._session(session_id="sess-2", status="FAILED"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, None, None
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_include_failed_adds_failed_sessions(self):
+        """Test include_failed=True includes FAILED sessions alongside COMPLETE"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(session_id="sess-1", status="COMPLETE"),
+            self._session(session_id="sess-2", status="FAILED"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", True, None, None
+        )
+
+        assert len(result.root) == 2
+
+    @pytest.mark.asyncio
+    async def test_started_after_and_before_window_inclusive(self):
+        """Test started_after/started_before window includes the inclusive boundary"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(
+                session_id="sess-boundary", started_at="2026-01-15T00:00:00Z"
+            ),
+            self._session(session_id="sess-out", started_at="2026-02-01T00:00:00Z"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, "2026-01-15T00:00:00Z", "2026-01-15T00:00:00Z"
+        )
+
+        assert len(result.root) == 1
+        assert result.root[0].session_id == "sess-boundary"
+
+    @pytest.mark.asyncio
+    async def test_no_matching_sessions_returns_empty_response(self):
+        """Test that no matches returns an empty response, not an error"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = [
+            self._session(agent_name="Other Agent"),
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.get_agent_session_token_usage(
+            ctx, "nonexistent", False, None, None
+        )
+
+        assert result == GetAgentSessionTokenUsageResponse(root=[])
+
+    @pytest.mark.asyncio
+    async def test_invalid_started_after_raises_validation_exception(self):
+        """Test a malformed started_after timestamp raises ValidationException"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = []
+        ctx = _make_context(mock_service)
+
+        with pytest.raises(ValidationException):
+            await agent_session_manager.get_agent_session_token_usage(
+                ctx, "CVE", False, "not-a-timestamp", None
+            )
+
+    @pytest.mark.asyncio
+    async def test_fetches_sessions_without_server_side_filter(self):
+        """Test the service is called unfiltered so name-substring matching can happen locally"""
+        mock_service = AsyncMock()
+        mock_service.get_sessions.return_value = []
+        ctx = _make_context(mock_service)
+
+        await agent_session_manager.get_agent_session_token_usage(
+            ctx, "CVE", False, None, None
+        )
+
+        mock_service.get_sessions.assert_called_once_with(None)
+
+
+class TestDescribeSessionTokenUsageTool:
+    """Test the describe_session_token_usage tool function"""
+
+    @pytest.mark.asyncio
+    async def test_succeeded_turn_extracts_duration_and_token_usage(self):
+        """Test a succeeded turn produces duration_ms and token_usage"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "eventId": "evt-1",
+                "timestamp": 1748779200000,
+                "type": "inference-succeeded",
+                "category": "AGENT_REASONING",
+                "sequenceNumber": 1,
+                "text": "Device configured.",
+                "data": {
+                    "durationMs": 500,
+                    "tokenUsage": {"inputTokens": 100, "outputTokens": 50},
+                },
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        assert isinstance(result, DescribeSessionTokenUsageResponse)
+        assert len(result.turns) == 1
+        turn = result.turns[0]
+        assert turn.event_type == "succeeded"
+        assert turn.duration_ms == 500
+        assert turn.token_usage.input_tokens == 100
+        assert turn.token_usage.output_tokens == 50
+        assert turn.sequence_number == 1
+
+    @pytest.mark.asyncio
+    async def test_token_usage_candidate_key_variant_prompt_completion(self):
+        """Test tokenUsage extraction handles promptTokens/completionTokens spelling"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 1,
+                "timestamp": None,
+                "text": "output",
+                "data": {
+                    "durationMs": 100,
+                    "tokenUsage": {"promptTokens": 20, "completionTokens": 10},
+                },
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        turn = result.turns[0]
+        assert turn.token_usage.input_tokens == 20
+        assert turn.token_usage.output_tokens == 10
+
+    @pytest.mark.asyncio
+    async def test_token_usage_candidate_key_variant_input_output(self):
+        """Test tokenUsage extraction handles inputTokens/outputTokens spelling"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 1,
+                "timestamp": None,
+                "text": "output",
+                "data": {
+                    "durationMs": 100,
+                    "tokenUsage": {"inputTokens": 30, "outputTokens": 15},
+                },
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        turn = result.turns[0]
+        assert turn.token_usage.input_tokens == 30
+        assert turn.token_usage.output_tokens == 15
+
+    @pytest.mark.asyncio
+    async def test_raw_preserves_original_token_usage_dict(self):
+        """Test SessionTurnTokenUsage.raw preserves the untouched original dict"""
+        mock_service = AsyncMock()
+        original = {"promptTokens": 20, "completionTokens": 10, "extraKey": "value"}
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 1,
+                "timestamp": None,
+                "text": "output",
+                "data": {"durationMs": 100, "tokenUsage": original},
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        assert result.turns[0].token_usage.raw == original
+
+    @pytest.mark.asyncio
+    async def test_failed_turn_has_no_token_usage_and_populates_error(self):
+        """Test a failed turn has token_usage=None and error from text"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-failed",
+                "sequenceNumber": 2,
+                "timestamp": None,
+                "text": "model timeout",
+                "data": {"durationMs": 200},
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        turn = result.turns[0]
+        assert turn.event_type == "failed"
+        assert turn.token_usage is None
+        assert turn.error == "model timeout"
+        assert turn.duration_ms == 200
+
+    @pytest.mark.asyncio
+    async def test_non_inference_message_types_filtered_out(self):
+        """Test tool-execution and status events are excluded from turns"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "tool-execution",
+                "sequenceNumber": 1,
+                "timestamp": None,
+                "data": {},
+            },
+            {
+                "sessionId": "sess-1",
+                "type": "agent-session-completed",
+                "sequenceNumber": 2,
+                "timestamp": None,
+                "data": {},
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        assert result.turns == []
+        assert result.summary.turn_count == 0
+
+    @pytest.mark.asyncio
+    async def test_summary_math_is_correct(self):
+        """Test summary sums duration and tokens across all turns, missing as 0"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 1,
+                "timestamp": None,
+                "text": "a",
+                "data": {
+                    "durationMs": 100,
+                    "tokenUsage": {"inputTokens": 10, "outputTokens": 5},
+                },
+            },
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 2,
+                "timestamp": None,
+                "text": "b",
+                "data": {"durationMs": 200},
+            },
+            {
+                "sessionId": "sess-1",
+                "type": "inference-failed",
+                "sequenceNumber": 3,
+                "timestamp": None,
+                "text": "boom",
+                "data": {},
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(ctx, "sess-1")
+
+        assert result.summary.session_id == "sess-1"
+        assert result.summary.turn_count == 3
+        assert result.summary.total_duration_ms == 300
+        assert result.summary.total_input_tokens == 10
+        assert result.summary.total_output_tokens == 5
+        assert result.summary.total_tokens == 15
+
+    @pytest.mark.asyncio
+    async def test_zero_inference_turns_returns_zeroed_summary(self):
+        """Test a session with zero inference turns returns a zeroed summary, not an error"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = []
+        ctx = _make_context(mock_service)
+
+        result = await agent_session_manager.describe_session_token_usage(
+            ctx, "sess-empty"
+        )
+
+        assert result.turns == []
+        assert result.summary.turn_count == 0
+        assert result.summary.total_duration_ms == 0
+        assert result.summary.total_input_tokens == 0
+        assert result.summary.total_output_tokens == 0
+        assert result.summary.total_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_epoch_timestamp_conversion(self):
+        """Test epoch millisecond timestamps are converted to ISO 8601"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.return_value = [
+            {
+                "sessionId": "sess-1",
+                "type": "inference-succeeded",
+                "sequenceNumber": 1,
+                "timestamp": 1748779200000,
+                "text": "a",
+                "data": {"durationMs": 100},
+            },
+        ]
+        ctx = _make_context(mock_service)
+
+        with patch(
+            "itential_mcp.tools.agent_session_manager.timeutils.epoch_to_timestamp"
+        ) as mock_ts:
+            mock_ts.return_value = "2025-06-01T12:00:00Z"
+            result = await agent_session_manager.describe_session_token_usage(
+                ctx, "sess-1"
+            )
+
+        mock_ts.assert_called_with(1748779200000)
+        assert result.turns[0].timestamp == "2025-06-01T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_client_error_propagates(self):
+        """Test describe_session_token_usage propagates errors from the service layer"""
+        mock_service = AsyncMock()
+        mock_service.get_session_messages.side_effect = Exception("session not found")
+        ctx = _make_context(mock_service)
+
+        with pytest.raises(Exception, match="session not found"):
+            await agent_session_manager.describe_session_token_usage(
+                ctx, "sess-missing"
+            )


### PR DESCRIPTION
## Summary
Adds token-usage / tokenomics analytics to the `agent_session_manager` module,
so callers can attribute and compare LLM token spend across agents, sessions,
and individual inference turns.

MINOR-shaped change: three net-new public tools plus two additive fields on an
existing tool. No breaking changes — the `get_sessions` additions are additive
and default to `None`.

## Changes
- **New tool `get_agent_token_usage`** — aggregate token/duration stats grouped
  by agent name, with `include_failed` and `started_after`/`started_before`
  filters; sorted by `total_tokens` descending. Only `COMPLETE` sessions count
  toward usage by default (finished, billable work); `include_failed=True`
  also folds in `FAILED` sessions.
- **New tool `get_agent_session_token_usage`** — per-session (non-aggregated)
  token breakdown for a single agent, sorted by `started_at` ascending.
- **New tool `describe_session_token_usage`** — per-inference-turn breakdown for
  one session, including typed `cache_read_tokens`/`cache_creation_tokens`
  fields and a rollup summary.
- **`get_sessions`** now surfaces `total_input_tokens`/`total_output_tokens`
  (fields the service layer already fetched but the tool never passed
  through — caught live during integration testing on this branch).
- New/updated Pydantic models across `models/agent_session_manager.py`.
- Docstrings document the live-observed session-level vs. turn-summed token
  total divergence (up to ~12x on multi-turn sessions) so callers don't
  expect the two to reconcile.

## Testing
- [x] Unit tests pass — `make ci` green (2647 tests; format, check, headers,
      bandit all clean)
- [x] Integration tests pass — verified live against a real Itential
      Platform; caught and fixed a bug where `get_sessions` returned null
      token fields (re-verified live: the affected session now returns real
      input/output token counts matching the other tools); confirmed the
      `inference-failed` error-source assumption against 3 real
      failed-inference events
- [x] Manual testing completed — exercised all 3 new tools plus `get_sessions`
      against the live platform via `itential-mcp call`
