### PR TITLE
feat: add MCP tool annotations, titles, and deterministic tool ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Purpose & Architecture
 
-Itential MCP is a production-grade Model Context Protocol (MCP) server that bridges AI agents with the Itential Platform — a network automation and orchestration system. It exposes 56+ tools across 10 functional categories (health, device config, workflow execution, lifecycle management, adapters, applications, compliance, projects, gateway, operations), allowing AI agents to configure devices, execute workflows, run compliance checks, and monitor platform health through a standardized MCP interface.
+Itential MCP is a production-grade Model Context Protocol (MCP) server that bridges AI agents with the Itential Platform — a network automation and orchestration system. It exposes 76+ tools across 10 functional categories (health, device config, workflow execution, lifecycle management, adapters, applications, compliance, projects, gateway, operations), allowing AI agents to configure devices, execute workflows, run compliance checks, and monitor platform health through a standardized MCP interface.
 
 **Primary data flow:**
 
@@ -237,10 +237,40 @@ Config objects are frozen Pydantic dataclasses — attempting to set attributes 
 1. Create `src/itential_mcp/tools/my_feature.py` with `__tags__` and async functions returning Pydantic models
 2. Create `src/itential_mcp/models/my_feature.py` with response models
 3. If the tool needs API calls, add `src/itential_mcp/platform/services/my_feature.py` with a `Service` class having `name = "my_feature"`
-4. Write tests in `tests/test_tools_my_feature.py`
-5. Run `make ci`
+4. Decorate every tool function with `@annotate(...)` from `itential_mcp.utilities.tool`, declaring at minimum `read_only` (or `destructive`) correctly. A tool that mutates or destroys platform state must never default to looking safe — never leave `readOnlyHint` unset/true on a mutating tool, and any destructive operation must set `destructive=True`. This is enforced in CI, not just style guidance: `tests/utilities/test_tool.py` has a completeness guard (`TestToolAnnotationCompleteness`) that fails if any discovered tool lacks `@annotate(...)`, and a safety-invariant test (`TestToolAnnotationSafetyInvariants`) that fails if any tool is simultaneously `readOnlyHint=True` and `destructiveHint=True`.
+5. Write tests in `tests/test_tools_my_feature.py`
+6. Run `make ci`
 
 Tools are discovered automatically — no registration code needed.
+
+**`@annotate(...)` examples:**
+
+Read-only tool (`src/itential_mcp/tools/health.py`):
+
+```python
+from itential_mcp.utilities.tool import annotate
+
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Health")
+async def get_health(ctx: Context) -> HealthResponse:
+    ...
+```
+
+Destructive tool (`src/itential_mcp/tools/devices.py`):
+
+```python
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Apply Device Configuration",
+)
+async def apply_device_configuration(
+    ctx: Context,
+    device: str,
+    config: str,
+) -> models.ApplyDeviceConfigurationResponse:
+    ...
+```
 
 ### New Service Plugin
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,7 @@ Examples:
 - [ ] Run code quality checks: `make lint`
 - [ ] Add tests for new functionality
 - [ ] Update documentation if needed
+- [ ] If this PR adds or changes a tool, confirm it has correct `@annotate(...)` classification (read-only vs. write vs. destructive)
 - [ ] Sign the Contributor License Agreement (CLA)
 
 ### Pull Request Description

--- a/src/itential_mcp/bindings/__init__.py
+++ b/src/itential_mcp/bindings/__init__.py
@@ -10,6 +10,8 @@ from typing import Tuple, Callable, Mapping, Any
 
 from fastmcp.utilities.logging import get_logger
 
+from mcp.types import ToolAnnotations
+
 from .. import config
 from ..platform import PlatformClient
 
@@ -43,6 +45,23 @@ def _import_binding(module_name: str) -> ModuleType:
     spec.loader.exec_module(module)
 
     return module
+
+
+def _humanize_title(name: str) -> str:
+    """Convert a snake_case tool name into a human-readable title.
+
+    Args:
+        name (str): The tool name, typically snake_case (e.g. `tool_name`
+            from a dynamic binding's configuration).
+
+    Returns:
+        str: A title-cased, space-separated human-readable title (e.g.
+            "Deploy Configuration").
+
+    Raises:
+        None
+    """
+    return " ".join(part.capitalize() for part in name.split("_") if part)
 
 
 async def bind_to_tool(
@@ -88,6 +107,10 @@ async def bind_to_tool(
                 - description: Tool description from binding module
                 - tags: Complete list of tags for filtering
                 - exclude_args: Arguments to hide from MCP schema
+                - annotations: Conservative ToolAnnotations (destructive,
+                    not read-only, open-world) since the bound automation's
+                    real-world effects are unknown at registration time
+                - title: A humanized title derived from the tool's name
 
     Raises:
         AttributeError: If the tool type module doesn't have a 'new' function.
@@ -96,10 +119,20 @@ async def bind_to_tool(
     logger.info(f"Adding dynamic binding for tool: {tool.name} (type={tool.type})")
 
     # Step 1: Prepare base registration kwargs
-    # exclude_args hides internal parameters from the MCP tool schema
+    # exclude_args hides internal parameters from the MCP tool schema.
+    # annotations default to the conservative posture (destructive,
+    # not-read-only, open-world) because a dynamically-bound tool triggers
+    # an arbitrary platform automation/workflow whose effects are unknown to
+    # us at registration time.
     kwargs = {
         "name": tool.tool_name,
         "exclude_args": ("_tool_config",),
+        "annotations": ToolAnnotations(
+            destructiveHint=True,
+            readOnlyHint=False,
+            openWorldHint=True,
+        ),
+        "title": _humanize_title(tool.tool_name),
     }
 
     # Step 2: Import the appropriate binding module for this tool type

--- a/src/itential_mcp/server/server.py
+++ b/src/itential_mcp/server/server.py
@@ -193,7 +193,14 @@ class Server:
         self.mcp.custom_route("/status/livez", methods=["GET"])(routes.get_livez)
 
     async def __init_tools__(self) -> None:
-        """Initialize tools."""
+        """Initialize tools.
+
+        Discovers and registers all static tools from the built-in tools
+        directory and, if configured, an additional `tools_path` directory.
+        Discovery order is deterministic (name-sorted) via
+        `toolutils.itertools()`, and each tool's `@annotate(...)` hints, if
+        any, are passed through to FastMCP as tool `annotations`/`title`.
+        """
         logging.info("Adding tools to MCP server")
 
         tool_paths = [pathlib.Path(__file__).parent.parent / "tools"]
@@ -205,9 +212,12 @@ class Server:
 
         for ele in tool_paths:
             logger.info(f"Adding MCP Tools from {ele}")
-            for f, tags in toolutils.itertools(ele):
+            for f, tags, annotations in toolutils.itertools(ele):
                 tags.add("default")
                 kwargs = {"tags": tags}
+
+                if annotations is not None:
+                    kwargs["annotations"] = annotations
 
                 try:
                     schema = toolutils.get_json_schema(f)

--- a/src/itential_mcp/tools/adapters.py
+++ b/src/itential_mcp/tools/adapters.py
@@ -9,11 +9,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import adapters as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("adapters",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Adapters")
 async def get_adapters(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetAdaptersResponse:
@@ -49,6 +51,12 @@ async def get_adapters(
     return models.GetAdaptersResponse(elements)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Start Adapter",
+)
 async def start_adapter(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the adapter to start")],
@@ -87,6 +95,12 @@ async def start_adapter(
     return models.StartAdapterResponse(name=data["id"], state=data["state"])
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Stop Adapter",
+)
 async def stop_adapter(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the adapter to stop")],
@@ -125,6 +139,12 @@ async def stop_adapter(
     return models.StopAdapterResponse(name=data["id"], state=data["state"])
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Restart Adapter",
+)
 async def restart_adapter(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the adapter to restart")],

--- a/src/itential_mcp/tools/adapters.py
+++ b/src/itential_mcp/tools/adapters.py
@@ -53,7 +53,7 @@ async def get_adapters(
 
 @annotate(
     read_only=False,
-    destructive=False,
+    destructive=True,
     open_world=True,
     title="Start Adapter",
 )
@@ -97,7 +97,7 @@ async def start_adapter(
 
 @annotate(
     read_only=False,
-    destructive=False,
+    destructive=True,
     open_world=True,
     title="Stop Adapter",
 )
@@ -141,7 +141,7 @@ async def stop_adapter(
 
 @annotate(
     read_only=False,
-    destructive=False,
+    destructive=True,
     open_world=True,
     title="Restart Adapter",
 )

--- a/src/itential_mcp/tools/agent_session_manager.py
+++ b/src/itential_mcp/tools/agent_session_manager.py
@@ -15,6 +15,7 @@ from fastmcp import Context
 
 from itential_mcp.core.exceptions import ValidationException
 from itential_mcp.utilities import time as timeutils
+from itential_mcp.utilities.tool import annotate
 from itential_mcp.models import agent_session_manager as models
 
 
@@ -181,6 +182,7 @@ def _parse_timestamp(value: str) -> datetime:
         raise ValidationException(f"Invalid ISO 8601 timestamp: {value!r}") from exc
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Sessions")
 async def get_sessions(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     agent_name: Annotated[
@@ -248,6 +250,7 @@ async def get_sessions(
     return models.GetSessionsResponse(root=session_elements)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Describe Session")
 async def describe_session(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     session_id: Annotated[
@@ -332,6 +335,12 @@ async def describe_session(
     )
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Agent Token Usage",
+)
 async def get_agent_token_usage(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     agent_name: Annotated[
@@ -480,6 +489,12 @@ async def get_agent_token_usage(
     return models.GetAgentTokenUsageResponse(root=stats)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Agent Session Token Usage",
+)
 async def get_agent_session_token_usage(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     agent_name: Annotated[
@@ -610,6 +625,12 @@ async def get_agent_session_token_usage(
     return models.GetAgentSessionTokenUsageResponse(root=elements)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Session Token Usage",
+)
 async def describe_session_token_usage(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     session_id: Annotated[

--- a/src/itential_mcp/tools/applications.py
+++ b/src/itential_mcp/tools/applications.py
@@ -9,11 +9,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import applications as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("applications",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Applications")
 async def get_applications(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetApplicationsResponse:
@@ -54,6 +56,12 @@ async def get_applications(
     return models.GetApplicationsResponse(root=elements)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Start Application",
+)
 async def start_application(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the application to start")],
@@ -92,6 +100,12 @@ async def start_application(
     return models.StartApplicationResponse(name=data["id"], state=data["state"])
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Stop Application",
+)
 async def stop_application(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the application to stop")],
@@ -130,6 +144,12 @@ async def stop_application(
     return models.StopApplicationResponse(name=data["id"], state=data["state"])
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Restart Application",
+)
 async def restart_application(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the application to restart")],

--- a/src/itential_mcp/tools/applications.py
+++ b/src/itential_mcp/tools/applications.py
@@ -58,7 +58,7 @@ async def get_applications(
 
 @annotate(
     read_only=False,
-    destructive=False,
+    destructive=True,
     open_world=True,
     title="Start Application",
 )
@@ -102,7 +102,7 @@ async def start_application(
 
 @annotate(
     read_only=False,
-    destructive=False,
+    destructive=True,
     open_world=True,
     title="Stop Application",
 )
@@ -146,7 +146,7 @@ async def stop_application(
 
 @annotate(
     read_only=False,
-    destructive=False,
+    destructive=True,
     open_world=True,
     title="Restart Application",
 )

--- a/src/itential_mcp/tools/command_templates.py
+++ b/src/itential_mcp/tools/command_templates.py
@@ -7,12 +7,19 @@ from pydantic import Field
 
 from fastmcp import Context
 from itential_mcp.utilities import json as jsonutils
+from itential_mcp.utilities.tool import annotate
 from itential_mcp.models import command_templates as models
 
 
 __tags__ = ("automation_studio",)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Command Templates",
+)
 async def get_command_templates(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetCommandTemplatesResponse:
@@ -49,6 +56,12 @@ async def get_command_templates(
     return models.GetCommandTemplatesResponse(templates=results)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Command Template",
+)
 async def describe_command_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -87,6 +100,12 @@ async def describe_command_template(
     return models.DescribeCommandTemplateResponse(template=template)
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Run Command Template",
+)
 async def run_command_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the command template to run")],
@@ -158,6 +177,12 @@ async def run_command_template(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Run Command",
+)
 async def run_command(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     cmd: Annotated[str, Field(description="The command to run on the devices")],
@@ -198,6 +223,12 @@ async def run_command(
     return models.RunCommandResponse(results=results)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Command Template",
+)
 async def create_command_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="Name for the command template")],
@@ -342,6 +373,12 @@ async def create_command_template(
     return models.CreateCommandTemplateResponse(**data)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Update Command Template",
+)
 async def update_command_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="Name of the command template to update")],

--- a/src/itential_mcp/tools/compliance_plans.py
+++ b/src/itential_mcp/tools/compliance_plans.py
@@ -9,11 +9,18 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import compliance_plans as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("configuration_manager",)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Compliance Plans",
+)
 async def get_compliance_plans(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetCompliancePlansResponse:
@@ -38,6 +45,12 @@ async def get_compliance_plans(
     return models.GetCompliancePlansResponse(plans=results)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Run Compliance Plan",
+)
 async def run_compliance_plan(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the compliance plan to run")],

--- a/src/itential_mcp/tools/compliance_reports.py
+++ b/src/itential_mcp/tools/compliance_reports.py
@@ -9,11 +9,18 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import compliance_reports as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("configuration_manager",)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Compliance Report",
+)
 async def describe_compliance_report(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     report_id: Annotated[str, Field(description="The ID of the report to describe")],

--- a/src/itential_mcp/tools/configuration_manager.py
+++ b/src/itential_mcp/tools/configuration_manager.py
@@ -9,12 +9,19 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.utilities import json as jsonutils
+from itential_mcp.utilities.tool import annotate
 from itential_mcp.models import configuration_manager as models
 
 
 __tags__ = ("configuration_manager",)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Render Template",
+)
 async def render_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     template: Annotated[str, Field(description="The Jinja2 template string")],

--- a/src/itential_mcp/tools/device_groups.py
+++ b/src/itential_mcp/tools/device_groups.py
@@ -9,11 +9,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import device_groups as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("configuration_manager",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Device Groups")
 async def get_device_groups(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetDeviceGroupsResponse:
@@ -48,6 +50,12 @@ async def get_device_groups(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Device Group",
+)
 async def create_device_group(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the device group to create")],
@@ -93,6 +101,13 @@ async def create_device_group(
     return models.CreateDeviceGroupResponse(**res)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    idempotent=True,
+    open_world=False,
+    title="Add Devices to Group",
+)
 async def add_devices_to_group(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -151,6 +166,12 @@ async def add_devices_to_group(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=False,
+    title="Remove Devices from Group",
+)
 async def remove_devices_from_group(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[

--- a/src/itential_mcp/tools/devices.py
+++ b/src/itential_mcp/tools/devices.py
@@ -9,11 +9,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import devices as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("configuration_manager",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Devices")
 async def get_devices(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetDevicesResponse:
@@ -39,6 +41,12 @@ async def get_devices(
     return models.GetDevicesResponse(results)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=True,
+    title="Get Device Configuration",
+)
 async def get_device_configuration(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -64,6 +72,12 @@ async def get_device_configuration(
     return await client.configuration_manager.get_device_configuration(name)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Backup Device Configuration",
+)
 async def backup_device_configuration(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the device to backup")],
@@ -104,6 +118,12 @@ async def backup_device_configuration(
     return models.BackupDeviceConfigurationResponse(**res)
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Apply Device Configuration",
+)
 async def apply_device_configuration(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     device: Annotated[

--- a/src/itential_mcp/tools/gateway_manager.py
+++ b/src/itential_mcp/tools/gateway_manager.py
@@ -16,6 +16,7 @@ from fastmcp.server.elicitation import (
 from mcp.types import ClientCapabilities, ElicitationCapability
 
 from itential_mcp.utilities import json as jsonutils
+from itential_mcp.utilities.tool import annotate
 from itential_mcp.core import exceptions
 
 from itential_mcp.models import gateway_manager as models
@@ -58,6 +59,7 @@ def _export_contains_sensitive_data(document: dict[str, Any]) -> bool:
     return False
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Services")
 async def get_services(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetServicesResponse:
@@ -100,6 +102,7 @@ async def get_services(
     return models.GetServicesResponse(results)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Gateways")
 async def get_gateways(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetGatewaysResponse:
@@ -154,6 +157,12 @@ async def get_gateways(
     return models.GetGatewaysResponse(results)
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Run Service",
+)
 async def run_service(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the service to run")],
@@ -215,6 +224,12 @@ async def run_service(
     return models.RunServiceResponse(**res["result"])
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=True,
+    title="Export Gateway Configuration",
+)
 async def export_gateway_configuration(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     cluster_id: Annotated[
@@ -292,6 +307,12 @@ async def export_gateway_configuration(
             )
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Import Gateway Configuration",
+)
 async def import_gateway_configuration(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     cluster_id: Annotated[

--- a/src/itential_mcp/tools/golden_config.py
+++ b/src/itential_mcp/tools/golden_config.py
@@ -11,6 +11,7 @@ from fastmcp import Context
 from itential_mcp.core import exceptions
 from itential_mcp.core import errors
 from itential_mcp.utilities import json as jsonutils
+from itential_mcp.utilities.tool import annotate
 
 from itential_mcp.models import configuration_manager as models
 
@@ -18,6 +19,12 @@ from itential_mcp.models import configuration_manager as models
 __tags__ = ("configuration_manager",)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Golden Config Trees",
+)
 async def get_golden_config_trees(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetGoldenConfigTreesResponse:
@@ -58,6 +65,12 @@ async def get_golden_config_trees(
     return models.GetGoldenConfigTreesResponse(root=results)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Golden Config Tree",
+)
 async def create_golden_config_tree(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -125,6 +138,12 @@ async def create_golden_config_tree(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Add Golden Config Node",
+)
 async def add_golden_config_node(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     tree_name: Annotated[

--- a/src/itential_mcp/tools/health.py
+++ b/src/itential_mcp/tools/health.py
@@ -10,11 +10,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models.health import HealthResponse
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("health",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Health")
 async def get_health(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> HealthResponse:

--- a/src/itential_mcp/tools/integrations.py
+++ b/src/itential_mcp/tools/integrations.py
@@ -9,12 +9,14 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.core import exceptions
+from itential_mcp.utilities.tool import annotate
 from itential_mcp.models import integrations as models
 
 
 __tags__ = ("integrations",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Integrations")
 async def get_integrations(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     model: Annotated[
@@ -67,6 +69,12 @@ async def get_integrations(
     return models.GetIntegrationsResponse(root=results)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Integration Models",
+)
 async def get_integration_models(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetIntegrationModelsResponse:
@@ -108,6 +116,12 @@ async def get_integration_models(
     return models.GetIntegrationModelsResponse(root=results)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Integration Model",
+)
 async def create_integration_model(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     model: Annotated[dict, Field(description="OpenAPI specification")],

--- a/src/itential_mcp/tools/inventory_manager.py
+++ b/src/itential_mcp/tools/inventory_manager.py
@@ -9,11 +9,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import inventory_manager as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("inventory_manager",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Inventories")
 async def get_inventories(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetInventoriesResponse:
@@ -49,6 +51,12 @@ async def get_inventories(
     )
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Inventory",
+)
 async def describe_inventory(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -90,6 +98,12 @@ async def describe_inventory(
     return models.DescribeInventoryResponse(**data)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Inventory",
+)
 async def create_inventory(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -153,6 +167,12 @@ async def create_inventory(
     return models.CreateInventoryResponse(**res)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Add Nodes to Inventory",
+)
 async def add_nodes_to_inventory(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     inventory_name: Annotated[
@@ -215,6 +235,12 @@ async def add_nodes_to_inventory(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=False,
+    title="Delete Inventory",
+)
 async def delete_inventory(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[

--- a/src/itential_mcp/tools/lifecycle_manager.py
+++ b/src/itential_mcp/tools/lifecycle_manager.py
@@ -13,12 +13,14 @@ from fastmcp import Context
 from itential_mcp.core import exceptions
 from itential_mcp.core import errors
 from itential_mcp.utilities import json as jsonutils
+from itential_mcp.utilities.tool import annotate
 from itential_mcp.models import lifecycle_manager as models
 
 
 __tags__ = ("lifecycle_manager",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Resources")
 async def get_resources(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetResourcesResponse:
@@ -56,6 +58,12 @@ async def get_resources(
     return models.GetResourcesResponse(root=results)
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Resource",
+)
 async def create_resource(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -110,6 +118,12 @@ async def create_resource(
     return models.CreateResourceResponse()
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Resource",
+)
 async def describe_resource(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -187,6 +201,7 @@ async def describe_resource(
     )
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Instances")
 async def get_instances(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     resource_name: Annotated[
@@ -239,6 +254,12 @@ async def get_instances(
     return models.GetInstancesResponse(root=results)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Instance",
+)
 async def describe_instance(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     resource_name: Annotated[
@@ -290,6 +311,12 @@ async def describe_instance(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Run Action",
+)
 async def run_action(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     resource_name: Annotated[
@@ -372,6 +399,12 @@ async def run_action(
     )
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Action Executions",
+)
 async def get_action_executions(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     resource_name: Annotated[

--- a/src/itential_mcp/tools/operations_manager.py
+++ b/src/itential_mcp/tools/operations_manager.py
@@ -15,6 +15,7 @@ from fastmcp import Context
 from itential_mcp.utilities import time as timeutils
 from itential_mcp.core import exceptions
 from itential_mcp.utilities import json as jsonutils
+from itential_mcp.utilities.tool import annotate
 
 from itential_mcp.models import operations_manager as models
 
@@ -114,6 +115,7 @@ async def _account_id_to_username(ctx: Context, account_id: str) -> str:
     return value
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Workflows")
 async def get_workflows(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetWorkflowsResponse:
@@ -170,6 +172,7 @@ async def get_workflows(
     return models.GetWorkflowsResponse(root=workflow_elements)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Agents")
 async def get_agents(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetAgentsResponse:
@@ -220,6 +223,7 @@ async def get_agents(
     return models.GetAgentsResponse(root=agent_elements)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Automations")
 async def get_automations(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetAutomationsResponse:
@@ -274,6 +278,12 @@ async def get_automations(
     return models.GetAutomationsResponse(root=elements)
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Trigger Automation",
+)
 async def trigger_automation(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     route_name: Annotated[
@@ -379,6 +389,12 @@ async def trigger_automation(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=True,
+    open_world=True,
+    title="Start Workflow",
+)
 async def start_workflow(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     route_name: Annotated[
@@ -411,6 +427,7 @@ async def start_workflow(
     return await trigger_automation(ctx, route_name, data)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Jobs")
 async def get_jobs(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -463,6 +480,7 @@ async def get_jobs(
     return models.GetJobsResponse(root=job_elements)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Describe Job")
 async def describe_job(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     object_id: Annotated[str, Field(description="The ID used to retrieve the job")],
@@ -512,6 +530,12 @@ async def describe_job(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Expose Workflow",
+)
 async def expose_workflow(
     ctx: Annotated[
         Context,
@@ -623,6 +647,12 @@ async def expose_workflow(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Expose Agent",
+)
 async def expose_agent(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     agent_id: Annotated[

--- a/src/itential_mcp/tools/projects.py
+++ b/src/itential_mcp/tools/projects.py
@@ -11,11 +11,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import projects as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("automation_studio",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Projects")
 async def get_projects(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetProjectsResponse:
@@ -55,6 +57,12 @@ async def get_projects(
     return models.GetProjectsResponse(root=results)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Project",
+)
 async def describe_project(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the project to describe")],

--- a/src/itential_mcp/tools/templates.py
+++ b/src/itential_mcp/tools/templates.py
@@ -11,11 +11,13 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import templates as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("automation_studio",)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Templates")
 async def get_templates(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     template_type: Annotated[
@@ -69,6 +71,12 @@ async def get_templates(
     return results
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Describe Template",
+)
 async def describe_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the template to describe")],
@@ -117,6 +125,12 @@ async def describe_template(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Create Template",
+)
 async def create_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the template to create")],
@@ -211,6 +225,12 @@ async def create_template(
     )
 
 
+@annotate(
+    read_only=False,
+    destructive=False,
+    open_world=False,
+    title="Update Template",
+)
 async def update_template(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[str, Field(description="The name of the template to update")],

--- a/src/itential_mcp/tools/workflow_engine.py
+++ b/src/itential_mcp/tools/workflow_engine.py
@@ -9,6 +9,7 @@ from pydantic import Field
 from fastmcp import Context
 
 from itential_mcp.models import workflow_engine as models
+from itential_mcp.utilities.tool import annotate
 
 
 __tags__ = ("workflow_engine",)
@@ -48,6 +49,7 @@ async def _get_job_metrics(
     return models.GetJobMetricsResponse(res)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Job Metrics")
 async def get_job_metrics(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetJobMetricsResponse:
@@ -75,6 +77,12 @@ async def get_job_metrics(
     return await _get_job_metrics(ctx)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Job Metrics for Workflow",
+)
 async def get_job_metrics_for_workflow(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -145,6 +153,7 @@ async def _get_task_metrics(
     return models.GetTaskMetricsResponse(res)
 
 
+@annotate(read_only=True, idempotent=True, open_world=False, title="Get Task Metrics")
 async def get_task_metrics(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
 ) -> models.GetTaskMetricsResponse:
@@ -173,6 +182,12 @@ async def get_task_metrics(
     return await _get_task_metrics(ctx)
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Task Metrics for Workflow",
+)
 async def get_task_metrics_for_workflow(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -210,6 +225,12 @@ async def get_task_metrics_for_workflow(
     )
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Task Metrics for App",
+)
 async def get_task_metrics_for_app(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[
@@ -248,6 +269,12 @@ async def get_task_metrics_for_app(
     return await _get_task_metrics(ctx, params={"equalsField": "app", "equals": name})
 
 
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Task Metrics for Task",
+)
 async def get_task_metrics_for_task(
     ctx: Annotated[Context, Field(description="The FastMCP Context object")],
     name: Annotated[

--- a/src/itential_mcp/utilities/tool.py
+++ b/src/itential_mcp/utilities/tool.py
@@ -10,10 +10,12 @@ import pathlib
 import importlib.util
 import types
 
-from typing import Any, Callable, Iterator, Tuple, Sequence, Union
+from typing import Any, Callable, Iterator, Sequence, Union
 from typing import get_type_hints, get_origin, get_args
 
 from pydantic import BaseModel, TypeAdapter
+
+from mcp.types import ToolAnnotations
 
 from ..cli import terminal
 
@@ -49,6 +51,73 @@ def tags(*tag_list) -> Callable:
 
     def decorator(func):
         setattr(func, "tags", list(tag_list))
+        return func
+
+    return decorator
+
+
+def annotate(
+    *,
+    read_only: bool | None = None,
+    destructive: bool | None = None,
+    idempotent: bool | None = None,
+    open_world: bool | None = None,
+    title: str | None = None,
+) -> Callable:
+    """
+    Decorator that attaches MCP tool annotation hints to a function
+
+    This decorator when called will attach a `mcp.types.ToolAnnotations`
+    instance to a function as its `annotations` attribute. The annotations
+    are advisory hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`,
+    `openWorldHint`, `title`) describing the tool's behavior to MCP clients,
+    which is separate from and unrelated to the tags system.
+
+    To use this decorator, import the function into the tools module and
+    decorate the target tool as shown below.
+
+    ```
+    from itential_mcp.utilities.tool import annotate
+
+    @annotate(read_only=True, idempotent=True, title="Get Health")
+    async def get_health(ctx: Context) -> HealthResponse:
+        ...
+    ```
+
+    Args:
+        read_only (bool | None): Whether the tool only reads state and never
+            modifies it. Defaults to None (unspecified).
+        destructive (bool | None): Whether the tool may perform destructive
+            updates (only meaningful when `read_only` is not True). Defaults
+            to None (unspecified).
+        idempotent (bool | None): Whether calling the tool repeatedly with
+            the same arguments has no additional effect. Defaults to None
+            (unspecified).
+        open_world (bool | None): Whether the tool interacts with an "open
+            world" of external entities (e.g. live network devices).
+            Defaults to None (unspecified).
+        title (str | None): A human-readable title for the tool. Defaults to
+            None (unspecified).
+
+    Returns:
+        Callable: A callable decorated function
+
+    Raises:
+        None
+    """
+
+    def decorator(func):
+        setattr(
+            func,
+            "annotations",
+            ToolAnnotations(
+                readOnlyHint=read_only,
+                destructiveHint=destructive,
+                idempotentHint=idempotent,
+                openWorldHint=open_world,
+                title=title,
+            ),
+        )
         return func
 
     return decorator
@@ -99,14 +168,17 @@ def get_json_schema(fn: Callable) -> dict[str, Any]:
     return ret.model_json_schema()
 
 
-def itertools(path: str) -> Iterator[Tuple[Callable, Sequence]]:
+def itertools(
+    path: str,
+) -> Iterator[tuple[Callable, Sequence, ToolAnnotations | None]]:
     """
     Iterate through all discovered tools.
 
     This function implements dynamic tool discovery by scanning a directory
     for Python modules and extracting callable functions. It supports a
     hierarchical tagging system where tags can be defined at both the module
-    level and function level.
+    level and function level, and reads back any `ToolAnnotations` attached
+    via the `@annotate(...)` decorator.
 
     **Tool Discovery Process:**
     1. Scan directory for .py files (excluding __init__.py and _private.py)
@@ -114,7 +186,8 @@ def itertools(path: str) -> Iterator[Tuple[Callable, Sequence]]:
     3. Extract module-level __tags__ if present
     4. Inspect module for public functions (not starting with _)
     5. Combine module tags with function-level tags
-    6. Yield function and complete tag set
+    6. Read back any function-level ToolAnnotations
+    7. Yield function, complete tag set, and annotations
 
     **Tagging Hierarchy:**
     - Module-level tags (__tags__): Apply to all functions in the module
@@ -122,23 +195,34 @@ def itertools(path: str) -> Iterator[Tuple[Callable, Sequence]]:
     - Function name: Automatically added as a tag
     - All tags are accumulated into a set per function
 
+    **Ordering:**
+    Module files and function members are both discovered in a stable,
+    name-sorted order so that `tools/list` registration order is
+    deterministic across runs and platforms.
+
     Args:
         path (str): The filesystem path to scan for tool modules.
 
     Yields:
-        Tuple[Callable, Sequence]: Each iteration yields a tuple of:
+        tuple[Callable, Sequence, ToolAnnotations | None]: Each iteration
+            yields a tuple of:
             - Callable: The tool function ready for registration
             - Sequence: Set of tags associated with this tool
+            - ToolAnnotations | None: The tool's annotation hints, if any
+                were attached via the `@annotate(...)` decorator
 
     Raises:
         None: Errors during module loading are silently ignored to allow
             partial tool loading if some modules fail.
     """
     # Step 1: Discover all Python module files in the tools directory
-    # Filter out __init__.py and any files without .py extension
-    module_files = [
+    # Filter out __init__.py and any files without .py extension. Sort the
+    # result so module import (and therefore tool registration) order is
+    # deterministic across runs/platforms rather than depending on
+    # os.listdir()'s unspecified ordering.
+    module_files = sorted(
         f[:-3] for f in os.listdir(path) if f.endswith(".py") and f != "__init__.py"
-    ]
+    )
 
     # Step 2: Import each discovered module and extract tools
     for module_name in module_files:
@@ -158,7 +242,10 @@ def itertools(path: str) -> Iterator[Tuple[Callable, Sequence]]:
             if hasattr(module, "__tags__"):
                 module_tags = set(module.__tags__)
 
-            # Step 4: Inspect module for all function members
+            # Step 4: Inspect module for all function members. inspect.getmembers
+            # already returns members sorted by name, so combined with the
+            # sorted module_files above this makes discovery fully
+            # deterministic.
             for name, f in inspect.getmembers(module, inspect.isfunction):
                 # Only process public functions defined in this module
                 # Skip: private functions (_func), imported functions
@@ -178,9 +265,14 @@ def itertools(path: str) -> Iterator[Tuple[Callable, Sequence]]:
                         for ele in f.tags:
                             tags.add(ele)
 
-                    # Step 6: Yield the function and its complete tag set
-                    # The caller (server initialization) will register this as an MCP tool
-                    yield f, tags
+                    # Step 6: Read back any ToolAnnotations attached via the
+                    # @annotate(...) decorator
+                    annotations = getattr(f, "annotations", None)
+
+                    # Step 7: Yield the function, its complete tag set, and
+                    # its annotations. The caller (server initialization)
+                    # will register this as an MCP tool.
+                    yield f, tags, annotations
 
 
 async def display_tools():
@@ -204,7 +296,7 @@ async def display_tools():
 
     path = pathlib.Path(__file__).parent.parent / "tools"
 
-    for f, _ in itertools(path):
+    for f, _, _annotations in itertools(path):
         if len(f.__name__) > maxlen:
             maxlen = len(f.__name__)
         tools[f.__name__] = f.__doc__
@@ -248,7 +340,7 @@ async def display_tags():
 
     path = pathlib.Path(__file__).parent.parent / "tools"
 
-    for _, t in itertools(path):
+    for _, t, _annotations in itertools(path):
         tags = tags.union(t)
 
     for ele in sorted(list(tags)):

--- a/tests/test_bindings_init.py
+++ b/tests/test_bindings_init.py
@@ -114,6 +114,9 @@ class TestBindToTool:
         assert kwargs["name"] == "test_tool_name"
         assert kwargs["exclude_args"] == ("_tool_config",)
         assert kwargs["tags"] == ["bindings", "test_tool_name", "tag1", "tag2"]
+        assert kwargs["annotations"].destructiveHint is True
+        assert not kwargs["annotations"].readOnlyHint
+        assert kwargs["title"] == "Test Tool Name"
 
     @patch("itential_mcp.bindings._import_binding")
     @pytest.mark.asyncio
@@ -140,6 +143,9 @@ class TestBindToTool:
         assert kwargs["name"] == "test_tool_name"
         assert kwargs["exclude_args"] == ("_tool_config",)
         assert kwargs["tags"] == ["bindings", "test_tool_name"]
+        assert kwargs["annotations"].destructiveHint is True
+        assert not kwargs["annotations"].readOnlyHint
+        assert kwargs["title"] == "Test Tool Name"
 
     @patch("itential_mcp.bindings._import_binding")
     @pytest.mark.asyncio
@@ -365,8 +371,30 @@ class TestBindingsIntegration:
             "workflow",
             "automation",
         ]
+        assert bound_kwargs["annotations"].destructiveHint is True
+        assert not bound_kwargs["annotations"].readOnlyHint
+        assert bound_kwargs["title"] == "Test Workflow"
 
         # Verify the endpoint module was called correctly
         mock_endpoint_module.new.assert_called_once_with(
             tool, mock_platform_client_instance
         )
+
+
+class TestHumanizeTitle:
+    """Test cases for the _humanize_title helper function."""
+
+    def test_humanize_title_simple(self):
+        from itential_mcp.bindings import _humanize_title
+
+        assert _humanize_title("deploy_configuration") == "Deploy Configuration"
+
+    def test_humanize_title_single_word(self):
+        from itential_mcp.bindings import _humanize_title
+
+        assert _humanize_title("deploy") == "Deploy"
+
+    def test_humanize_title_collapses_extra_underscores(self):
+        from itential_mcp.bindings import _humanize_title
+
+        assert _humanize_title("deploy__config") == "Deploy Config"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -665,7 +665,7 @@ class TestIntegration:
             pass
 
         mock_func.__name__ = "test_tool"
-        mock_itertools.return_value = [(mock_func, {"system", "test"})]
+        mock_itertools.return_value = [(mock_func, {"system", "test"}, None)]
 
         async def empty_aiter():
             return
@@ -1091,7 +1091,7 @@ class TestServerInitialization:
             pass
 
         mock_func.__name__ = "test_tool"
-        mock_itertools.return_value = [(mock_func, {"test"})]
+        mock_itertools.return_value = [(mock_func, {"test"}, None)]
 
         server_instance = server_module.Server(mock_config)
 
@@ -1124,7 +1124,7 @@ class TestServerInitialization:
             pass
 
         mock_func.__name__ = "test_tool"
-        mock_itertools.return_value = [(mock_func, {"test"})]
+        mock_itertools.return_value = [(mock_func, {"test"}, None)]
 
         # Mock schema with object type
         mock_get_schema.return_value = {"type": "object", "properties": {}}
@@ -1160,7 +1160,7 @@ class TestServerInitialization:
             pass
 
         mock_func.__name__ = "test_tool"
-        mock_itertools.return_value = [(mock_func, {"test"})]
+        mock_itertools.return_value = [(mock_func, {"test"}, None)]
 
         # Mock get_json_schema to raise ValueError
         mock_get_schema.side_effect = ValueError("No schema")
@@ -1487,3 +1487,91 @@ class TestServerInfoVersion:
                 # version= kwarg and silently falls back to fastmcp's own
                 # package version.
                 assert server_info.version != fastmcp.__version__
+
+
+class TestToolAnnotationsAndOrdering:
+    """Test that static tool registration carries through annotations/title
+    metadata and yields a deterministic tools/list ordering.
+
+    Regression coverage for the MCP tool-annotations/title/ordering hygiene
+    work: a destructive tool must never register with readOnlyHint=true by
+    omission, and tools/list order must be stable across server instances.
+    """
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.bindings.iterbindings")
+    async def test_known_read_only_and_destructive_tools_registered_correctly(
+        self, mock_iterbindings, mock_auth_builder
+    ):
+        """get_health must register readOnlyHint=True and
+        apply_device_configuration must register destructiveHint=True, using
+        the real tools/ discovery path (no itertools mocking)."""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", tools_path=None, log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        async def empty_aiter():
+            return
+            yield  # unreachable but makes this an async generator
+
+        mock_iterbindings.return_value = empty_aiter()
+
+        server_instance = server_module.Server(mock_config)
+
+        async with server_instance:
+            async with Client(server_instance.mcp) as client:
+                tools = await client.list_tools()
+
+                by_name = {t.name: t for t in tools}
+
+                assert "get_health" in by_name
+                health_annotations = by_name["get_health"].annotations
+                assert health_annotations is not None
+                assert health_annotations.readOnlyHint is True
+
+                assert "apply_device_configuration" in by_name
+                apply_annotations = by_name["apply_device_configuration"].annotations
+                assert apply_annotations is not None
+                assert apply_annotations.destructiveHint is True
+                assert not apply_annotations.readOnlyHint
+
+    @pytest.mark.asyncio
+    @patch("itential_mcp.server.auth.build_auth_provider")
+    @patch("itential_mcp.server.server.bindings.iterbindings")
+    async def test_tool_registration_order_is_deterministic(
+        self, mock_iterbindings, mock_auth_builder
+    ):
+        """Two independently constructed Server instances must register
+        tools in the same order over the real tools/ discovery path."""
+        from itential_mcp.config.models import Config, ServerConfig, AuthConfig
+
+        mock_config = Config(
+            server=ServerConfig(transport="stdio", tools_path=None, log_level="INFO"),
+            auth=AuthConfig(type="none"),
+        )
+
+        mock_auth_builder.return_value = None
+
+        async def empty_aiter():
+            return
+            yield  # unreachable but makes this an async generator
+
+        mock_iterbindings.side_effect = [empty_aiter(), empty_aiter()]
+
+        server_a = server_module.Server(mock_config)
+        async with server_a:
+            async with Client(server_a.mcp) as client_a:
+                names_a = [t.name for t in await client_a.list_tools()]
+
+        server_b = server_module.Server(mock_config)
+        async with server_b:
+            async with Client(server_b.mcp) as client_b:
+                names_b = [t.name for t in await client_b.list_tools()]
+
+        assert names_a == names_b

--- a/tests/utilities/test_tool.py
+++ b/tests/utilities/test_tool.py
@@ -13,8 +13,11 @@ from typing import Union
 
 from pydantic import BaseModel
 
+from mcp.types import ToolAnnotations
+
 from itential_mcp.utilities.tool import (
     tags,
+    annotate,
     itertools,
     display_tools,
     display_tags,
@@ -186,7 +189,7 @@ def another_test():
             # Should find 2 functions (test_function and another_test, not _private_function)
             assert len(tools) == 2
 
-            func_names = [func.__name__ for func, _ in tools]
+            func_names = [func.__name__ for func, _, _annotations in tools]
             assert "test_function" in func_names
             assert "another_test" in func_names
             assert "_private_function" not in func_names
@@ -209,11 +212,12 @@ def tagged_function():
             tools = list(itertools(temp_dir))
 
             assert len(tools) == 1
-            func, tags_set = tools[0]
+            func, tags_set, tool_annotations = tools[0]
             assert func.__name__ == "tagged_function"
             assert "module_tag" in tags_set
             assert "shared" in tags_set
             assert "tagged_function" in tags_set  # function name is also added as tag
+            assert tool_annotations is None
 
     def test_itertools_with_function_tags(self):
         """Test itertools with function-level tags decorator"""
@@ -234,11 +238,12 @@ def decorated_function():
             tools = list(itertools(temp_dir))
 
             assert len(tools) == 1
-            func, tags_set = tools[0]
+            func, tags_set, tool_annotations = tools[0]
             assert func.__name__ == "decorated_function"
             assert "decorated" in tags_set
             assert "special" in tags_set
             assert "decorated_function" in tags_set
+            assert tool_annotations is None
 
     def test_itertools_ignores_underscore_modules(self):
         """Test that itertools ignores modules starting with underscore"""
@@ -296,7 +301,7 @@ def local_function():
 
             # Should only find local_function, not imported join
             assert len(tools) == 1
-            func, _ = tools[0]
+            func, _, _annotations = tools[0]
             assert func.__name__ == "local_function"
 
     def test_itertools_with_explicit_path(self):
@@ -320,7 +325,7 @@ def explicit_path_function():
             tools = list(itertools(tools_dir))
 
             assert len(tools) == 1
-            func, _ = tools[0]
+            func, _, _annotations = tools[0]
             assert func.__name__ == "explicit_path_function"
 
     def test_itertools_path_parameter_required(self):
@@ -348,7 +353,10 @@ class TestDisplayFunctions:
         mock_func2.__name__ = "another_tool"
         mock_func2.__doc__ = "\n    Another tool for testing\n    "
 
-        mock_itertools.return_value = [(mock_func1, set()), (mock_func2, set())]
+        mock_itertools.return_value = [
+            (mock_func1, set(), None),
+            (mock_func2, set(), None),
+        ]
 
         await display_tools()
 
@@ -371,7 +379,7 @@ class TestDisplayFunctions:
         mock_func.__name__ = "tool"
         mock_func.__doc__ = "\n    This is a very long description that should be truncated because it exceeds the terminal width\n    "
 
-        mock_itertools.return_value = [(mock_func, set())]
+        mock_itertools.return_value = [(mock_func, set(), None)]
 
         await display_tools()
 
@@ -395,7 +403,10 @@ class TestDisplayFunctions:
         tags1 = {"tag1", "shared", "alpha"}
         tags2 = {"tag2", "shared", "beta"}
 
-        mock_itertools.return_value = [(mock_func1, tags1), (mock_func2, tags2)]
+        mock_itertools.return_value = [
+            (mock_func1, tags1, None),
+            (mock_func2, tags2, None),
+        ]
 
         await display_tags()
 
@@ -449,3 +460,196 @@ class TestDisplayFunctions:
         header_call = mock_print.call_args_list[0]
         assert "TOOLS" in str(header_call)
         assert "DESCRIPTION" in str(header_call)
+
+
+class TestAnnotateDecorator:
+    """Test the annotate decorator functionality"""
+
+    def test_annotate_sets_annotations_attribute(self):
+        @annotate(read_only=True, idempotent=True, title="Get Health")
+        def my_func():
+            return "hello"
+
+        assert hasattr(my_func, "annotations")
+        assert isinstance(my_func.annotations, ToolAnnotations)
+        assert my_func.annotations.readOnlyHint is True
+        assert my_func.annotations.idempotentHint is True
+        assert my_func.annotations.title == "Get Health"
+
+    def test_annotate_destructive_tool(self):
+        @annotate(read_only=False, destructive=True, open_world=True)
+        def apply_config():
+            return "applied"
+
+        assert apply_config.annotations.readOnlyHint is False
+        assert apply_config.annotations.destructiveHint is True
+        assert apply_config.annotations.openWorldHint is True
+
+    def test_annotate_defaults_to_none(self):
+        @annotate()
+        def unspecified_func():
+            return None
+
+        annotations = unspecified_func.annotations
+        assert annotations.readOnlyHint is None
+        assert annotations.destructiveHint is None
+        assert annotations.idempotentHint is None
+        assert annotations.openWorldHint is None
+        assert annotations.title is None
+
+    def test_annotate_does_not_modify_function_behavior(self):
+        @annotate(read_only=True)
+        def simple_func(x):
+            return x * 2
+
+        assert simple_func(4) == 8
+
+    def test_annotate_preserves_function_name_and_doc(self):
+        @annotate(read_only=True, title="Documented")
+        def documented_func():
+            """This is a test function"""
+            return True
+
+        assert documented_func.__name__ == "documented_func"
+        assert documented_func.__doc__ == "This is a test function"
+
+
+class TestItertoolsDeterministicOrdering:
+    """Test that itertools yields tools in a stable, name-sorted order"""
+
+    def test_itertools_stable_order_across_calls(self):
+        """Two successive calls to itertools() over the same directory must
+        yield tools in the same order."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            modules = {
+                "zeta.py": "def zeta_func():\n    pass\n",
+                "alpha.py": "def alpha_func():\n    pass\n",
+                "mu.py": "def mu_func():\n    pass\n",
+            }
+            for filename, content in modules.items():
+                with open(os.path.join(temp_dir, filename), "w") as f:
+                    f.write(content)
+
+            first_pass = [f.__name__ for f, _, _ann in itertools(temp_dir)]
+            second_pass = [f.__name__ for f, _, _ann in itertools(temp_dir)]
+
+            assert first_pass == second_pass
+
+    def test_itertools_orders_by_module_file_name(self):
+        """Module files must be discovered in name-sorted order regardless
+        of filesystem/os.listdir() return order."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            modules = {
+                "zeta.py": "def zeta_func():\n    pass\n",
+                "alpha.py": "def alpha_func():\n    pass\n",
+                "mu.py": "def mu_func():\n    pass\n",
+            }
+            for filename, content in modules.items():
+                with open(os.path.join(temp_dir, filename), "w") as f:
+                    f.write(content)
+
+            names = [f.__name__ for f, _, _ann in itertools(temp_dir)]
+
+            # Modules should be imported in sorted order: alpha, mu, zeta
+            assert names == ["alpha_func", "mu_func", "zeta_func"]
+
+    def test_real_tools_directory_discovery_is_stable(self):
+        """Discovery order over the real tools/ package must be stable
+        across two calls."""
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "src"
+            / "itential_mcp"
+            / "tools"
+        )
+
+        first_pass = [f.__name__ for f, _, _ann in itertools(str(path))]
+        second_pass = [f.__name__ for f, _, _ann in itertools(str(path))]
+
+        assert first_pass == second_pass
+
+
+class TestToolAnnotationCompleteness:
+    """Completeness guard: every discovered static tool must be decorated
+    with @annotate(...), so that a destructive tool can never end up
+    unclassified (and therefore un-audited) by omission."""
+
+    def _discover_real_tools(self):
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "src"
+            / "itential_mcp"
+            / "tools"
+        )
+        return list(itertools(str(path)))
+
+    def test_every_discovered_tool_has_annotations(self):
+        tools = self._discover_real_tools()
+
+        assert len(tools) > 0
+
+        missing = [f.__name__ for f, _tags, ann in tools if ann is None]
+
+        assert missing == [], (
+            f"the following tools are missing @annotate(...) classification: {missing}"
+        )
+
+
+class TestToolAnnotationSafetyInvariants:
+    """Safety-invariant tests over the real, decorated tool set."""
+
+    _EXPLICITLY_DESTRUCTIVE = {
+        "apply_device_configuration",
+        "run_command",
+        "run_command_template",
+        "run_service",
+        "import_gateway_configuration",
+        "run_action",
+        "delete_inventory",
+        "remove_devices_from_group",
+        "trigger_automation",
+        "start_workflow",
+    }
+
+    def _discover_real_tools(self):
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "src"
+            / "itential_mcp"
+            / "tools"
+        )
+        return list(itertools(str(path)))
+
+    def test_no_tool_is_both_read_only_and_destructive(self):
+        tools = self._discover_real_tools()
+
+        violations = [
+            f.__name__
+            for f, _tags, ann in tools
+            if ann is not None and ann.readOnlyHint and ann.destructiveHint
+        ]
+
+        assert violations == [], (
+            f"the following tools are marked both readOnlyHint=True and "
+            f"destructiveHint=True, which is a contradiction: {violations}"
+        )
+
+    def test_explicitly_destructive_tools_are_correctly_classified(self):
+        tools = self._discover_real_tools()
+
+        by_name = {f.__name__: ann for f, _tags, ann in tools}
+
+        missing_from_discovery = self._EXPLICITLY_DESTRUCTIVE - by_name.keys()
+        assert missing_from_discovery == set(), missing_from_discovery
+
+        for name in self._EXPLICITLY_DESTRUCTIVE:
+            ann = by_name[name]
+            assert ann is not None, f"{name} has no annotations at all"
+            assert ann.destructiveHint is True, f"{name} must have destructiveHint=True"
+            assert not ann.readOnlyHint, f"{name} must not have readOnlyHint truthy"

--- a/tests/utilities/test_tool.py
+++ b/tests/utilities/test_tool.py
@@ -613,6 +613,12 @@ class TestToolAnnotationSafetyInvariants:
         "remove_devices_from_group",
         "trigger_automation",
         "start_workflow",
+        "start_adapter",
+        "stop_adapter",
+        "restart_adapter",
+        "start_application",
+        "stop_application",
+        "restart_application",
     }
 
     def _discover_real_tools(self):


### PR DESCRIPTION
## Summary
Adds MCP advisory tool annotations (readOnlyHint/destructiveHint/idempotentHint/
openWorldHint) and per-tool human-readable titles to every tool this server
exposes, and makes tool discovery/registration order deterministic. Closes the
compliance gap where clients received no behavioral hints and had to treat
every tool as unknown-risk, and stabilizes `tools/list` for client-side prompt
caching.

## Changes
- Add an `annotate(...)` decorator in `utilities/tool.py`, mirroring the
  existing `tags()` decorator, that attaches an `mcp.types.ToolAnnotations`
  instance (hints + title) to a tool function.
- Apply `@annotate(...)` to all 76 static tools, classifying each read-only vs.
  write vs. destructive per a safety-first classification pass.
- Make `utilities/tool.py:itertools()` yield annotations alongside tags and
  discover tools in a stable, name-sorted order (sorted module files +
  name-sorted members); consume the new value in `server/server.py:__init_tools__`.
- Give dynamic bindings (`bindings/__init__.py:bind_to_tool()`) a conservative
  default (destructiveHint=True, readOnlyHint=False, openWorldHint=True) plus a
  humanized title, since a bound automation's real-world effects are unknown at
  registration time.
- Add tests: annotate-decorator unit tests, a completeness guard that fails if
  any discovered tool is unannotated, safety-invariant tests (no tool both
  read-only and destructive; the destructive set is correctly classified),
  deterministic-ordering tests, and binding-default assertions.

No new dependencies (`ToolAnnotations` is from the already-pinned `mcp` SDK).

## Testing
- [x] Unit tests pass (`make ci`: ruff, bandit, headers, 2710 tests, ~98% coverage, unchanged baseline)
- [x] Integration tests pass (live Itential Platform: verified tools/list
      annotations/titles across a read-only/write/destructive sample, stable
      ordering across two server instantiations, no schema regressions, a live
      dynamic-binding registration confirming the conservative default, and a
      live `get_health` call)
- [x] Manual testing completed

## Related Issues
Implements roadmap Tier D1 items G7, G8, and G14 (MCP 2026-07-28 tool
annotations, per-tool titles, and deterministic tool ordering).
