### PR TITLE
feat: add gateway configuration export/import tools to gateway_manager

### DIFF
--- a/src/itential_mcp/models/gateway_manager.py
+++ b/src/itential_mcp/models/gateway_manager.py
@@ -197,6 +197,137 @@ class GetGatewaysResponse(RootModel):
     ]
 
 
+class ExportGatewayConfigurationResponse(RootModel):
+    """Response model for the export gateway configuration API endpoint.
+
+    This root model wraps the opaque DSL document returned by the platform.
+    The document shape is not defined by the platform's API contract, so it
+    is passed through unchanged.
+
+    Attributes:
+        root: The exported DSL configuration document.
+    """
+
+    root: Annotated[
+        dict[str, Any],
+        Field(
+            description=inspect.cleandoc(
+                """
+                The exported DSL configuration document
+                """
+            )
+        ),
+    ]
+
+
+class ImportSummary(BaseModel):
+    """Aggregate counts for an import gateway configuration operation.
+
+    Attributes:
+        added: Number of resources added.
+        replaced: Number of resources replaced.
+        skipped: Number of resources skipped.
+    """
+
+    added: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of resources added
+                """
+            ),
+            default=0,
+        ),
+    ]
+
+    replaced: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of resources replaced
+                """
+            ),
+            default=0,
+        ),
+    ]
+
+    skipped: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of resources skipped
+                """
+            ),
+            default=0,
+        ),
+    ]
+
+
+class ImportGatewayConfigurationResponse(BaseModel):
+    """Response model for the import gateway configuration API endpoint.
+
+    All fields are optional so that an undocumented dry-run (check=true)
+    diff shape does not fail validation.
+
+    Attributes:
+        added: Resources added by the import.
+        replaced: Resources replaced by the import.
+        skipped: Resources skipped by the import.
+        summary: Aggregate counts for the import.
+    """
+
+    added: Annotated[
+        list[Any],
+        Field(
+            description=inspect.cleandoc(
+                """
+                Resources added by the import
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+    replaced: Annotated[
+        list[Any],
+        Field(
+            description=inspect.cleandoc(
+                """
+                Resources replaced by the import
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+    skipped: Annotated[
+        list[Any],
+        Field(
+            description=inspect.cleandoc(
+                """
+                Resources skipped by the import
+                """
+            ),
+            default_factory=list,
+        ),
+    ]
+
+    summary: Annotated[
+        ImportSummary | None,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Aggregate counts for the import
+                """
+            ),
+            default=None,
+        ),
+    ]
+
+
 class RunServiceResponse(BaseModel):
     """Response model for the run service API operation.
 

--- a/src/itential_mcp/platform/services/gateway_manager.py
+++ b/src/itential_mcp/platform/services/gateway_manager.py
@@ -1066,6 +1066,91 @@ class Service(ServiceBase):
         res = await self.client.get("/gateway_manager/v1/health/status")
         return res.json()
 
+    async def export_configuration(self, cluster_id: str) -> Mapping[str, Any]:
+        """
+        Export a gateway cluster's full DB configuration as a DSL document.
+
+        The gateway must be connected and active. The returned document can
+        be passed unchanged as the content of a future import.
+
+        Args:
+            cluster_id (str): The cluster ID of the target gateway
+
+        Returns:
+            Mapping[str, Any]: The exported DSL configuration document
+
+        Raises:
+            HTTPError: If the API request fails
+            NotFoundError: If the cluster doesn't exist
+            ConnectionException: If the gateway is not connected
+
+        Example:
+            document = await client.gateway_manager.export_configuration("cluster_1")
+        """
+        res = await self.client.get(
+            f"/gateway_manager/v1/gateways/{cluster_id}/configuration/export"
+        )
+        return res.json()
+
+    async def import_configuration(
+        self,
+        cluster_id: str,
+        *,
+        source: str,
+        content: dict | str | None = None,
+        git: dict[str, Any] | None = None,
+        force: bool = False,
+        validate: bool = False,
+        check: bool = False,
+    ) -> Mapping[str, Any]:
+        """
+        Import a DB configuration into a connected gateway cluster.
+
+        The configuration content may be supplied inline (source="content")
+        or fetched from a git repository (source="git"). The gateway must be
+        connected and active.
+
+        Args:
+            cluster_id (str): The cluster ID of the target gateway.
+            source: The import source, either "content" or "git".
+            content: Inline DSL document, required if source is "content". Defaults to None.
+            git: Git repository options, required if source is "git". Defaults to None.
+            force: Overwrite existing resources. Defaults to False.
+            validate: Parse and validate only, with no writes. Defaults to False.
+            check: Dry-run diff showing what would change, with no writes. Defaults to False.
+
+        Returns:
+            Mapping[str, Any]: The import result summary
+
+        Raises:
+            HTTPError: If the API request fails
+            NotFoundError: If the cluster doesn't exist
+            ValidationException: If the configuration content is invalid
+            ConnectionException: If the gateway is not connected
+
+        Example:
+            result = await client.gateway_manager.import_configuration(
+                "cluster_1", source="content", content=document
+            )
+        """
+        options: dict[str, Any] = {
+            "source": source,
+            "force": force,
+            "validate": validate,
+            "check": check,
+        }
+
+        if content is not None:
+            options["content"] = content
+        if git is not None:
+            options["git"] = git
+
+        res = await self.client.post(
+            f"/gateway_manager/v1/gateways/{cluster_id}/configuration/import",
+            json={"options": options},
+        )
+        return res.json()
+
     async def get_version(self) -> Mapping[str, Any]:
         """
         Get the version information for Gateway Manager.

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -284,6 +284,12 @@ async def export_gateway_configuration(
                 "secrets or user credentials and confirmation was not "
                 "granted"
             )
+        case _:
+            raise exceptions.AuthorizationException(
+                "export refused: received an unexpected or unrecognized "
+                "elicitation result while confirming the gateway "
+                "configuration export"
+            )
 
 
 async def import_gateway_configuration(

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -7,6 +7,13 @@ from typing import Annotated, Any
 from pydantic import Field
 
 from fastmcp import Context
+from fastmcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
+
+from mcp.types import ClientCapabilities, ElicitationCapability
 
 from itential_mcp.utilities import json as jsonutils
 from itential_mcp.core import exceptions
@@ -15,6 +22,40 @@ from itential_mcp.models import gateway_manager as models
 
 
 __tags__ = ("gateway_manager",)
+
+
+# Top-level document keys that indicate the presence of secret or credential
+# material in a gateway configuration export.
+_SENSITIVE_EXPORT_KEYS = ("secrets", "users")
+
+
+def _export_contains_sensitive_data(document: dict[str, Any]) -> bool:
+    """
+    Determine whether a gateway configuration export contains sensitive data
+
+    Checks the top-level document for non-empty `secrets` or `users` fields,
+    as well as any nested `secrets` field on individual entries in the
+    `services` list, since a service entry may reference secret material
+    independently of the top-level `secrets` list.
+
+    Args:
+        document (dict[str, Any]): The exported gateway configuration
+            document
+
+    Returns:
+        bool: True if the document contains secrets or user credentials,
+            False otherwise
+    """
+    if any(document.get(key) for key in _SENSITIVE_EXPORT_KEYS):
+        return True
+
+    services = document.get("services")
+    if isinstance(services, list):
+        for service in services:
+            if isinstance(service, dict) and service.get("secrets"):
+                return True
+
+    return False
 
 
 async def get_services(
@@ -185,7 +226,8 @@ async def export_gateway_configuration(
 
     The gateway must be connected and active. The returned document can be
     passed unchanged as the content of a future import_gateway_configuration
-    call.
+    call. If the export contains secrets or user credentials, this may
+    prompt for explicit confirmation via MCP elicitation before returning.
 
     Args:
         ctx (Context): The FastMCP Context object
@@ -196,6 +238,10 @@ async def export_gateway_configuration(
             document
 
     Raises:
+        AuthorizationException: If the export contains secrets or user
+            credentials and the operator declines confirmation, or if the
+            connected client does not support the required confirmation
+            prompt
         Exception: If there is an error exporting the configuration from
             Gateway Manager
     """
@@ -205,7 +251,39 @@ async def export_gateway_configuration(
 
     document = await client.gateway_manager.export_configuration(cluster_id)
 
-    return models.ExportGatewayConfigurationResponse(document)
+    if not _export_contains_sensitive_data(document):
+        return models.ExportGatewayConfigurationResponse(document)
+
+    if not ctx.session.check_client_capability(
+        ClientCapabilities(elicitation=ElicitationCapability())
+    ):
+        raise exceptions.AuthorizationException(
+            "the exported gateway configuration contains secrets or user "
+            "credentials, but the connected client does not support the "
+            "confirmation prompt required to return it"
+        )
+
+    result = await ctx.elicit(
+        message=(
+            "This gateway configuration export contains secrets or user "
+            "credentials. Confirm to proceed and return the export?"
+        ),
+        response_type=bool,
+    )
+
+    match result:
+        case AcceptedElicitation(data=True):
+            return models.ExportGatewayConfigurationResponse(document)
+        case (
+            AcceptedElicitation(data=False)
+            | DeclinedElicitation()
+            | CancelledElicitation()
+        ):
+            raise exceptions.AuthorizationException(
+                "export declined: the gateway configuration contains "
+                "secrets or user credentials and confirmation was not "
+                "granted"
+            )
 
 
 async def import_gateway_configuration(

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import Field
 
@@ -172,3 +172,208 @@ async def run_service(
         pass
 
     return models.RunServiceResponse(**res["result"])
+
+
+async def export_gateway_configuration(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    cluster_id: Annotated[
+        str, Field(description="The cluster ID of the target gateway, e.g. 'cluster_1'")
+    ],
+) -> models.ExportGatewayConfigurationResponse:
+    """
+    Export a gateway cluster's full DB configuration as a DSL document
+
+    The gateway must be connected and active. The returned document can be
+    passed unchanged as the content of a future import_gateway_configuration
+    call.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+        cluster_id (str): The cluster ID of the target gateway
+
+    Returns:
+        ExportGatewayConfigurationResponse: The exported DSL configuration
+            document
+
+    Raises:
+        Exception: If there is an error exporting the configuration from
+            Gateway Manager
+    """
+    await ctx.debug("inside export_gateway_configuration(...)")
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    document = await client.gateway_manager.export_configuration(cluster_id)
+
+    return models.ExportGatewayConfigurationResponse(document)
+
+
+async def import_gateway_configuration(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    cluster_id: Annotated[
+        str, Field(description="The cluster ID of the target gateway")
+    ],
+    content: Annotated[
+        dict | str | None,
+        Field(
+            description=(
+                "Inline DSL document to import — either the object returned by "
+                "export_gateway_configuration, or a raw YAML/JSON string. "
+                "Mutually exclusive with the git_* parameters."
+            ),
+            default=None,
+        ),
+    ],
+    git_url: Annotated[
+        str | None,
+        Field(
+            description="Git repository URL to import from. Requires git_file. Mutually exclusive with content.",
+            default=None,
+        ),
+    ],
+    git_file: Annotated[
+        str | None,
+        Field(
+            description="Path to the DSL file within the git repository. Required when git_url is set.",
+            default=None,
+        ),
+    ],
+    git_reference: Annotated[
+        str | None,
+        Field(
+            description="Branch, tag, or SHA to check out. Defaults to the repository's default branch.",
+            default=None,
+        ),
+    ],
+    git_username: Annotated[
+        str | None,
+        Field(
+            description="HTTP basic auth username for HTTPS git repositories.",
+            default=None,
+        ),
+    ],
+    git_password: Annotated[
+        str | None,
+        Field(
+            description=(
+                "HTTP basic auth password for HTTPS git repositories. Supports "
+                "$GATEWAYSECRET_(alias) references resolved by the gateway."
+            ),
+            default=None,
+        ),
+    ],
+    git_private_key: Annotated[
+        str | None,
+        Field(
+            description="SSH private key file path on the gateway host filesystem.",
+            default=None,
+        ),
+    ],
+    force: Annotated[
+        bool, Field(description="Overwrite existing resources.", default=False)
+    ],
+    validate: Annotated[
+        bool,
+        Field(
+            description="Parse and validate only, with no writes. Mutually exclusive with check.",
+            default=False,
+        ),
+    ],
+    check: Annotated[
+        bool,
+        Field(
+            description="Dry-run diff showing what would change, with no writes. Mutually exclusive with validate.",
+            default=False,
+        ),
+    ],
+) -> models.ImportGatewayConfigurationResponse:
+    """
+    Import a DB configuration into a connected gateway cluster
+
+    The configuration content may be supplied inline via content, or fetched
+    from a git repository via the git_* parameters. The gateway must be
+    connected and active.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+        cluster_id (str): The cluster ID of the target gateway
+        content (dict | str | None): Inline DSL document to import
+        git_url (str | None): Git repository URL to import from
+        git_file (str | None): Path to the DSL file within the git repository
+        git_reference (str | None): Branch, tag, or SHA to check out
+        git_username (str | None): HTTP basic auth username for the git repository
+        git_password (str | None): HTTP basic auth password for the git repository
+        git_private_key (str | None): SSH private key file path on the gateway host
+        force (bool): Overwrite existing resources
+        validate (bool): Parse and validate only, with no writes
+        check (bool): Dry-run diff showing what would change, with no writes
+
+    Returns:
+        ImportGatewayConfigurationResponse: Summary of resources added,
+            replaced, and skipped by the import
+
+    Raises:
+        ValidationException: If validate and check are both set, if content
+            and git parameters are both set, if neither is set, or if only
+            one of git_url/git_file is set
+        Exception: If there is an error importing the configuration into
+            Gateway Manager
+    """
+    await ctx.debug("inside import_gateway_configuration(...)")
+
+    if validate and check:
+        raise exceptions.ValidationException(
+            "validate and check are mutually exclusive"
+        )
+
+    git_params = (
+        git_url,
+        git_file,
+        git_reference,
+        git_username,
+        git_password,
+        git_private_key,
+    )
+
+    if content is not None and any(param is not None for param in git_params):
+        raise exceptions.ValidationException(
+            "content and the git_* parameters are mutually exclusive"
+        )
+
+    if content is None and git_url is None:
+        raise exceptions.ValidationException(
+            "either content or git_url must be provided"
+        )
+
+    if (git_url is None) != (git_file is None):
+        raise exceptions.ValidationException(
+            "git_url and git_file are both required together for a git source"
+        )
+
+    client = ctx.request_context.lifespan_context.get("client")
+
+    source = "content" if content is not None else "git"
+
+    git: dict[str, Any] | None = None
+    if source == "git":
+        git = {"url": git_url, "file": git_file}
+        if git_reference is not None:
+            git["reference"] = git_reference
+        if git_username is not None:
+            git["username"] = git_username
+        if git_password is not None:
+            git["password"] = git_password
+        if git_private_key is not None:
+            git["privateKey"] = git_private_key
+
+    result = await client.gateway_manager.import_configuration(
+        cluster_id,
+        source=source,
+        content=content,
+        git=git,
+        force=force,
+        validate=validate,
+        check=check,
+    )
+
+    return models.ImportGatewayConfigurationResponse(**result)

--- a/tests/test_models_gateway_manager.py
+++ b/tests/test_models_gateway_manager.py
@@ -11,6 +11,9 @@ from itential_mcp.models.gateway_manager import (
     GatewayElement,
     GetGatewaysResponse,
     RunServiceResponse,
+    ExportGatewayConfigurationResponse,
+    ImportSummary,
+    ImportGatewayConfigurationResponse,
 )
 
 
@@ -678,6 +681,115 @@ class TestRunServiceResponse:
         )
 
         assert response.elapsed_time == -1.0
+
+
+class TestExportGatewayConfigurationResponse:
+    """Test cases for ExportGatewayConfigurationResponse model"""
+
+    def test_export_gateway_configuration_response_valid_document(self):
+        """Test creating ExportGatewayConfigurationResponse with a valid document"""
+        document = {
+            "version": "1.0",
+            "resources": [{"type": "service", "name": "svc-1"}],
+        }
+
+        response = ExportGatewayConfigurationResponse(document)
+        assert response.root == document
+
+    def test_export_gateway_configuration_response_empty_document(self):
+        """Test ExportGatewayConfigurationResponse with an empty document"""
+        response = ExportGatewayConfigurationResponse({})
+        assert response.root == {}
+
+    def test_export_gateway_configuration_response_serialization(self):
+        """Test ExportGatewayConfigurationResponse serializes directly as a dict"""
+        document = {"key": "value"}
+        response = ExportGatewayConfigurationResponse(document)
+
+        serialized = response.model_dump()
+        assert isinstance(serialized, dict)
+        assert serialized == document
+
+    def test_export_gateway_configuration_response_invalid_type(self):
+        """Test ExportGatewayConfigurationResponse rejects non-dict input"""
+        with pytest.raises(ValidationError):
+            ExportGatewayConfigurationResponse("not a dict")
+
+
+class TestImportSummary:
+    """Test cases for ImportSummary model"""
+
+    def test_import_summary_defaults(self):
+        """Test ImportSummary default values"""
+        summary = ImportSummary()
+        assert summary.added == 0
+        assert summary.replaced == 0
+        assert summary.skipped == 0
+
+    def test_import_summary_explicit_values(self):
+        """Test ImportSummary with explicit values"""
+        summary = ImportSummary(added=3, replaced=1, skipped=2)
+        assert summary.added == 3
+        assert summary.replaced == 1
+        assert summary.skipped == 2
+
+    def test_import_summary_field_validation(self):
+        """Test ImportSummary field type validation"""
+        with pytest.raises(ValidationError):
+            ImportSummary(added="not-an-int")
+
+
+class TestImportGatewayConfigurationResponse:
+    """Test cases for ImportGatewayConfigurationResponse model"""
+
+    def test_import_gateway_configuration_response_defaults(self):
+        """Test ImportGatewayConfigurationResponse default values"""
+        response = ImportGatewayConfigurationResponse()
+        assert response.added == []
+        assert response.replaced == []
+        assert response.skipped == []
+        assert response.summary is None
+
+    def test_import_gateway_configuration_response_full(self):
+        """Test ImportGatewayConfigurationResponse with all fields populated"""
+        response = ImportGatewayConfigurationResponse(
+            added=["res_1"],
+            replaced=["res_2"],
+            skipped=["res_3"],
+            summary=ImportSummary(added=1, replaced=1, skipped=1),
+        )
+        assert response.added == ["res_1"]
+        assert response.replaced == ["res_2"]
+        assert response.skipped == ["res_3"]
+        assert response.summary.added == 1
+
+    def test_import_gateway_configuration_response_summary_as_dict(self):
+        """Test ImportGatewayConfigurationResponse accepts a dict for summary"""
+        response = ImportGatewayConfigurationResponse(
+            added=[], replaced=[], skipped=[], summary={"added": 2}
+        )
+        assert isinstance(response.summary, ImportSummary)
+        assert response.summary.added == 2
+        assert response.summary.replaced == 0
+
+    def test_import_gateway_configuration_response_empty_dict_permissive(self):
+        """Test that an empty dict does not fail validation (permissive model)"""
+        response = ImportGatewayConfigurationResponse(**{})
+        assert response.added == []
+        assert response.replaced == []
+        assert response.skipped == []
+        assert response.summary is None
+
+    def test_import_gateway_configuration_response_undocumented_shape(self):
+        """Test that an undocumented dry-run diff shape doesn't crash validation"""
+        # Simulates an unknown check=true diff response shape - unrecognized
+        # keys should be ignored rather than raising a validation error.
+        undocumented = {"diff": {"unexpected": "shape"}, "other_field": 123}
+        response = ImportGatewayConfigurationResponse(**undocumented)
+        assert response.added == []
+        assert response.replaced == []
+        assert response.skipped == []
+        assert response.summary is None
 
 
 class TestModelInteroperability:

--- a/tests/test_services_gateway_manager.py
+++ b/tests/test_services_gateway_manager.py
@@ -1734,6 +1734,205 @@ class TestGetHealthStatus:
         assert result["status"] == "healthy"
 
 
+class TestExportConfiguration:
+    """Test cases for the export_configuration method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock client for testing"""
+        client = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create a Service instance with mocked client"""
+        service = Service(mock_client)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_export_configuration_success(self, service, mock_client):
+        """Test successful configuration export with raw dict passthrough"""
+        cluster_id = "cluster_1"
+        expected_document = {
+            "version": "1.0",
+            "resources": [{"type": "service", "name": "svc-1"}],
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_document
+        mock_client.get.return_value = mock_response
+
+        result = await service.export_configuration(cluster_id)
+
+        mock_client.get.assert_called_once_with(
+            f"/gateway_manager/v1/gateways/{cluster_id}/configuration/export"
+        )
+        assert result == expected_document
+
+    @pytest.mark.asyncio
+    async def test_export_configuration_client_error(self, service, mock_client):
+        """Test configuration export with client error"""
+        mock_client.get.side_effect = Exception("Gateway not connected")
+
+        with pytest.raises(Exception, match="Gateway not connected"):
+            await service.export_configuration("cluster_1")
+
+
+class TestImportConfiguration:
+    """Test cases for the import_configuration method"""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock client for testing"""
+        client = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create a Service instance with mocked client"""
+        service = Service(mock_client)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_import_configuration_content_source(self, service, mock_client):
+        """Test import with inline content source"""
+        cluster_id = "cluster_1"
+        content = {"version": "1.0", "resources": []}
+        expected_result = {
+            "added": ["res_1"],
+            "replaced": [],
+            "skipped": [],
+            "summary": {"added": 1, "replaced": 0, "skipped": 0},
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        result = await service.import_configuration(
+            cluster_id, source="content", content=content
+        )
+
+        expected_body = {
+            "options": {
+                "source": "content",
+                "force": False,
+                "validate": False,
+                "check": False,
+                "content": content,
+            }
+        }
+        mock_client.post.assert_called_once_with(
+            f"/gateway_manager/v1/gateways/{cluster_id}/configuration/import",
+            json=expected_body,
+        )
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_import_configuration_git_source(self, service, mock_client):
+        """Test import with git repository source"""
+        cluster_id = "cluster_1"
+        git = {
+            "url": "https://example.com/repo.git",
+            "file": "config.yml",
+            "reference": "main",
+            "username": "user",
+            "password": "pass",
+            "privateKey": "/path/to/key",
+        }
+        expected_result = {"added": [], "replaced": [], "skipped": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        result = await service.import_configuration(cluster_id, source="git", git=git)
+
+        expected_body = {
+            "options": {
+                "source": "git",
+                "force": False,
+                "validate": False,
+                "check": False,
+                "git": git,
+            }
+        }
+        mock_client.post.assert_called_once_with(
+            f"/gateway_manager/v1/gateways/{cluster_id}/configuration/import",
+            json=expected_body,
+        )
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_import_configuration_force_validate_check_passthrough(
+        self, service, mock_client
+    ):
+        """Test that force, validate, and check flags pass through to the request body"""
+        cluster_id = "cluster_1"
+        content = {"version": "1.0"}
+        expected_result = {"added": [], "replaced": [], "skipped": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        await service.import_configuration(
+            cluster_id,
+            source="content",
+            content=content,
+            force=True,
+            validate=True,
+            check=False,
+        )
+
+        expected_body = {
+            "options": {
+                "source": "content",
+                "force": True,
+                "validate": True,
+                "check": False,
+                "content": content,
+            }
+        }
+        mock_client.post.assert_called_once_with(
+            f"/gateway_manager/v1/gateways/{cluster_id}/configuration/import",
+            json=expected_body,
+        )
+
+    @pytest.mark.asyncio
+    async def test_import_configuration_response_passthrough(
+        self, service, mock_client
+    ):
+        """Test that the raw API response is passed through unchanged"""
+        cluster_id = "cluster_1"
+        expected_result = {
+            "added": ["a"],
+            "replaced": ["b"],
+            "skipped": ["c"],
+            "summary": {"added": 1, "replaced": 1, "skipped": 1},
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_result
+        mock_client.post.return_value = mock_response
+
+        result = await service.import_configuration(
+            cluster_id, source="content", content={"key": "value"}
+        )
+
+        assert result == expected_result
+
+    @pytest.mark.asyncio
+    async def test_import_configuration_client_error(self, service, mock_client):
+        """Test configuration import with client error"""
+        mock_client.post.side_effect = Exception("Gateway not connected")
+
+        with pytest.raises(Exception, match="Gateway not connected"):
+            await service.import_configuration(
+                "cluster_1", source="content", content={}
+            )
+
+
 class TestGetVersion:
     """Test cases for the get_version method"""
 

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -925,6 +925,26 @@ class TestExportGatewayConfiguration(TestGatewayManagerTools):
             )
 
     @pytest.mark.asyncio
+    async def test_export_gateway_configuration_unrecognized_result_raises(self):
+        """An unrecognized elicitation result raises AuthorizationException.
+
+        This proves the fail-closed guarantee does not implicitly depend on
+        ctx.elicit() only ever returning one of the known elicitation result
+        types -- if it ever returned something else, the function must still
+        raise rather than fall through the match and return None.
+        """
+        document = {"secrets": [{"name": "sec1"}]}
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(return_value=object())
+
+        with pytest.raises(AuthorizationException):
+            await export_gateway_configuration(
+                self.mock_context, cluster_id="cluster_1"
+            )
+
+    @pytest.mark.asyncio
     async def test_export_gateway_configuration_incapable_client_raises(self):
         """Incapable client raises AuthorizationException without calling elicit."""
         document = {"secrets": [{"name": "sec1"}]}

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -7,6 +7,11 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from fastmcp import Context
+from fastmcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
 
 from itential_mcp.tools.gateway_manager import (
     get_services,
@@ -14,6 +19,7 @@ from itential_mcp.tools.gateway_manager import (
     run_service,
     export_gateway_configuration,
     import_gateway_configuration,
+    _export_contains_sensitive_data,
 )
 from itential_mcp.models.gateway_manager import (
     ServiceElement,
@@ -24,7 +30,7 @@ from itential_mcp.models.gateway_manager import (
     ExportGatewayConfigurationResponse,
     ImportGatewayConfigurationResponse,
 )
-from itential_mcp.core.exceptions import ValidationException
+from itential_mcp.core.exceptions import AuthorizationException, ValidationException
 
 
 class TestGatewayManagerTools:
@@ -776,6 +782,238 @@ class TestExportGatewayConfiguration(TestGatewayManagerTools):
             await export_gateway_configuration(
                 self.mock_context, cluster_id="cluster_1"
             )
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_non_sensitive_no_elicit(self):
+        """Non-sensitive export returns normally without elicitation."""
+        document = {
+            "decorators": [],
+            "executable-objects": [],
+            "mcp_servers": [],
+            "registries": [],
+            "repositories": [],
+            "secret-providers": [],
+            "services": [{"name": "svc-1"}],
+        }
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock()
+        self.mock_context.elicit = AsyncMock()
+
+        result = await export_gateway_configuration(
+            self.mock_context, cluster_id="cluster_1"
+        )
+
+        assert isinstance(result, ExportGatewayConfigurationResponse)
+        assert result.root == document
+        self.mock_context.elicit.assert_not_called()
+        self.mock_context.session.check_client_capability.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_top_level_secrets_accept(self):
+        """Sensitive top-level secrets + capable client + accept returns data."""
+        document = {
+            "secrets": [{"name": "sec1", "value": "enc-value"}],
+            "users": [],
+            "services": [],
+        }
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(
+            return_value=AcceptedElicitation(data=True)
+        )
+
+        result = await export_gateway_configuration(
+            self.mock_context, cluster_id="cluster_1"
+        )
+
+        assert isinstance(result, ExportGatewayConfigurationResponse)
+        assert result.root == document
+        self.mock_context.elicit.assert_called_once()
+        self.mock_context.session.check_client_capability.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_top_level_users_accept(self):
+        """Sensitive top-level users (no secrets) + capable client + accept."""
+        document = {
+            "users": [{"name": "admin", "password": "hash"}],
+            "secrets": [],
+            "services": [],
+        }
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(
+            return_value=AcceptedElicitation(data=True)
+        )
+
+        result = await export_gateway_configuration(
+            self.mock_context, cluster_id="cluster_1"
+        )
+
+        assert isinstance(result, ExportGatewayConfigurationResponse)
+        assert result.root == document
+        self.mock_context.elicit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_nested_service_secrets_accept(self):
+        """Nested per-service secrets (no top-level secrets/users) still triggers."""
+        document = {
+            "services": [
+                {"name": "svc-1", "secrets": []},
+                {"name": "svc-2", "secrets": [{"name": "sec1"}]},
+            ],
+        }
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(
+            return_value=AcceptedElicitation(data=True)
+        )
+
+        result = await export_gateway_configuration(
+            self.mock_context, cluster_id="cluster_1"
+        )
+
+        assert isinstance(result, ExportGatewayConfigurationResponse)
+        assert result.root == document
+        self.mock_context.elicit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_declined_raises(self):
+        """DeclinedElicitation raises AuthorizationException."""
+        document = {"secrets": [{"name": "sec1"}]}
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(return_value=DeclinedElicitation())
+
+        with pytest.raises(AuthorizationException):
+            await export_gateway_configuration(
+                self.mock_context, cluster_id="cluster_1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_cancelled_raises(self):
+        """CancelledElicitation raises AuthorizationException."""
+        document = {"secrets": [{"name": "sec1"}]}
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(return_value=CancelledElicitation())
+
+        with pytest.raises(AuthorizationException):
+            await export_gateway_configuration(
+                self.mock_context, cluster_id="cluster_1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_accepted_false_raises(self):
+        """AcceptedElicitation(data=False) raises AuthorizationException."""
+        document = {"secrets": [{"name": "sec1"}]}
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(return_value=True)
+        self.mock_context.elicit = AsyncMock(
+            return_value=AcceptedElicitation(data=False)
+        )
+
+        with pytest.raises(AuthorizationException):
+            await export_gateway_configuration(
+                self.mock_context, cluster_id="cluster_1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_incapable_client_raises(self):
+        """Incapable client raises AuthorizationException without calling elicit."""
+        document = {"secrets": [{"name": "sec1"}]}
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock(
+            return_value=False
+        )
+        self.mock_context.elicit = AsyncMock()
+
+        with pytest.raises(AuthorizationException):
+            await export_gateway_configuration(
+                self.mock_context, cluster_id="cluster_1"
+            )
+
+        self.mock_context.elicit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_private_key_name_not_sensitive(self):
+        """A repositories entry with private-key-name alone does not trigger."""
+        document = {
+            "repositories": [
+                {"name": "repo-1", "private-key-name": "my-ssh-key"},
+            ],
+            "services": [],
+        }
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+        self.mock_context.session = MagicMock()
+        self.mock_context.session.check_client_capability = MagicMock()
+        self.mock_context.elicit = AsyncMock()
+
+        result = await export_gateway_configuration(
+            self.mock_context, cluster_id="cluster_1"
+        )
+
+        assert isinstance(result, ExportGatewayConfigurationResponse)
+        assert result.root == document
+        self.mock_context.elicit.assert_not_called()
+        self.mock_context.session.check_client_capability.assert_not_called()
+
+
+class TestExportContainsSensitiveData:
+    """Direct unit tests for the _export_contains_sensitive_data helper."""
+
+    def test_empty_dict(self):
+        """An empty document is not sensitive."""
+        assert _export_contains_sensitive_data({}) is False
+
+    def test_top_level_secrets_only(self):
+        """Non-empty top-level secrets triggers detection."""
+        document = {"secrets": [{"name": "sec1", "value": "enc"}]}
+        assert _export_contains_sensitive_data(document) is True
+
+    def test_top_level_users_only(self):
+        """Non-empty top-level users triggers detection."""
+        document = {"users": [{"name": "admin", "password": "hash"}]}
+        assert _export_contains_sensitive_data(document) is True
+
+    def test_nested_service_secrets_only(self):
+        """A service entry with non-empty secrets triggers detection."""
+        document = {
+            "services": [
+                {"name": "svc-1", "secrets": []},
+                {"name": "svc-2", "secrets": [{"name": "sec1"}]},
+            ]
+        }
+        assert _export_contains_sensitive_data(document) is True
+
+    def test_private_key_name_alone_not_sensitive(self):
+        """A repositories entry with private-key-name alone is not sensitive."""
+        document = {
+            "repositories": [{"name": "repo-1", "private-key-name": "my-ssh-key"}]
+        }
+        assert _export_contains_sensitive_data(document) is False
+
+    def test_fully_clean_document(self):
+        """A fully populated but non-sensitive document is not sensitive."""
+        document = {
+            "decorators": [{"name": "dec-1"}],
+            "executable-objects": [{"name": "obj-1"}],
+            "mcp_servers": [{"name": "mcp-1"}],
+            "registries": [{"name": "reg-1"}],
+            "repositories": [{"name": "repo-1", "private-key-name": "my-ssh-key"}],
+            "secret-providers": [],
+            "secrets": [],
+            "services": [{"name": "svc-1", "secrets": []}],
+            "users": [],
+        }
+        assert _export_contains_sensitive_data(document) is False
 
 
 class TestImportGatewayConfiguration(TestGatewayManagerTools):

--- a/tests/test_tools_gateway_manager.py
+++ b/tests/test_tools_gateway_manager.py
@@ -8,14 +8,23 @@ from unittest.mock import AsyncMock, MagicMock
 
 from fastmcp import Context
 
-from itential_mcp.tools.gateway_manager import get_services, get_gateways, run_service
+from itential_mcp.tools.gateway_manager import (
+    get_services,
+    get_gateways,
+    run_service,
+    export_gateway_configuration,
+    import_gateway_configuration,
+)
 from itential_mcp.models.gateway_manager import (
     ServiceElement,
     GetServicesResponse,
     GatewayElement,
     GetGatewaysResponse,
     RunServiceResponse,
+    ExportGatewayConfigurationResponse,
+    ImportGatewayConfigurationResponse,
 )
+from itential_mcp.core.exceptions import ValidationException
 
 
 class TestGatewayManagerTools:
@@ -34,6 +43,8 @@ class TestGatewayManagerTools:
         self.mock_gateway_manager_service.get_services = AsyncMock()
         self.mock_gateway_manager_service.get_gateways = AsyncMock()
         self.mock_gateway_manager_service.run_service = AsyncMock()
+        self.mock_gateway_manager_service.export_configuration = AsyncMock()
+        self.mock_gateway_manager_service.import_configuration = AsyncMock()
 
         # Attach gateway manager service to client
         self.mock_client.gateway_manager = self.mock_gateway_manager_service
@@ -722,6 +733,284 @@ class TestRunService(TestGatewayManagerTools):
         assert "Процесс завершен успешно" in result.stdout["messages"]
         assert "Opération réussie 🎉" in result.stdout["messages"]
         assert "Attention: mode de test activé ⚠️" in result.stderr
+
+
+class TestExportGatewayConfiguration(TestGatewayManagerTools):
+    """Test cases for export_gateway_configuration function."""
+
+    def test_export_gateway_configuration_function_exists(self):
+        """Test that export_gateway_configuration function exists and is callable."""
+        assert callable(export_gateway_configuration)
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_success(self):
+        """Test successful export returns the expected wrapped model."""
+        document = {
+            "version": "1.0",
+            "resources": [{"type": "service", "name": "svc-1"}],
+        }
+        self.mock_client.gateway_manager.export_configuration.return_value = document
+
+        result = await export_gateway_configuration(
+            self.mock_context, cluster_id="cluster_1"
+        )
+
+        self.mock_context.debug.assert_called_once_with(
+            "inside export_gateway_configuration(...)"
+        )
+        self.mock_client.gateway_manager.export_configuration.assert_called_once_with(
+            "cluster_1"
+        )
+
+        assert isinstance(result, ExportGatewayConfigurationResponse)
+        assert result.root == document
+
+    @pytest.mark.asyncio
+    async def test_export_gateway_configuration_client_error(self):
+        """Test export_gateway_configuration when client raises an exception."""
+        self.mock_client.gateway_manager.export_configuration.side_effect = Exception(
+            "Gateway not connected"
+        )
+
+        with pytest.raises(Exception, match="Gateway not connected"):
+            await export_gateway_configuration(
+                self.mock_context, cluster_id="cluster_1"
+            )
+
+
+class TestImportGatewayConfiguration(TestGatewayManagerTools):
+    """Test cases for import_gateway_configuration function."""
+
+    def test_import_gateway_configuration_function_exists(self):
+        """Test that import_gateway_configuration function exists and is callable."""
+        assert callable(import_gateway_configuration)
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_content_source_success(self):
+        """Test valid content-source call succeeds."""
+        expected_result = {
+            "added": ["res_1"],
+            "replaced": [],
+            "skipped": [],
+            "summary": {"added": 1, "replaced": 0, "skipped": 0},
+        }
+        self.mock_client.gateway_manager.import_configuration.return_value = (
+            expected_result
+        )
+
+        result = await import_gateway_configuration(
+            self.mock_context,
+            cluster_id="cluster_1",
+            content={"version": "1.0"},
+            git_url=None,
+            git_file=None,
+            git_reference=None,
+            git_username=None,
+            git_password=None,
+            git_private_key=None,
+            force=False,
+            validate=False,
+            check=False,
+        )
+
+        self.mock_client.gateway_manager.import_configuration.assert_called_once_with(
+            "cluster_1",
+            source="content",
+            content={"version": "1.0"},
+            git=None,
+            force=False,
+            validate=False,
+            check=False,
+        )
+
+        assert isinstance(result, ImportGatewayConfigurationResponse)
+        assert result.added == ["res_1"]
+        assert result.summary.added == 1
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_git_source_all_fields(self):
+        """Test valid git-source call succeeds with all git_* fields."""
+        expected_result = {"added": [], "replaced": [], "skipped": []}
+        self.mock_client.gateway_manager.import_configuration.return_value = (
+            expected_result
+        )
+
+        result = await import_gateway_configuration(
+            self.mock_context,
+            cluster_id="cluster_1",
+            content=None,
+            git_url="https://example.com/repo.git",
+            git_file="config.yml",
+            git_reference="main",
+            git_username="user",
+            git_password="pass",
+            git_private_key="/path/to/key",
+            force=True,
+            validate=False,
+            check=False,
+        )
+
+        expected_git = {
+            "url": "https://example.com/repo.git",
+            "file": "config.yml",
+            "reference": "main",
+            "username": "user",
+            "password": "pass",
+            "privateKey": "/path/to/key",
+        }
+        self.mock_client.gateway_manager.import_configuration.assert_called_once_with(
+            "cluster_1",
+            source="git",
+            content=None,
+            git=expected_git,
+            force=True,
+            validate=False,
+            check=False,
+        )
+
+        assert isinstance(result, ImportGatewayConfigurationResponse)
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_git_source_minimal(self):
+        """Test valid git-source call succeeds with only git_url and git_file."""
+        expected_result = {"added": [], "replaced": [], "skipped": []}
+        self.mock_client.gateway_manager.import_configuration.return_value = (
+            expected_result
+        )
+
+        await import_gateway_configuration(
+            self.mock_context,
+            cluster_id="cluster_1",
+            content=None,
+            git_url="https://example.com/repo.git",
+            git_file="config.yml",
+            git_reference=None,
+            git_username=None,
+            git_password=None,
+            git_private_key=None,
+            force=False,
+            validate=False,
+            check=False,
+        )
+
+        expected_git = {
+            "url": "https://example.com/repo.git",
+            "file": "config.yml",
+        }
+        self.mock_client.gateway_manager.import_configuration.assert_called_once_with(
+            "cluster_1",
+            source="git",
+            content=None,
+            git=expected_git,
+            force=False,
+            validate=False,
+            check=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_validate_and_check_raises(self):
+        """Test validate=True and check=True together raises ValidationException."""
+        with pytest.raises(ValidationException):
+            await import_gateway_configuration(
+                self.mock_context,
+                cluster_id="cluster_1",
+                content={"version": "1.0"},
+                git_url=None,
+                git_file=None,
+                git_reference=None,
+                git_username=None,
+                git_password=None,
+                git_private_key=None,
+                force=False,
+                validate=True,
+                check=True,
+            )
+
+        self.mock_client.gateway_manager.import_configuration.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_content_and_git_raises(self):
+        """Test content set AND git_url set together raises ValidationException."""
+        with pytest.raises(ValidationException):
+            await import_gateway_configuration(
+                self.mock_context,
+                cluster_id="cluster_1",
+                content={"version": "1.0"},
+                git_url="https://example.com/repo.git",
+                git_file=None,
+                git_reference=None,
+                git_username=None,
+                git_password=None,
+                git_private_key=None,
+                force=False,
+                validate=False,
+                check=False,
+            )
+
+        self.mock_client.gateway_manager.import_configuration.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_no_source_raises(self):
+        """Test neither content nor git_url set raises ValidationException."""
+        with pytest.raises(ValidationException):
+            await import_gateway_configuration(
+                self.mock_context,
+                cluster_id="cluster_1",
+                content=None,
+                git_url=None,
+                git_file=None,
+                git_reference=None,
+                git_username=None,
+                git_password=None,
+                git_private_key=None,
+                force=False,
+                validate=False,
+                check=False,
+            )
+
+        self.mock_client.gateway_manager.import_configuration.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_git_url_without_git_file_raises(self):
+        """Test git_url set without git_file raises ValidationException."""
+        with pytest.raises(ValidationException):
+            await import_gateway_configuration(
+                self.mock_context,
+                cluster_id="cluster_1",
+                content=None,
+                git_url="https://example.com/repo.git",
+                git_file=None,
+                git_reference=None,
+                git_username=None,
+                git_password=None,
+                git_private_key=None,
+                force=False,
+                validate=False,
+                check=False,
+            )
+
+        self.mock_client.gateway_manager.import_configuration.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_import_gateway_configuration_git_file_without_git_url_raises(self):
+        """Test git_file set without git_url raises ValidationException."""
+        with pytest.raises(ValidationException):
+            await import_gateway_configuration(
+                self.mock_context,
+                cluster_id="cluster_1",
+                content=None,
+                git_url=None,
+                git_file="config.yml",
+                git_reference=None,
+                git_username=None,
+                git_password=None,
+                git_private_key=None,
+                force=False,
+                validate=False,
+                check=False,
+            )
+
+        self.mock_client.gateway_manager.import_configuration.assert_not_called()
 
 
 class TestGatewayManagerToolsModule:


### PR DESCRIPTION
## Summary
Adds gateway configuration export/import capability to the `gateway_manager`
module, so callers can snapshot a Gateway 5 cluster's full DB configuration as
an opaque DSL document and re-import it — inline or from a git repository —
with validate/check dry-run modes.

MINOR-shaped change: two net-new public tools. No breaking changes.

## Changes
- **New tool `export_gateway_configuration`** — exports a Gateway 5 cluster's
  DB configuration as an opaque DSL document (passed through unchanged via a
  `RootModel[dict]` response, since the platform does not contract the shape).
- **New tool `import_gateway_configuration`** — imports a DB configuration from
  inline `content` or a git repo (`git_url`/`git_file`/`git_reference`/
  `git_username`/`git_password`/`git_private_key`), with `force`, `validate`,
  and `check` modes. Four client-side validation guards reject bad input
  combinations before any platform call: validate+check, content+git,
  neither-source, and one-sided git_url/git_file.
- **New service methods** `export_configuration` / `import_configuration` on the
  gateway_manager `Service`.
- **Response models** in `models/gateway_manager.py`. `ImportGatewayConfigurationResponse`
  has all fields optional/defaulted with no Union return type, so an
  undocumented `check=true` dry-run diff shape (which omits `summary` entirely)
  validates cleanly.

## Testing
- [x] Unit tests pass — `make ci` green (2678 tests; format, check, headers,
      bandit all clean)
- [x] Integration tests pass — verified live against a real Itential Platform:
      `export_gateway_configuration` on two real Gateway 5 clusters (returned a
      structurally sound DSL document); `import_gateway_configuration`
      round-trip in both no-write modes (`validate=True` and `check=True`),
      confirming live that the `check=true` response omits `summary` and still
      validates against the permissive model; all 4 validation guards confirmed
      live with exact error messages; invalid-cluster 404 propagates cleanly.
- [x] Manual testing — exercised both tools via `itential-mcp call`.
- Note: the destructive `force=True` write path was intentionally not exercised
  live (no safe throwaway cluster); its request-body construction is unit-tested
  and shares the code path with the validated modes.



---

## Update: added confirmation gate for sensitive exports (commits `2d31de7`, `fb08c45`)

**Summary**

Live review testing found that `export_gateway_configuration` returned a document containing real secrets and a user password hash with no warning. This adds a human-in-the-loop confirmation gate before such exports are returned. This is the first use of MCP elicitation (`ctx.elicit`) in this codebase.

**Changes**
- New helper `_export_contains_sensitive_data` detects top-level `secrets`/`users` and nested `services[].secrets`; deliberately excludes `repositories[].private-key-name` (a name reference, not key material).
- When sensitive data is present, `export_gateway_configuration` first checks the client's elicitation capability (`ctx.session.check_client_capability`) and fails closed with `AuthorizationException` if unsupported (no hang), then prompts for confirmation via `ctx.elicit(response_type=bool)`.
- Only an explicit accept returns the document; decline, cancel, `data=False`, and any unrecognized result all raise `AuthorizationException`. Reuses the existing `AuthorizationException` — no new exception class, no response-model changes.

**Testing**
- 16 new unit tests covering the detection helper (all documented cases incl. private-key-name exclusion) and every elicitation branch, including the fail-closed fallback and incapable-client paths; full suite 2694 tests passing via `make ci`.
- Live-tested against a real platform: accept path (real elicitation handler, real 5-secret/1-user cluster) returns the document; decline path and no-handler CLI path both fail closed with the expected message; verified no secret values appear in any output or error message.
- Independently confirmed live via Claude Desktop (a real MCP client with no elicitation support): attempting to export a secret-containing cluster correctly failed closed with a clear message, no hang, no data returned.
