### PR TITLE
feat: add Python 3.14 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@
 #
 # Jobs:
 #   quality  — format check, lint, copyright headers, security scan (runs once)
-#   test     — full test suite with coverage enforcement (matrix: 3.10–3.13)
+#   test     — full test suite with coverage enforcement (matrix: 3.10–3.14)
 #
 # The quality job runs on a single Python version since these checks are
 # version-agnostic. The test matrix runs independently so all versions
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ export PYTHONDONTWRITEBYTECODE := 1
 
 .PHONY: build certs check check-headers clean clean-venv container coverage \
         fix fix-headers format lint ci run security test \
-        tox tox-py310 tox-py311 tox-py312 tox-py313 \
+        tox tox-py310 tox-py311 tox-py312 tox-py313 tox-py314 \
         tox-coverage tox-format tox-lint tox-list tox-ci tox-security \
         help
 
@@ -102,7 +102,7 @@ container: ## Build multi-arch container image (amd64 + arm64)
 # Tox (multi-version testing)
 # ------------------------------------------------------------------------------
 
-tox: ## Run tests across all supported Python versions (3.10-3.13)
+tox: ## Run tests across all supported Python versions (3.10-3.14)
 	uv run tox
 
 tox-py310: ## Run tests with Python 3.10
@@ -116,6 +116,9 @@ tox-py312: ## Run tests with Python 3.12
 
 tox-py313: ## Run tests with Python 3.13
 	uv run tox -e py313
+
+tox-py314: ## Run tests with Python 3.14
+	uv run tox -e py314
 
 tox-coverage: ## Run tests with coverage report via tox
 	uv run tox -e coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 # This configuration uses tox-uv for faster dependency resolution and installation
 
 [tox]
-# Define test environments for Python 3.10, 3.11, 3.12, and 3.13
-envlist = py310,py311,py312,py313
+# Define test environments for Python 3.10, 3.11, 3.12, 3.13, and 3.14
+envlist = py310,py311,py312,py313,py314
 min_version = 4.0
 # Use uv for package installation (requires tox-uv plugin)
 requires =
@@ -54,6 +54,10 @@ description = Run tests with Python 3.12
 [testenv:py313]
 basepython = python3.13
 description = Run tests with Python 3.13
+
+[testenv:py314]
+basepython = python3.14
+description = Run tests with Python 3.14
 
 [testenv:coverage]
 # Special environment for running tests with coverage


### PR DESCRIPTION
## Summary

Adds Python 3.14 as a fifth tested/supported version in CI, alongside the
existing 3.10–3.13 (roadmap item #14). Purely additive — no existing
version's support changes, and no source or test code is touched.

CI uses `astral-sh/setup-uv` (not `actions/setup-python`), which serves
interpreters via python-build-standalone, so stable 3.14.x is already
available with no CI infrastructure change beyond the matrix entry. The only
two compiled dependencies — `cryptography` and `pydantic-core` — both ship
`cp314` wheels; the rest of the tree is pure-Python, so no dependency or
lockfile changes are needed (`uv.lock` is untouched).

## Changes

- `.github/workflows/ci.yaml`: add `'3.14'` to the test matrix
- `pyproject.toml`: add the `Programming Language :: Python :: 3.14` classifier
- `tox.ini`: add `py314` to `envlist` and a `[testenv:py314]` environment
- `Makefile`: add a `tox-py314` convenience target, register it in `.PHONY`,
  and update the `tox` help text to read 3.10–3.14

## Testing

Local pre-checks (all pass on Python 3.14.6):
- `make ci` → 2694 passed
- `uv run --python 3.14 pytest tests -v` → 2694 passed
- `make tox-py314` → py314: OK

Note: the local runs above are a pre-check only. **The authoritative
validation that 3.14 works on a real runner is this PR's own CI — watch the
`Test (Python 3.14)` matrix job in this PR's Actions run before merging.**

## Related Issues

Roadmap item #14 (widen supported-version surface). No CHANGELOG entry in this
PR by convention — it will be drafted at 0.14.0 release-cut time.
