### PR TITLE
feat(compliance): add get_compliance_reports_by_batch tool and surface batchId

### DIFF
--- a/src/itential_mcp/models/compliance_plans.py
+++ b/src/itential_mcp/models/compliance_plans.py
@@ -105,6 +105,10 @@ class CompliancePlanInstance(BaseModel):
         name: Name of the compliance plan that was started.
         description: Compliance plan description.
         jobStatus: Current execution status of the compliance plan instance.
+        batchId: Batch identifier used to retrieve the compliance reports
+            produced by this plan run (pass to
+            get_compliance_reports_by_batch). May be absent for some plan
+            runs, in which case it is None.
     """
 
     id: Annotated[
@@ -150,6 +154,20 @@ class CompliancePlanInstance(BaseModel):
             )
         ),
     ]
+
+    batchId: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=inspect.cleandoc(
+                """
+                Batch identifier used to retrieve the compliance reports
+                produced by this plan run (pass to
+                get_compliance_reports_by_batch)
+                """
+            ),
+        ),
+    ] = None
 
 
 class RunCompliancePlanResponse(BaseModel):

--- a/src/itential_mcp/models/compliance_reports.py
+++ b/src/itential_mcp/models/compliance_reports.py
@@ -32,3 +32,192 @@ class DescribeComplianceReportResponse(BaseModel):
             )
         ),
     ]
+
+
+class ComplianceReportTotals(BaseModel):
+    """
+    Aggregate check-result counts for a single compliance report.
+
+    Attributes:
+        errors: Number of failed checks classified as errors.
+        warnings: Number of failed checks classified as warnings.
+        infos: Number of informational check results.
+        passes: Number of checks that passed.
+    """
+
+    errors: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of failed checks classified as errors
+                """
+            )
+        ),
+    ]
+
+    warnings: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of failed checks classified as warnings
+                """
+            )
+        ),
+    ]
+
+    infos: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of informational check results
+                """
+            )
+        ),
+    ]
+
+    passes: Annotated[
+        int,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Number of checks that passed
+                """
+            )
+        ),
+    ]
+
+
+class ComplianceReportBrief(BaseModel):
+    """
+    Represents a summary compliance report entry from a compliance plan batch run.
+
+    This model defines the structure for a single per-device compliance
+    report as returned when listing all reports produced by a compliance
+    plan run batch. Use the report's `id` with `describe_compliance_report`
+    to retrieve the full report detail.
+
+    Attributes:
+        id: Unique identifier for this compliance report.
+        batchId: Identifier of the batch run that produced this report.
+        treeId: Identifier of the Golden Configuration tree checked.
+        version: Version of the Golden Configuration tree checked.
+        nodePath: Hierarchical path of the node checked within the tree.
+        deviceName: Name of the device this report was generated for.
+        timestamp: ISO8601 timestamp of when the report was generated.
+        totals: Aggregate check-result counts for this report.
+    """
+
+    id: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Unique identifier for this compliance report
+                """
+            )
+        ),
+    ]
+
+    batchId: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Identifier of the batch run that produced this report
+                """
+            )
+        ),
+    ]
+
+    treeId: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Identifier of the Golden Configuration tree checked
+                """
+            )
+        ),
+    ]
+
+    version: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Version of the Golden Configuration tree checked
+                """
+            )
+        ),
+    ]
+
+    nodePath: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Hierarchical path of the node checked within the tree
+                """
+            )
+        ),
+    ]
+
+    deviceName: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Name of the device this report was generated for
+                """
+            )
+        ),
+    ]
+
+    timestamp: Annotated[
+        str,
+        Field(
+            description=inspect.cleandoc(
+                """
+                ISO8601 timestamp of when the report was generated
+                """
+            )
+        ),
+    ]
+
+    totals: Annotated[
+        ComplianceReportTotals,
+        Field(
+            description=inspect.cleandoc(
+                """
+                Aggregate check-result counts for this report
+                """
+            )
+        ),
+    ]
+
+
+class GetComplianceReportsByBatchResponse(BaseModel):
+    """
+    Response model for get_compliance_reports_by_batch function.
+
+    This model represents the list of compliance report summaries produced
+    by a single compliance plan run batch, as returned by the
+    get_compliance_reports_by_batch function from the Configuration Manager.
+
+    Attributes:
+        reports: List of compliance report brief objects.
+    """
+
+    reports: Annotated[
+        list[ComplianceReportBrief],
+        Field(
+            description=inspect.cleandoc(
+                """
+                List of compliance report brief objects
+                """
+            )
+        ),
+    ]

--- a/src/itential_mcp/platform/services/configuration_manager.py
+++ b/src/itential_mcp/platform/services/configuration_manager.py
@@ -529,6 +529,32 @@ class Service(ServiceBase):
         )
         return res.json()
 
+    async def get_compliance_reports_by_batch(self, batch_id: str) -> list[dict]:
+        """
+        Retrieve compliance reports produced by a specific compliance plan batch run.
+
+        Compliance reports are generated per-device when a compliance plan is
+        executed. All reports produced by a single plan run share the same
+        batch identifier, which is returned as `batchId` on the compliance
+        plan instance created by running the plan.
+
+        Args:
+            batch_id (str): Unique identifier of the compliance plan run batch
+                to retrieve reports for
+
+        Returns:
+            list[dict]: List of compliance report brief objects containing
+                summary results for each device checked in the batch,
+                including per-device error/warning/info/pass totals
+
+        Raises:
+            ServerException: If there is an error communicating with the server
+        """
+        res = await self.client.get(
+            f"/configuration_manager/compliance_reports/batch/{batch_id}"
+        )
+        return res.json()
+
     async def get_devices(self) -> list[dict]:
         """
         Get all devices known to Itential Platform.

--- a/src/itential_mcp/tools/compliance_plans.py
+++ b/src/itential_mcp/tools/compliance_plans.py
@@ -83,5 +83,6 @@ async def run_compliance_plan(
         name=data["name"],
         description=data["description"],
         jobStatus=data["jobStatus"],
+        batchId=data.get("batchId"),
     )
     return models.RunCompliancePlanResponse(instance=compliance_instance)

--- a/src/itential_mcp/tools/compliance_reports.py
+++ b/src/itential_mcp/tools/compliance_reports.py
@@ -48,3 +48,49 @@ async def describe_compliance_report(
     client = ctx.request_context.lifespan_context.get("client")
     res = await client.configuration_manager.describe_compliance_report(report_id)
     return models.DescribeComplianceReportResponse(result=res)
+
+
+@annotate(
+    read_only=True,
+    idempotent=True,
+    open_world=False,
+    title="Get Compliance Reports By Batch",
+)
+async def get_compliance_reports_by_batch(
+    ctx: Annotated[Context, Field(description="The FastMCP Context object")],
+    batch_id: Annotated[
+        str,
+        Field(
+            description=(
+                "The batch ID from a compliance plan run "
+                "(CompliancePlanInstance.batchId) to fetch reports for"
+            )
+        ),
+    ],
+) -> models.GetComplianceReportsByBatchResponse:
+    """
+    Retrieve compliance reports produced by a specific compliance plan batch run.
+
+    Compliance reports are generated per-device when a compliance plan is
+    executed. All reports produced by a single plan run share the same batch
+    identifier. This tool closes the chain from running a plan to inspecting
+    its results: run_compliance_plan returns instance.batchId, which is
+    passed here to list per-device report summaries, and each report's id
+    can then be passed to describe_compliance_report for full detail.
+
+    Args:
+        ctx (Context): The FastMCP Context object
+        batch_id (str): The batch ID from a compliance plan run
+            (CompliancePlanInstance.batchId) to fetch reports for
+
+    Returns:
+        models.GetComplianceReportsByBatchResponse: Response containing the
+            list of compliance report brief objects produced by the batch run
+
+    Raises:
+        Exception: If there is an error retrieving the compliance reports from the platform
+    """
+    await ctx.debug("inside get_compliance_reports_by_batch(...)")
+    client = ctx.request_context.lifespan_context.get("client")
+    res = await client.configuration_manager.get_compliance_reports_by_batch(batch_id)
+    return models.GetComplianceReportsByBatchResponse(reports=res)

--- a/tests/test_models_compliance_plans.py
+++ b/tests/test_models_compliance_plans.py
@@ -106,6 +106,7 @@ class TestCompliancePlanInstance:
             "name": "Running Security Check",
             "description": "Currently executing security compliance",
             "jobStatus": "running",
+            "batchId": "67ead32d5f12757d048a48df",
         }
 
         instance = CompliancePlanInstance(**instance_data)
@@ -114,6 +115,7 @@ class TestCompliancePlanInstance:
         assert instance.name == "Running Security Check"
         assert instance.description == "Currently executing security compliance"
         assert instance.jobStatus == "running"
+        assert instance.batchId == "67ead32d5f12757d048a48df"
 
     def test_compliance_plan_instance_missing_required_fields(self):
         """Test that CompliancePlanInstance raises ValidationError for missing required fields."""
@@ -128,6 +130,19 @@ class TestCompliancePlanInstance:
 
         assert required_fields.issubset(missing_fields)
 
+    def test_compliance_plan_instance_batch_id_defaults_to_none(self):
+        """Test that batchId defaults to None when omitted (optional field)."""
+        instance_data = {
+            "id": "instance-456",
+            "name": "Running Security Check",
+            "description": "Currently executing security compliance",
+            "jobStatus": "running",
+        }
+
+        instance = CompliancePlanInstance(**instance_data)
+
+        assert instance.batchId is None
+
 
 class TestRunCompliancePlanResponse:
     """Test cases for RunCompliancePlanResponse model."""
@@ -139,6 +154,7 @@ class TestRunCompliancePlanResponse:
             name="Test Instance",
             description="Test instance description",
             jobStatus="completed",
+            batchId="67ead32d5f12757d048a48df",
         )
 
         response = RunCompliancePlanResponse(instance=instance)
@@ -146,6 +162,7 @@ class TestRunCompliancePlanResponse:
         assert response.instance.id == "instance-789"
         assert response.instance.name == "Test Instance"
         assert response.instance.jobStatus == "completed"
+        assert response.instance.batchId == "67ead32d5f12757d048a48df"
 
     def test_run_response_missing_instance_field(self):
         """Test that RunCompliancePlanResponse raises ValidationError for missing instance field."""

--- a/tests/test_models_compliance_reports.py
+++ b/tests/test_models_compliance_reports.py
@@ -2,6 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import pytest
+from pydantic import ValidationError
 
 from itential_mcp.models import compliance_reports as models
 
@@ -55,3 +57,133 @@ class TestDescribeComplianceReportResponse:
         json_str = response.model_dump_json()
         assert '"report_id":"789"' in json_str
         assert '"status":"running"' in json_str
+
+
+def _make_totals(**overrides):
+    """Build a valid totals dict, allowing field overrides for negative tests."""
+    data = {"errors": 1, "warnings": 2, "infos": 3, "passes": 10}
+    data.update(overrides)
+    return data
+
+
+def _make_brief(**overrides):
+    """Build a valid compliance report brief dict, allowing field overrides."""
+    data = {
+        "id": "67ead32d5f12757d048a48d1",
+        "batchId": "67ead32d5f12757d048a48df",
+        "treeId": "67ead32d5f12757d048a48d2",
+        "version": "initial",
+        "nodePath": "base/US East/Atlanta",
+        "deviceName": "router1",
+        "timestamp": "2026-08-18T00:00:00Z",
+        "totals": _make_totals(),
+    }
+    data.update(overrides)
+    return data
+
+
+class TestComplianceReportTotals:
+    """Test cases for ComplianceReportTotals model."""
+
+    def test_create_valid_totals(self):
+        """Test creating a valid ComplianceReportTotals instance."""
+        totals = models.ComplianceReportTotals(**_make_totals())
+
+        assert totals.errors == 1
+        assert totals.warnings == 2
+        assert totals.infos == 3
+        assert totals.passes == 10
+
+    def test_totals_missing_required_fields(self):
+        """Test that ComplianceReportTotals raises ValidationError for missing fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            models.ComplianceReportTotals()
+
+        errors = exc_info.value.errors()
+        required_fields = {"errors", "warnings", "infos", "passes"}
+        missing_fields = {
+            error["loc"][0] for error in errors if error["type"] == "missing"
+        }
+        assert required_fields.issubset(missing_fields)
+
+    def test_totals_non_int_value_rejected(self):
+        """Test that ComplianceReportTotals enforces int type on its fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            models.ComplianceReportTotals(**_make_totals(errors="not-a-number"))
+
+        errors = exc_info.value.errors()
+        errors_field_errors = [e for e in errors if e["loc"][0] == "errors"]
+        assert len(errors_field_errors) > 0
+        assert "int_parsing" in errors_field_errors[0]["type"]
+
+
+class TestComplianceReportBrief:
+    """Test cases for ComplianceReportBrief model."""
+
+    def test_create_valid_brief(self):
+        """Test creating a valid ComplianceReportBrief instance with all fields."""
+        brief = models.ComplianceReportBrief(**_make_brief())
+
+        assert brief.id == "67ead32d5f12757d048a48d1"
+        assert brief.batchId == "67ead32d5f12757d048a48df"
+        assert brief.treeId == "67ead32d5f12757d048a48d2"
+        assert brief.version == "initial"
+        assert brief.nodePath == "base/US East/Atlanta"
+        assert brief.deviceName == "router1"
+        assert brief.timestamp == "2026-08-18T00:00:00Z"
+        assert brief.totals.errors == 1
+        assert brief.totals.warnings == 2
+        assert brief.totals.infos == 3
+        assert brief.totals.passes == 10
+
+    def test_brief_missing_required_fields(self):
+        """Test that ComplianceReportBrief raises ValidationError for missing fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            models.ComplianceReportBrief()
+
+        errors = exc_info.value.errors()
+        required_fields = {
+            "id",
+            "batchId",
+            "treeId",
+            "version",
+            "nodePath",
+            "deviceName",
+            "timestamp",
+            "totals",
+        }
+        missing_fields = {
+            error["loc"][0] for error in errors if error["type"] == "missing"
+        }
+        assert required_fields.issubset(missing_fields)
+
+
+class TestGetComplianceReportsByBatchResponse:
+    """Test cases for GetComplianceReportsByBatchResponse model."""
+
+    def test_create_valid_response(self):
+        """Test creating a valid GetComplianceReportsByBatchResponse instance."""
+        brief1 = models.ComplianceReportBrief(**_make_brief())
+        brief2 = models.ComplianceReportBrief(
+            **_make_brief(id="67ead32d5f12757d048a48d9", deviceName="router2")
+        )
+
+        response = models.GetComplianceReportsByBatchResponse(reports=[brief1, brief2])
+
+        assert len(response.reports) == 2
+        assert response.reports[0].deviceName == "router1"
+        assert response.reports[1].deviceName == "router2"
+
+    def test_empty_reports_list(self):
+        """Test creating response with an empty reports list."""
+        response = models.GetComplianceReportsByBatchResponse(reports=[])
+        assert response.reports == []
+
+    def test_response_missing_reports_field(self):
+        """Test that GetComplianceReportsByBatchResponse raises ValidationError for missing reports field."""
+        with pytest.raises(ValidationError) as exc_info:
+            models.GetComplianceReportsByBatchResponse()
+
+        errors = exc_info.value.errors()
+        reports_errors = [error for error in errors if error["loc"][0] == "reports"]
+        assert len(reports_errors) > 0

--- a/tests/test_services_configuration_manager.py
+++ b/tests/test_services_configuration_manager.py
@@ -1520,6 +1520,49 @@ class TestConfigurationManagerComplianceReports:
         assert result == expected_data
         assert result["devices"] == []
 
+    @pytest.mark.asyncio
+    async def test_get_compliance_reports_by_batch_success(self, service, mock_client):
+        """Test successful retrieval of compliance reports by batch id."""
+        expected_data = [
+            {
+                "id": "67ead32d5f12757d048a48d1",
+                "batchId": "67ead32d5f12757d048a48df",
+                "treeId": "67ead32d5f12757d048a48d2",
+                "version": "initial",
+                "nodePath": "base/US East/Atlanta",
+                "deviceName": "router1",
+                "timestamp": "2026-08-18T00:00:00Z",
+                "totals": {"errors": 1, "warnings": 2, "infos": 3, "passes": 10},
+            },
+        ]
+
+        mock_response = Mock()
+        mock_response.json.return_value = expected_data
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_compliance_reports_by_batch(
+            "67ead32d5f12757d048a48df"
+        )
+
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/compliance_reports/batch/67ead32d5f12757d048a48df"
+        )
+        assert result == expected_data
+
+    @pytest.mark.asyncio
+    async def test_get_compliance_reports_by_batch_empty(self, service, mock_client):
+        """Test retrieving compliance reports by batch id with an empty result."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_client.get.return_value = mock_response
+
+        result = await service.get_compliance_reports_by_batch("empty-batch-id")
+
+        mock_client.get.assert_called_once_with(
+            "/configuration_manager/compliance_reports/batch/empty-batch-id"
+        )
+        assert result == []
+
 
 class TestConfigurationManagerDevices:
     """Test cases for Configuration Manager Device methods."""

--- a/tests/test_tools_compliance_plans.py
+++ b/tests/test_tools_compliance_plans.py
@@ -121,6 +121,7 @@ class TestRunCompliancePlanTool:
             "name": "Security Baseline",
             "description": "Checks security config",
             "jobStatus": "running",
+            "batchId": "67ead32d5f12757d048a48df",
         }
 
         result = await run_compliance_plan(self.mock_context, name="Security Baseline")
@@ -131,6 +132,7 @@ class TestRunCompliancePlanTool:
         assert isinstance(result, RunCompliancePlanResponse)
         assert result.instance.id == "instance-123"
         assert result.instance.jobStatus == "running"
+        assert result.instance.batchId == "67ead32d5f12757d048a48df"
 
     @pytest.mark.asyncio
     async def test_run_compliance_plan_passes_name(self):
@@ -146,3 +148,30 @@ class TestRunCompliancePlanTool:
 
         call_kwargs = self.mock_cm_service.run_compliance_plan.call_args
         assert call_kwargs.kwargs.get("name") == "QoS Compliance"
+
+    @pytest.mark.asyncio
+    async def test_run_compliance_plan_surfaces_batch_id(self):
+        """run_compliance_plan must surface batchId from the raw service payload.
+
+        This is the anti-drop regression test: it returns a full raw instance
+        dict (all real fields the platform sends, including extras the tool
+        does not model) and asserts batchId survives into the response while
+        unmodeled extra keys are silently ignored.
+        """
+        self.mock_cm_service.run_compliance_plan.return_value = {
+            "id": "instance-999",
+            "planId": "plan-999",
+            "jobId": "job-999",
+            "name": "Full Payload Plan",
+            "description": "Exercises the full raw instance payload",
+            "jobStatus": "running",
+            "started": "2026-08-18T00:00:00Z",
+            "throttle": 5,
+            "nodes": ["node1", "node2"],
+            "batchId": "67ead32d5f12757d048a48df",
+        }
+
+        result = await run_compliance_plan(self.mock_context, name="Full Payload Plan")
+
+        assert isinstance(result, RunCompliancePlanResponse)
+        assert result.instance.batchId == "67ead32d5f12757d048a48df"

--- a/tests/test_tools_compliance_reports.py
+++ b/tests/test_tools_compliance_reports.py
@@ -5,8 +5,14 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from itential_mcp.tools.compliance_reports import describe_compliance_report
-from itential_mcp.models.compliance_reports import DescribeComplianceReportResponse
+from itential_mcp.tools.compliance_reports import (
+    describe_compliance_report,
+    get_compliance_reports_by_batch,
+)
+from itential_mcp.models.compliance_reports import (
+    DescribeComplianceReportResponse,
+    GetComplianceReportsByBatchResponse,
+)
 from fastmcp import Context
 
 
@@ -111,3 +117,119 @@ class TestDescribeComplianceReportTool:
         self.mock_context.debug.assert_called_once_with(
             "inside describe_compliance_report(...)"
         )
+
+
+class TestGetComplianceReportsByBatchTool:
+    """Tests for get_compliance_reports_by_batch."""
+
+    def setup_method(self):
+        """Set up shared mock fixtures."""
+        self.mock_context = AsyncMock(spec=Context)
+        self.mock_context.debug = AsyncMock()
+
+        self.mock_client = MagicMock()
+        self.mock_cm_service = MagicMock()
+        self.mock_cm_service.get_compliance_reports_by_batch = AsyncMock()
+
+        self.mock_client.configuration_manager = self.mock_cm_service
+        self.mock_context.request_context.lifespan_context.get.return_value = (
+            self.mock_client
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_compliance_reports_by_batch_awaits_service_call(self):
+        """get_compliance_reports_by_batch must await the configuration_manager service call.
+
+        The mock is an AsyncMock — if the tool does NOT await it, the
+        coroutine object propagates to Pydantic and raises ValidationError
+        "Input should be a valid list". If it DOES await, the mock returns
+        the configured list and the response model is valid.
+        """
+        self.mock_cm_service.get_compliance_reports_by_batch.return_value = []
+
+        result = await get_compliance_reports_by_batch(
+            self.mock_context, batch_id="67ead32d5f12757d048a48df"
+        )
+
+        self.mock_cm_service.get_compliance_reports_by_batch.assert_awaited_once_with(
+            "67ead32d5f12757d048a48df"
+        )
+        assert isinstance(result, GetComplianceReportsByBatchResponse)
+        assert result.reports == []
+
+    @pytest.mark.asyncio
+    async def test_get_compliance_reports_by_batch_passes_batch_id(self):
+        """get_compliance_reports_by_batch must pass batch_id positionally to the service."""
+        self.mock_cm_service.get_compliance_reports_by_batch.return_value = []
+
+        await get_compliance_reports_by_batch(
+            self.mock_context, batch_id="67ead32d5f12757d048a48df"
+        )
+
+        args, _ = self.mock_cm_service.get_compliance_reports_by_batch.call_args
+        assert args[0] == "67ead32d5f12757d048a48df"
+
+    @pytest.mark.asyncio
+    async def test_get_compliance_reports_by_batch_maps_response_array(self):
+        """get_compliance_reports_by_batch must map the raw report array onto the model."""
+        raw_reports = [
+            {
+                "id": "67ead32d5f12757d048a48d1",
+                "batchId": "67ead32d5f12757d048a48df",
+                "treeId": "67ead32d5f12757d048a48d2",
+                "version": "initial",
+                "nodePath": "base/US East/Atlanta",
+                "deviceName": "router1",
+                "timestamp": "2026-08-18T00:00:00Z",
+                "totals": {"errors": 1, "warnings": 2, "infos": 3, "passes": 10},
+            },
+            {
+                "id": "67ead32d5f12757d048a48d9",
+                "batchId": "67ead32d5f12757d048a48df",
+                "treeId": "67ead32d5f12757d048a48d2",
+                "version": "initial",
+                "nodePath": "base/US East/Atlanta",
+                "deviceName": "router2",
+                "timestamp": "2026-08-18T00:01:00Z",
+                "totals": {"errors": 0, "warnings": 0, "infos": 1, "passes": 15},
+            },
+        ]
+        self.mock_cm_service.get_compliance_reports_by_batch.return_value = raw_reports
+
+        result = await get_compliance_reports_by_batch(
+            self.mock_context, batch_id="67ead32d5f12757d048a48df"
+        )
+
+        assert isinstance(result, GetComplianceReportsByBatchResponse)
+        assert len(result.reports) == 2
+        assert result.reports[0].deviceName == "router1"
+        assert result.reports[0].totals.passes == 10
+        assert result.reports[1].deviceName == "router2"
+        assert result.reports[1].totals.errors == 0
+        assert result.reports[1].totals.passes == 15
+
+    @pytest.mark.asyncio
+    async def test_get_compliance_reports_by_batch_logs_entry(self):
+        """get_compliance_reports_by_batch must log entry via ctx.debug."""
+        self.mock_cm_service.get_compliance_reports_by_batch.return_value = []
+
+        await get_compliance_reports_by_batch(self.mock_context, batch_id="batch-1")
+
+        self.mock_context.debug.assert_called_once_with(
+            "inside get_compliance_reports_by_batch(...)"
+        )
+
+    def test_get_compliance_reports_by_batch_annotation_classification(self):
+        """get_compliance_reports_by_batch must be annotated read-only, non-destructive.
+
+        Documents intent: this is a GET-only, safe, non-destructive tool.
+        The repo-wide TestToolAnnotationCompleteness and
+        TestToolAnnotationSafetyInvariants guards in
+        tests/utilities/test_tool.py already enforce this automatically for
+        every discovered tool; this is an explicit spot-check.
+        """
+        annotations = get_compliance_reports_by_batch.annotations
+
+        assert annotations is not None
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint is not True


### PR DESCRIPTION
## Summary
Adds a new read-only tool `get_compliance_reports_by_batch(ctx, batch_id)` and
fixes a bug where `run_compliance_plan` silently discarded the platform's
`batchId`. The two changes are coupled: the new tool needs a batch ID, which
was previously being dropped before the caller could ever see it.

## Changes
- `run_compliance_plan` now surfaces `batchId: str | None` (optional; graceful
  degradation over strict validation, per explicit design decision).
- New tool `get_compliance_reports_by_batch(ctx, batch_id: str)`, annotated
  `read_only=True, idempotent=True, open_world=False`.
- New service method on the configuration_manager platform service.
- New response models validated field-by-field against a real platform
  OpenAPI spec, using the established wrapper-model pattern (per #405/#356/#361).
- Tests: model, service, and tool coverage for both changes, incl. a regression
  test that fails without the batchId pass-through.

## Testing
- `make ci` passes clean (2858 tests).
- Integration-tested against a real live Itential Platform: ran a real
  compliance plan ("NERC-CIP Cisco IOS Compliance Plan"), confirmed the
  response now includes a populated `batchId`, then called
  `get_compliance_reports_by_batch` with that real batch ID and received 4 real
  per-device compliance report records with correct schema. No regression on
  `describe_compliance_report` or `get_compliance_plans`.

## Known limitations
- The batch-reports endpoint returns an empty list both when a batch has zero
  matching devices and when the batch ID is unknown/nonexistent. Callers cannot
  currently distinguish these two cases from the response alone.

## Related Issues
Roadmap: 0.15.0 Tier C #10.
